### PR TITLE
fix: install latest WinGet pre-release from GitHub

### DIFF
--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -34,15 +34,20 @@ if ($InstallerType) { $nameParts += $InstallerType }
 $artifactName = $nameParts -join '-'
 "artifact_name=$artifactName" >> $env:GITHUB_OUTPUT
 
-# Install latest WinGet version for fonts support
-winget --version
-try {
-    Install-Module -Name Microsoft.WinGet.Client -Repository PSGallery -Force
-    Repair-WinGetPackageManager -Latest -Force
-} catch {}
-winget --version
+# Install latest pre-release WinGet version for fonts support and local manifest fixes.
+# Switch back to Repair-WinGetPackageManager and stable WinGet once 1.29.x releases and
+# PowerShell modules update.
+$assetUrl = gh api `
+    '/repos/microsoft/winget-cli/releases' `
+    --jq 'map(select(.prerelease)) | first | .assets[] | select(.name == "Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle") | .browser_download_url'
+
+$wingetBundle = Join-Path $env:RUNNER_TEMP 'Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle'
+Invoke-WebRequest -Uri $assetUrl -OutFile $wingetBundle
+Add-AppxPackage -Path $wingetBundle -ForceUpdateFromAnyVersion -ErrorAction Stop
+Write-Host "Installed latest WinGet pre-release: $(winget --version)"
+
 @{
-    '$schema' = 'https://aka.ms/winget-settings.schema.json'
+    '$schema'            = 'https://aka.ms/winget-settings.schema.json'
     experimentalFeatures = @{
         fonts = $true
     }
@@ -104,7 +109,7 @@ elseif ($InstallerType -eq 'portable') {
     $appPath = (@($selectedInstaller.Commands) + @($manifest.Commands)) | Where-Object { $_ } | Select-Object -First 1
 }
 elseif ($InstallerType -eq 'msix') {
-    $manifest = Get-AppxPackage | Where-Object PackageFamilyName -eq $selectedInstaller.PackageFamilyName | Get-AppxPackageManifest
+    $manifest = Get-AppxPackage | Where-Object PackageFamilyName -EQ $selectedInstaller.PackageFamilyName | Get-AppxPackageManifest
     $appPath = "shell:AppsFolder\$($selectedInstaller.PackageFamilyName)!$($manifest.Package.Applications.Application.Id)"
 }
 else {
@@ -132,7 +137,8 @@ if ($appPath) {
     if ($app) {
         if ($app.HasExited) {
             Write-Host "App exited with code $($app.ExitCode) after $($app.ExitTime - $app.StartTime)"
-        } else {
+        }
+        else {
             Stop-Process -Id $app.Id -ErrorAction SilentlyContinue
         }
     }


### PR DESCRIPTION
microsoft/winget-cli#6071 hasn't actually landed in a release yet so `Repair-WinGetPackageManager` still sends unauthenticated requests. I updated the script to fetch via GitHub releases as a workaround. Also noticed that arm64 test runs were hitting the issue fixed in microsoft/winget-cli#6127, so this PR also switches to using the latest pre-release which fixes it.