### PR TITLE
feat: resolve dependencies from microsoft/winget-pkgs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,11 +28,23 @@ jobs:
 
       # TODO improve speed, takes 30s
       - name: Merge manifests
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           choco install yq
 
           $TMP_MANIFESTS = "$env:TEMP\manifests"
           New-Item -ItemType Directory -Path $TMP_MANIFESTS -Force
+
+          # winget can't resolve dependencies across sources (microsoft/winget-cli#3271), so
+          # copy each declared winget-pkgs dependency in to be merged alongside our packages.
+          $deps = Get-ChildItem manifests,fonts -Recurse -Filter *.installer.yaml | ForEach-Object { & yq '(.Dependencies, .Installers[].Dependencies).PackageDependencies[].PackageIdentifier' $_ } | Where-Object { $_ } | Sort-Object -Unique
+          foreach ($dep in $deps) {
+            $path = "manifests/$($dep.Substring(0,1).ToLower())/$($dep -replace '\.','/')"
+            $version = gh api "repos/microsoft/winget-pkgs/contents/$path" | ConvertFrom-Json | Where-Object type -eq dir | Select-Object -ExpandProperty name | Sort-Object | Select-Object -Last 1
+            New-Item "$path/$version" -ItemType Directory -Force | Out-Null
+            gh api "repos/microsoft/winget-pkgs/contents/$path/$version" | ConvertFrom-Json | Where-Object name -like *.yaml | ForEach-Object { Invoke-WebRequest $_.download_url -OutFile "$path/$version/$($_.name)" }
+          }
 
           $leafDirs = Get-ChildItem -Path "manifests","fonts" -Recurse -Directory | Where-Object {
             (Get-ChildItem -Path $_.FullName -Filter "*.yaml").Count -gt 0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,7 @@ jobs:
           $deps = Get-ChildItem manifests,fonts -Recurse -Filter *.installer.yaml | ForEach-Object { & yq '(.Dependencies, .Installers[].Dependencies).PackageDependencies[].PackageIdentifier' $_ } | Where-Object { $_ } | Sort-Object -Unique
           foreach ($dep in $deps) {
             $path = "manifests/$($dep.Substring(0,1).ToLower())/$($dep -replace '\.','/')"
+            if ((Test-Path $path) -or (Test-Path ($path -replace '^manifests','fonts'))) { continue }  # already in winget-extras
             $version = gh api "repos/microsoft/winget-pkgs/contents/$path" | ConvertFrom-Json | Where-Object type -eq dir | Select-Object -ExpandProperty name | Sort-Object | Select-Object -Last 1
             New-Item "$path/$version" -ItemType Directory -Force | Out-Null
             gh api "repos/microsoft/winget-pkgs/contents/$path/$version" | ConvertFrom-Json | Where-Object name -like *.yaml | ForEach-Object { Invoke-WebRequest $_.download_url -OutFile "$path/$version/$($_.name)" }

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,12 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
-
       # TODO improve speed, takes 30s
       - name: Merge manifests
         env:
@@ -75,6 +69,12 @@ jobs:
             $version = Get-Date -Format yyyy.M.d.hm
             (Get-Content -Path AppxManifest.xml) -replace "<VERSION>", $version | Set-Content -Path AppxManifest.xml
             .\AppInstallerCLIE2ETests\IndexCreationTool.exe -f source.json
+
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ vars.AZURE_CLIENT_ID }}
+          tenant-id: ${{ vars.AZURE_TENANT_ID }}
+          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
       - name: Sign source package
         working-directory: index

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -55,6 +55,9 @@ Write-Host "Installed latest WinGet pre-release: $(winget --version)"
 winget settings --enable LocalManifestFiles
 winget settings --enable LocalArchiveMalwareScanOverride
 
+# Add the source so declared dependencies (copied in from winget-pkgs at publish) resolve
+winget source add --name winget-extras --type Microsoft.PreIndexed.Package --arg https://winget.tplant.com.au/cache --accept-source-agreements
+
 $programFilesBefore = Get-ChildItem $env:ProgramFiles -Directory | Select-Object -ExpandProperty FullName
 $programFilesx86Before = Get-ChildItem ${env:ProgramFiles(x86)} -Directory | Select-Object -ExpandProperty FullName
 $analyzerArgs = @(


### PR DESCRIPTION
## Description

This PR adds support for resolving declared winget package dependencies during the publish workflow. Since winget cannot resolve dependencies across sources (microsoft/winget-cli#3271), we now:

1. **In publish.yml**: Extract all declared dependencies from local manifests, fetch their latest versions from microsoft/winget-pkgs via the GitHub API, and copy them into the local manifests directory for merging alongside our packages.

2. **In validate.ps1**: Add the winget-extras source to the winget configuration so that declared dependencies (which are copied in from winget-pkgs at publish time) can be properly resolved during validation.

These changes ensure that packages with dependencies on winget-pkgs entries can be properly validated and installed.

## Related Issues

- Relates to microsoft/winget-cli#3271

## Testing

- Existing CI validation workflow will verify that manifests with dependencies can be properly validated
- The publish workflow will test the dependency resolution logic when processing manifests with declared dependencies

https://claude.ai/code/session_01U4HVXo7LMXSUqu8FSirzXq