### PR TITLE
fix: post link to screenshot, print logs instead of uploading

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -70,6 +70,8 @@ jobs:
 
   validate:
     needs: detect
+    permissions:
+      pull-requests: write
     runs-on: ${{ matrix.installer.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
     strategy:
       fail-fast: false
@@ -108,32 +110,18 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Upload winget log
+      - name: Print logs
         if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          path: ${{ runner.temp }}\artifacts\${{ steps.validate.outputs.artifact_name }}-winget.log
-          archive: false
-
-      - name: Upload installer log
-        id: upload-log
-        if: always()
-        continue-on-error: true
-        uses: actions/upload-artifact@v7
-        with:
-          path: ${{ runner.temp }}\artifacts\${{ steps.validate.outputs.artifact_name }}-installer.log
-          if-no-files-found: ignore
-          archive: false
-
-      - name: Upload installer logs
-        if: steps.upload-log.outcome == 'failure'
-        uses: actions/upload-artifact@v7
-        with:
-          # Somehow this can match multiple files
-          path: ${{ runner.temp }}\artifacts\${{ steps.validate.outputs.artifact_name }}-installer.log
-          if-no-files-found: ignore
+        shell: pwsh
+        run: |
+          Get-ChildItem "$env:RUNNER_TEMP\artifacts\${{ steps.validate.outputs.artifact_name }}-*.log" | ForEach-Object {
+            Write-Host "::group::$($_.Name)"
+            Get-Content $_
+            Write-Host "::endgroup::"
+          }
 
       - name: Upload screenshot
+        id: screenshot
         if: always()
         uses: actions/upload-artifact@v7
         with:
@@ -148,3 +136,18 @@ jobs:
           path: ${{ runner.temp }}\artifacts\${{ steps.validate.outputs.artifact_name }}-asa.sarif
           if-no-files-found: ignore
           archive: false
+
+      - name: Comment
+        if: always() && github.event_name == 'pull_request'
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SCREENSHOT_URL: ${{ steps.screenshot.outputs.artifact-url }}
+          ICON: ${{ steps.validate.outcome == 'success' && '✅' || '❌' }}
+        run: |
+          $job = gh api "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID/jobs" `
+            --jq "first(.jobs[] | select(.runner_name == \"$env:RUNNER_NAME\") | .html_url)"
+          $links = @("[logs]($job)")
+          if ($env:SCREENSHOT_URL) { $links += "[screenshot]($env:SCREENSHOT_URL)" }
+          gh pr comment ${{ github.event.pull_request.number }} `
+            --body "$env:ICON **${{ steps.validate.outputs.artifact_name }}** — $($links -join ' · ')"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -142,7 +142,6 @@ jobs:
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ICON: ${{ steps.validate.outcome == 'success' && '✅' || '❌' }}
         run: |
           gh pr comment ${{ github.event.pull_request.number }} `
-            --body "$env:ICON **${{ steps.validate.outputs.artifact_name }}** — [screenshot](${{ steps.screenshot.outputs.artifact-url }})"
+            --body "**${{ steps.validate.outputs.artifact_name }}** — [screenshot](${{ steps.screenshot.outputs.artifact-url }})"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -138,16 +138,11 @@ jobs:
           archive: false
 
       - name: Comment
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && steps.screenshot.outputs.artifact-url
         shell: pwsh
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SCREENSHOT_URL: ${{ steps.screenshot.outputs.artifact-url }}
           ICON: ${{ steps.validate.outcome == 'success' && '✅' || '❌' }}
         run: |
-          $job = gh api "repos/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID/jobs" `
-            --jq "first(.jobs[] | select(.runner_name == \"$env:RUNNER_NAME\") | .html_url)"
-          $links = @("[logs]($job)")
-          if ($env:SCREENSHOT_URL) { $links += "[screenshot]($env:SCREENSHOT_URL)" }
           gh pr comment ${{ github.event.pull_request.number }} `
-            --body "$env:ICON **${{ steps.validate.outputs.artifact_name }}** — $($links -join ' · ')"
+            --body "$env:ICON **${{ steps.validate.outputs.artifact_name }}** — [screenshot](${{ steps.screenshot.outputs.artifact-url }})"


### PR DESCRIPTION
## Description

This PR refactors the GitHub Actions workflow to improve log visibility and PR integration:

### Changes
- **Log handling**: Replace artifact uploads for individual log files with a single PowerShell step that prints logs using GitHub workflow annotations (groups), making them visible directly in the workflow run output
- **PR comments**: Add automatic PR comments with screenshot artifacts when validation completes on pull requests
- **Permissions**: Add `pull-requests: write` permission to the validate job to enable PR commenting

### Rationale
- Consolidates multiple artifact upload steps into a single, more maintainable log printing step
- Improves developer experience by surfacing logs in the workflow UI via annotations instead of requiring artifact downloads
- Automatically links validation screenshots to PRs for easier review
- Simplifies the workflow by removing redundant upload logic and error handling

### Testing
The changes are workflow configuration only. Validation will be confirmed through the next workflow run on a pull request.

---

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
   - N/A (workflow infrastructure change)

https://claude.ai/code/session_0131U1HpxvUSNWJXFSeFPptR