### PR TITLE
New package: Microsoft.WindowsAdvancedSettings version 0.2101.858

### DIFF
--- a/manifests/m/Microsoft/WindowsAdvancedSettings/0.2101.858/Microsoft.WindowsAdvancedSettings.installer.yaml
+++ b/manifests/m/Microsoft/WindowsAdvancedSettings/0.2101.858/Microsoft.WindowsAdvancedSettings.installer.yaml
@@ -21,9 +21,9 @@ Installers:
   InstallerUrl: https://github.com/microsoft/WindowsAdvancedSettings/releases/download/v1.0.0/Windows.DevHome_0.2101.858.0.msixbundle
   InstallerSha256: 7AA637FF90634CBC5B82B8F7EFFD751D179FC7B2E59E5B1F47DBFD51367F3AAD
   SignatureSha256: C6214BAB2793CDC0C9A8831BD121DA0D9D00066139629349159691C327881696
-# Dependencies: (Commented out due to https://github.com/microsoft/winget-cli/issues/3271)
-#   PackageDependencies:
-#   - PackageIdentifier: Microsoft.VCLibs.Desktop.14
-#   - PackageIdentifier: Microsoft.WindowsAppRuntime.1.5
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCLibs.Desktop.14
+  - PackageIdentifier: Microsoft.WindowsAppRuntime.1.5
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/WindowsAdvancedSettings/0.2101.858/Microsoft.WindowsAdvancedSettings.installer.yaml
+++ b/manifests/m/Microsoft/WindowsAdvancedSettings/0.2101.858/Microsoft.WindowsAdvancedSettings.installer.yaml
@@ -1,0 +1,29 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAdvancedSettings
+PackageVersion: 0.2101.858
+ReleaseDate: 2025-05-29
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: msix
+PackageFamilyName: Microsoft.Windows.DevHome_8wekyb3d8bbwe
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/microsoft/WindowsAdvancedSettings/releases/download/v1.0.0/Windows.DevHome_0.2101.858.0.msixbundle
+  InstallerSha256: 7AA637FF90634CBC5B82B8F7EFFD751D179FC7B2E59E5B1F47DBFD51367F3AAD
+  SignatureSha256: C6214BAB2793CDC0C9A8831BD121DA0D9D00066139629349159691C327881696
+- Architecture: x64
+  InstallerUrl: https://github.com/microsoft/WindowsAdvancedSettings/releases/download/v1.0.0/Windows.DevHome_0.2101.858.0.msixbundle
+  InstallerSha256: 7AA637FF90634CBC5B82B8F7EFFD751D179FC7B2E59E5B1F47DBFD51367F3AAD
+  SignatureSha256: C6214BAB2793CDC0C9A8831BD121DA0D9D00066139629349159691C327881696
+- Architecture: arm64
+  InstallerUrl: https://github.com/microsoft/WindowsAdvancedSettings/releases/download/v1.0.0/Windows.DevHome_0.2101.858.0.msixbundle
+  InstallerSha256: 7AA637FF90634CBC5B82B8F7EFFD751D179FC7B2E59E5B1F47DBFD51367F3AAD
+  SignatureSha256: C6214BAB2793CDC0C9A8831BD121DA0D9D00066139629349159691C327881696
+# Dependencies: (Commented out due to https://github.com/microsoft/winget-cli/issues/3271)
+#   PackageDependencies:
+#   - PackageIdentifier: Microsoft.VCLibs.Desktop.14
+#   - PackageIdentifier: Microsoft.WindowsAppRuntime.1.5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/WindowsAdvancedSettings/0.2101.858/Microsoft.WindowsAdvancedSettings.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsAdvancedSettings/0.2101.858/Microsoft.WindowsAdvancedSettings.locale.en-US.yaml
@@ -1,0 +1,27 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAdvancedSettings
+PackageVersion: 0.2101.858
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PackageName: Windows Advanced Settings
+PackageUrl: https://github.com/microsoft/WindowsAdvancedSettings
+License: MIT
+ShortDescription: Allows you to view Git information for your repositories directly in File Explorer.
+Description: |-
+  Allows you to view Git information for your repositories directly in File Explorer.
+
+  Note that despite the app's name and marketing, the vast majority of settings in Settings → System → Advanced do not actually need this app as of Windows 11 25H2. It is only the «Add folder to File Explorer Settings page» function that needs this app.
+
+  Also note that the app's version numbering collides with that of the (discontinued) DevHome program, and that 0.2101.858 is what is branded as 1.0.0 at the Homepage.
+Moniker: windowsadvancedsettings  
+Tags:
+- windows-advanced-settings  
+- git-repositories
+- gitrepos
+- file-explorer
+- fileexplorer
+- 9n8mhtphngvv
+ReleaseNotesUrl: https://github.com/microsoft/WindowsAdvancedSettings/releases/tag/v1.0.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/WindowsAdvancedSettings/0.2101.858/Microsoft.WindowsAdvancedSettings.yaml
+++ b/manifests/m/Microsoft/WindowsAdvancedSettings/0.2101.858/Microsoft.WindowsAdvancedSettings.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.WindowsAdvancedSettings
+PackageVersion: 0.2101.858
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
   <!-- Example: Resolves #328283 -->
  - Relates to https://github.com/microsoft/winget-pkgs/pull/324318.
  - Relates to https://github.com/microsoft/winget-pkgs/issues/324316.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* There seems to have been quite some confusion in the pkgs PR. I can't spot any signs on my PC of the supposed Insiders requirements.
* Due to very poor coding by Team Windows Advanced Settings, the MSIXBundle's internal metadata claims a minimum OS build of 10.0.19041.0, despite the devs themselves  stating it requires 10.0.22000.0. This resulted in the pkgs 21H2 pipelines glitching out, as they installed an app that did nothing if installed on 21H2.