### PR TITLE
Update version: Microsoft.RemoteBannerApp version 2.0.02931.136

### DIFF
--- a/manifests/m/Microsoft/RemoteBannerApp/2.0.02931.136/Microsoft.RemoteBannerApp.installer.yaml
+++ b/manifests/m/Microsoft/RemoteBannerApp/2.0.02931.136/Microsoft.RemoteBannerApp.installer.yaml
@@ -16,10 +16,9 @@ AppsAndFeaturesEntries:
   UpgradeCode: '{B4122187-72B2-4C6F-A276-96B95B520BD7}'
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%\.\Microsoft\bannerApp'
-# https://github.com/microsoft/winget-cli/issues/3272
-# Dependencies:
-#   PackageDependencies:
-#   - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 Installers:
 - Architecture: x64
   InstallerUrl: https://prod.api.toolbox.azure-test.net/api/tool/Microsoft/RemoteBannerApp/2.0.02931.136/artifact/BannerAppSetup.msi


### PR DESCRIPTION
## Description

Now that dependency resolution from microsoft/winget-pkgs is supported (#202), this enables the Visual C++ Redistributable dependency that was previously commented out in the `Microsoft.RemoteBannerApp` installer manifest.

- `Microsoft.VCRedist.2015+.x64`

The dependency was originally blocked pending [microsoft/winget-cli#3272](https://github.com/microsoft/winget-cli/issues/3272) (specifying a dependency source). The #202 workaround copies declared dependencies into the winget-extras source at publish time, so they resolve from a single source — the same approach already shipped for `Microsoft.WindowsAdvancedSettings` (#201).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CTcTykgX7QzukXmgcMEMU5)_