### PR TITLE
chore: add daily validation run to populate ASA cache

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,6 +15,9 @@ on:
     paths:
       - 'manifests/**'
       - 'fonts/**'
+  schedule:
+    # Daily run on main to populate the Attack Surface Analyzer baseline cache
+    - cron: '0 0 * * *'
 
 permissions: {}
 
@@ -42,12 +45,12 @@ jobs:
         id: matrix
         shell: pwsh
         env:
-          PACKAGE_ID: ${{ inputs.package_id }}
-          VERSION: ${{ inputs.version }}
+          PACKAGE_ID: ${{ inputs.package_id || 'Microsoft.ConfigMgr.SupportCenter' }}
+          VERSION: ${{ inputs.version || '5.2509.1065.1000' }}
           CHANGED: ${{ steps.changed.outputs.all_changed_files }}
         run: |
           Install-Module powershell-yaml -Force
-          $packages = @(if ($env:GITHUB_EVENT_NAME -eq 'workflow_dispatch') {
+          $packages = @(if ($env:GITHUB_EVENT_NAME -ne 'pull_request') {
             $relativePath = "$($env:PACKAGE_ID.Substring(0,1).ToLower())/$($env:PACKAGE_ID -replace '\.', '/')/$($env:VERSION)"
             if (Test-Path "fonts/$relativePath") { "fonts/$relativePath" } else { "manifests/$relativePath" }
           } else {


### PR DESCRIPTION
## Summary

Adds a daily `schedule` trigger to the `validate` workflow. Scheduled runs execute on `main` and validate `Microsoft.ConfigMgr.SupportCenter` version `5.2509.1065.1000`, which runs through the install + Attack Surface Analyzer collect steps and saves the ASA baseline cache.

Because GitHub Actions caches created on `main` are restorable by all PRs, this keeps a fresh ASA baseline available for PR validation runs — including after the runner image version (part of the cache key) rolls over.

## Changes

- Add `schedule: cron '0 0 * * *'` (daily) to the workflow triggers. Scheduled workflows only run on the default branch, so this targets `main`.
- The matrix builder now uses the fixed package/version on any non-`pull_request` event (schedule + `workflow_dispatch`), defaulting `PACKAGE_ID`/`VERSION` to `Microsoft.ConfigMgr.SupportCenter` / `5.2509.1065.1000` when no dispatch inputs are supplied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U44sCExip3bRu5j3eLHxNq

---
_Generated by [Claude Code](https://claude.ai/code/session_01U44sCExip3bRu5j3eLHxNq)_