### PR TITLE
New package: Microsoft.VCRedist.2015+.arm32 version 14.0.23918

### DIFF
--- a/manifests/m/Microsoft/VCRedist/2015+/arm32/14.0.23918.0/Microsoft.VCRedist.2015+.arm32.installer.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/arm32/14.0.23918.0/Microsoft.VCRedist.2015+.arm32.installer.yaml
@@ -1,8 +1,19 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.VCRedist.2015+.arm32
 PackageVersion: 14.0.23918.0
 InstallerType: burn
+AppsAndFeaturesEntries:
+- DisplayName: Microsoft Visual C++ 2015 Redistributable (arm) - 14.0.23918
+  Publisher: Microsoft Corporation
+  DisplayVersion: 14.0.23918.0
+  ProductCode: '{3468a23a-d220-493d-a784-11f65aa6d220}'
+  UpgradeCode: '{5A59FC33-FD53-3D29-AC7A-6E6F173919DC}'
+  InstallerType: burn
+- Publisher: Microsoft Corporation
+  DisplayVersion: 14.0.23918
+  ProductCode: '{A708B64E-3B92-391A-816D-C2BE158A6A16}'
+  InstallerType: wix
 Installers:
 - Architecture: arm
   InstallerUrl: https://download.microsoft.com/download/0/2/5/02596cd9-63cd-4c90-8e13-073ff0fe7fb5/vc_redist.arm.exe

--- a/manifests/m/Microsoft/VCRedist/2015+/arm32/14.0.23918.0/Microsoft.VCRedist.2015+.arm32.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/arm32/14.0.23918.0/Microsoft.VCRedist.2015+.arm32.locale.en-US.yaml
@@ -1,4 +1,4 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.VCRedist.2015+.arm32
 PackageVersion: 14.0.23918.0

--- a/manifests/m/Microsoft/VCRedist/2015+/arm32/14.0.23918.0/Microsoft.VCRedist.2015+.arm32.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/arm32/14.0.23918.0/Microsoft.VCRedist.2015+.arm32.yaml
@@ -1,4 +1,4 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.VCRedist.2015+.arm32
 PackageVersion: 14.0.23918.0


### PR DESCRIPTION
This particular app is a bit of an oddball, though it likely meets the "Require specific hardware to test" criteria.

As it is an ARM32-only app, it should *in theory* work on Windows 10 ARM64 devices from "October 2018 Update" onwards (which is the minimum OS version listed in winget-cli's readme as supporting Winget), and on Windows 11 ARM64 devices from 23H2 stable and earlier.

But I lack ARM64 devices to test with, the main pkgs repo uses 24H2 pipelines for ARM64, and there have been uncertanties on whether the app can even be installed on ARM64 OS installations or not.

Nevertheless, the app seems perfectly official enough on the same level as the x64/x86/ARM64 VC redists.