### PR TITLE
Update version: laoo.Felix version 0.6.4

### DIFF
--- a/manifests/l/laoo/Felix/0.6.4/laoo.Felix.installer.yaml
+++ b/manifests/l/laoo/Felix/0.6.4/laoo.Felix.installer.yaml
@@ -10,17 +10,17 @@ Installers:
   InstallerSha256: F507AB2B2A4D203018E82275F38BEF9626CB080AE71B01D96E33E6953158D801
   Commands:
   - felixemulator
-  # Dependencies:
-  #   PackageDependencies:
-  #   - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 - Architecture: x86
   InstallerUrl: https://github.com/laoo/Felix/releases/download/v0.6.4/Felix32.exe
   InstallerSha256: afccd22d92e324df4016367d155adcc127ea88f612dafe4fd2ce99e75d6ec8fe
   Commands:
   - felixemulator86
-  # Dependencies:
-  #   PackageDependencies:
-  #   - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.VCRedist.2015+.x86
 FileExtensions:
 - lnx
 - lyx


### PR DESCRIPTION
## Description

Now that dependency resolution from microsoft/winget-pkgs is supported (#202), this enables the Visual C++ Redistributable dependencies that were previously commented out in the `laoo.Felix` installer manifest.

- x64 installer: `Microsoft.VCRedist.2015+.x64`
- x86 installer: `Microsoft.VCRedist.2015+.x86`

These are declared per-installer (architecture-specific) to match each binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTcTykgX7QzukXmgcMEMU5)_