### PR TITLE
New package: Microsoft.DotNet.Framework.Runtime.3 version 3.5

### DIFF
--- a/manifests/m/Microsoft/DotNet/Framework/Runtime/3/3.5/Microsoft.DotNet.Framework.Runtime.3.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/Runtime/3/3.5/Microsoft.DotNet.Framework.Runtime.3.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.Runtime.3
+PackageVersion: "3.5"
+MinimumOSVersion: 10.0.28000.0 # Windows 11 26H1
+InstallerType: burn
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.microsoft.com/download/298af580-974e-4001-a07d-bb200d7c5792/DotNet35Setup.exe
+  InstallerSha256: B969D1D0A662BDFD20F42AED9F0EDE21122723FBBCEE545F16DA7150FF01926D
+  AppsAndFeaturesEntries:
+  - DisplayName: Microsoft .NET Framework 3.5 (5087077)
+    DisplayVersion: 1.0.03391.144
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/DotNet/Framework/Runtime/3/3.5/Microsoft.DotNet.Framework.Runtime.3.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/Runtime/3/3.5/Microsoft.DotNet.Framework.Runtime.3.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.Runtime.3
+PackageVersion: "3.5"
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: Microsoft .NET Framework Runtime 3.5 for Windows 11 ≥26H1
+PackageUrl: https://learn.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-11
+License: Proprietary (Freeware)
+Copyright: © Microsoft Corporation. All rights reserved.
+ShortDescription: Starting with Windows 11 26H1 (build 28000), .NET Framework 3.5 is only available as a standalone installer.
+Description: |-
+  Starting with Windows 11 26H1 (build 28000), .NET Framework 3.5 is only available as a standalone installer.
+
+  If you use 25H2 or earlier, run «Enable-WindowsOptionalFeature -FeatureName NetFx3 -Online» instead.
+Moniker: netfx3-26
+Tags:
+- microsoft-dotnet-framework-runtime-3.5
+- microsoftdotnetframeworkruntime3.5
+- microsoft-.net-framework-runtime-3.5
+- microsoft.netframeworkruntime3.5
+- netfx3
+- netfx35
+- kb5087077
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/DotNet/Framework/Runtime/3/3.5/Microsoft.DotNet.Framework.Runtime.3.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/Runtime/3/3.5/Microsoft.DotNet.Framework.Runtime.3.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.DotNet.Framework.Runtime.3
+PackageVersion: "3.5"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
   <!-- Example: Resolves #328283 -->
  - Relates to microsoft/winget-pkgs#[Issue Number]

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* For whatever reason, Microsoft are changing .NET Framework 3.5 so it'll be an installer instead of an optional feature in 26H1 onwards (https://learn.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-11). I've had big problems getting even 22H2 apps into winget-pkgs, so submitting a 26Hx app there is off the table. Remarkably, x64 ISOs of 26H1 do exist, making me able to test the manifest successfully in a VM.