### PR TITLE
Add monikers to all packages

### DIFF
--- a/archive/m/Microsoft/MDEClientAnalyzer/2024.5.8/Microsoft.MDEClientAnalyzer.locale.en-US.yaml
+++ b/archive/m/Microsoft/MDEClientAnalyzer/2024.5.8/Microsoft.MDEClientAnalyzer.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: Microsoft Defender for Endpoint Client Analyzer
 License: Proprietary
 ShortDescription: The Microsoft Defender for Endpoint Client Analyzer (MDECA) can be useful when diagnosing sensor health or reliability issues on onboarded devices.
+Moniker: mde-client-analyzer
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/archive/m/Microsoft/MDEClientAnalyzer/Preview/2025.5.8/Microsoft.MDEClientAnalyzer.Preview.locale.en-US.yaml
+++ b/archive/m/Microsoft/MDEClientAnalyzer/Preview/2025.5.8/Microsoft.MDEClientAnalyzer.Preview.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: Microsoft Defender for Endpoint Client Analyzer Preview
 License: Proprietary
 ShortDescription: The Microsoft Defender for Endpoint Client Analyzer (MDECA) can be useful when diagnosing sensor health or reliability issues on onboarded devices.
+Moniker: mde-client-analyzer-preview
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/archive/n/NationalSecurityAgency/Ghidra/11.4/NationalSecurityAgency.Ghidra.locale.en-US.yaml
+++ b/archive/n/NationalSecurityAgency/Ghidra/11.4/NationalSecurityAgency.Ghidra.locale.en-US.yaml
@@ -8,6 +8,7 @@ Publisher: National Security Agency
 PackageName: Ghidra
 License: Apache-2.0
 ShortDescription: Ghidra is a software reverse engineering (SRE) framework.
+Moniker: ghidra
 Tags:
 - disassembler
 - reverse-engineering

--- a/fonts/a/atelierAnchor/SmileySans/OTF/2.0.1/atelierAnchor.SmileySans.OTF.locale.en-US.yaml
+++ b/fonts/a/atelierAnchor/SmileySans/OTF/2.0.1/atelierAnchor.SmileySans.OTF.locale.en-US.yaml
@@ -13,6 +13,7 @@ LicenseUrl: https://github.com/atelier-anchor/smiley-sans/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2022--2024, atelierAnchor <https://atelier-anchor.com>, with Reserved Font Name <Smiley> and <得意黑>.
 ShortDescription: A condensed and oblique Chinese typeface seeking a visual balance between the humanist and the geometric.
 Description: Smiley Sans is a Chinese sans-serif typeface seeking a visual balance between the humanist and the geometric. The overall character shape is narrow and slightly slanted, with details incorporating special forms inspired by hand-drawn display lettering. The font supports commonly used Simplified Chinese characters (covering GB/T 2312-1980 character set and the "General Standard Chinese Characters" list), Latin, Cyrillic, and Greek letters, Japanese kana, Arabic numerals, and various punctuation marks.
+Moniker: smiley-sans-otf
 Tags:
 - font
 - typeface

--- a/fonts/a/atelierAnchor/SmileySans/TTF/2.0.1/atelierAnchor.SmileySans.TTF.locale.en-US.yaml
+++ b/fonts/a/atelierAnchor/SmileySans/TTF/2.0.1/atelierAnchor.SmileySans.TTF.locale.en-US.yaml
@@ -13,6 +13,7 @@ LicenseUrl: https://github.com/atelier-anchor/smiley-sans/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2022--2024, atelierAnchor <https://atelier-anchor.com>, with Reserved Font Name <Smiley> and <得意黑>.
 ShortDescription: A condensed and oblique Chinese typeface seeking a visual balance between the humanist and the geometric.
 Description: Smiley Sans is a Chinese sans-serif typeface seeking a visual balance between the humanist and the geometric. The overall character shape is narrow and slightly slanted, with details incorporating special forms inspired by hand-drawn display lettering. The font supports commonly used Simplified Chinese characters (covering GB/T 2312-1980 character set and the "General Standard Chinese Characters" list), Latin, Cyrillic, and Greek letters, Japanese kana, Arabic numerals, and various punctuation marks.
+Moniker: smiley-sans-ttf
 Tags:
 - font
 - typeface

--- a/fonts/h/Huawei/HarmonyOSSans/1.0/Huawei.HarmonyOSSans.locale.en-US.yaml
+++ b/fonts/h/Huawei/HarmonyOSSans/1.0/Huawei.HarmonyOSSans.locale.en-US.yaml
@@ -12,6 +12,7 @@ License: Freeware
 LicenseUrl: https://gitcode.com/openharmony/global_system_resources/blob/master/LICENSE_Fonts
 Copyright: Copyright 2021 Huawei Device Co., Ltd.
 ShortDescription: A variable font family designed and developed for full-scenario experience.
+Moniker: harmony-os-sans
 Tags:
 - font
 - typeface

--- a/fonts/r/ryanoasis/FiraMono/3.4.0/ryanoasis.FiraMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/FiraMono/3.4.0/ryanoasis.FiraMono.locale.en-US.yaml
@@ -15,6 +15,7 @@ LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Fira Mono is a Mozilla-designed monospaced family with crisp glyphs plus icon and powerline coverage tuned for terminals and tooling.
+Moniker: fira-mono-nerd-font
 Tags:
 - font
 - font-awesome

--- a/fonts/r/ryanoasis/VictorMono/3.4.0/ryanoasis.VictorMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/VictorMono/3.4.0/ryanoasis.VictorMono.locale.en-US.yaml
@@ -16,6 +16,7 @@ Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Free programming font with cursive italics and ligatures
 Description: Victor Mono is a free and open-source programming font featuring semi-connected cursive italics and symbol ligatures. Designed for readability and aesthetics in code editors, it combines a monospace design with expressive italic variants to enhance code readability.
+Moniker: victor-mono-nerd-font
 Tags:
 - font
 - font-awesome

--- a/fonts/s/SourceFoundry/Hack/3.003/SourceFoundry.Hack.locale.en-US.yaml
+++ b/fonts/s/SourceFoundry/Hack/3.003/SourceFoundry.Hack.locale.en-US.yaml
@@ -19,6 +19,7 @@ Copyright: |-
 CopyrightUrl: https://github.com/source-foundry/Hack/blob/HEAD/LICENSE.md
 ShortDescription: A workhorse monospace typeface designed for source code, with excellent legibility and Powerline support included.
 Description: Hack is a carefully hand-groomed and optically balanced monospace typeface designed for source code. It features a large x-height, wide aperture, and low contrast design for optimal legibility at commonly used source code text sizes (8-14pt range). Available in four styles (Regular, Bold, Italic, Bold Italic), Hack includes over 1500 glyphs supporting extended Latin, Greek, and Cyrillic character sets, plus Powerline symbols included by default with no patching required. The font is based on the Bitstream Vera and DejaVu projects, re-designed with an expanded glyph set, optimized metrics, and distinctive features like strategically placed serifs on narrow characters and semi-bold punctuation for better code clarity.
+Moniker: hack
 Tags:
 - developer
 - developer-tools

--- a/fonts/u/umihotaru/Nishiki-teki/4.0.4/umihotaru.Nishiki-teki.locale.en-US.yaml
+++ b/fonts/u/umihotaru/Nishiki-teki/4.0.4/umihotaru.Nishiki-teki.locale.en-US.yaml
@@ -8,6 +8,7 @@ PackageName: Nishiki-teki
 PackageUrl: https://umihotaru.work
 License: Open Font License
 ShortDescription: A bold, curvy font with very wide support for languages, even more so for Japanese.
+Moniker: nishiki-teki
 Tags:
 - font
 - nishikiteki

--- a/manifests/a/AIMP/AIMP/5.40.2703/AIMP.AIMP.locale.en-US.yaml
+++ b/manifests/a/AIMP/AIMP/5.40.2703/AIMP.AIMP.locale.en-US.yaml
@@ -9,6 +9,7 @@ PackageName: AIMP
 License: Proprietary
 Copyright: Artem Izmaylov
 ShortDescription: AIMP
+Moniker: aimp
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0
 Documentations:

--- a/manifests/a/Audiveris/Audiveris/5.10.2/Audiveris.Audiveris.locale.en-US.yaml
+++ b/manifests/a/Audiveris/Audiveris/5.10.2/Audiveris.Audiveris.locale.en-US.yaml
@@ -12,6 +12,7 @@ PackageUrl: https://audiveris.github.io/audiveris/
 License: AGPL-3.0
 LicenseUrl: https://github.com/Audiveris/audiveris/blob/master/LICENSE
 ShortDescription: Open-source optical music recognition (OMR) software.
+Moniker: audiveris
 Tags:
 - java
 - open-source

--- a/manifests/a/Auslogics/DiskDefragUltimate/4.13.0.2/Auslogics.DiskDefragUltimate.locale.en-US.yaml
+++ b/manifests/a/Auslogics/DiskDefragUltimate/4.13.0.2/Auslogics.DiskDefragUltimate.locale.en-US.yaml
@@ -12,5 +12,6 @@ License: Proprietary
 LicenseUrl: https://www.auslogics.com/en/eula/
 Copyright: Copyright © 2008-2025 Auslogics Labs Pty Ltd
 ShortDescription: Disk defragmentation and optimization utility.
+Moniker: disk-defrag-ultimate
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/b/BegoniaHoldings/HopToDesk/1.45.10/BegoniaHoldings.HopToDesk.locale.en-US.yaml
+++ b/manifests/b/BegoniaHoldings/HopToDesk/1.45.10/BegoniaHoldings.HopToDesk.locale.en-US.yaml
@@ -9,6 +9,7 @@ PackageUrl: https://www.hoptodesk.com
 License: Freeware
 Copyright: © 2026 Begonia Holdings. © 2026 Purslane Ltd.
 ShortDescription: Free remote desktop software featuring true end-to-end encrypted traffic, file transfer, and live chat.
+Moniker: hoptodesk
 Tags:
 - hop-to-desk
 - remote-desktop

--- a/manifests/c/Composer/WindowsSetup/6.3/Composer.WindowsSetup.locale.en-US.yaml
+++ b/manifests/c/Composer/WindowsSetup/6.3/Composer.WindowsSetup.locale.en-US.yaml
@@ -10,6 +10,7 @@ License: MIT
 Copyright: © 2012-2026 John Stevenson
 ShortDescription: Helps you declare, manage, and install dependencies of PHP projects.
 Description: Composer's official .exe for initial installations of the PHP dependency manager Composer. It fetches the newest or near-newest Composer version (For instance 2.10.1), has an internal temp runphp.exe to configure PHP and PATH to work better with Composer, and provides an uninstaller if needed.
+Moniker: composer
 Tags:
 - getcomposer
 - php-dependency-manager

--- a/manifests/f/Fortinet/FortiClientVPN/7.4.3.1790/Fortinet.FortiClientVPN.locale.en-US.yaml
+++ b/manifests/f/Fortinet/FortiClientVPN/7.4.3.1790/Fortinet.FortiClientVPN.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: FortiClient VPN Online Installation
 License: Proprietary
 Copyright: 2025 Fortinet Inc. All rights reserved.
 ShortDescription: FortiClient VPN-only
+Moniker: forticlient-vpn
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/g/gnome/BansheeMediaPlayer/2.4.0/gnome.BansheeMediaPlayer.locale.en-US.yaml
+++ b/manifests/g/gnome/BansheeMediaPlayer/2.4.0/gnome.BansheeMediaPlayer.locale.en-US.yaml
@@ -9,6 +9,7 @@ PackageUrl: https://www.banshee-project.org
 License: MIT
 ShortDescription: Play your music and videos. Keep up with your podcasts and Internet radio. Discover new music and podcasts. Keep your portable device loaded with good stuff.
 Description: |-
+Moniker: banshee
   Play your music and videos. Keep up with your podcasts and Internet radio. Discover new music and podcasts. Keep your portable device loaded with good stuff.
 
   Note that as of January 9, 2025, the recentmost Windows version (2.4.0) lags noticeably behind the recentmost Linux version (2.9.1).

--- a/manifests/h/HOIC/HOIC/2.1.003/HOIC.HOIC.locale.en-US.yaml
+++ b/manifests/h/HOIC/HOIC/2.1.003/HOIC.HOIC.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Praetox Technologies
 PackageName: High Orbit Ion Cannon
 License: Freeware
 ShortDescription: High Orbit Ion Cannon
+Moniker: hoic
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/l/LOIC/LOIC/1.0.8/LOIC.LOIC.locale.en-US.yaml
+++ b/manifests/l/LOIC/LOIC/1.0.8/LOIC.LOIC.locale.en-US.yaml
@@ -8,6 +8,7 @@ Publisher: Praetox Technologies
 PackageName: Low Orbit Ion Cannon
 License: Freeware
 ShortDescription: Low Orbit Ion Cannon
+Moniker: loic
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0
 Documentations:

--- a/manifests/l/laoo/Felix/0.6.4/laoo.Felix.locale.en-US.yaml
+++ b/manifests/l/laoo/Felix/0.6.4/laoo.Felix.locale.en-US.yaml
@@ -8,6 +8,7 @@ PackageName: Felix
 PackageUrl: https://github.com/laoo/Felix
 License: MIT
 ShortDescription: Atari Lynx emulator.
+Moniker: felix
 Tags:
 - emulator
 - atari-lynx

--- a/manifests/m/MCJack123/CraftOS-PC/2.8.3/MCJack123.CraftOS-PC.locale.en-US.yaml
+++ b/manifests/m/MCJack123/CraftOS-PC/2.8.3/MCJack123.CraftOS-PC.locale.en-US.yaml
@@ -12,6 +12,7 @@ PackageUrl: https://www.craftos-pc.cc/
 License: MIT
 LicenseUrl: https://github.com/MCJack123/craftos2/blob/master/LICENSE
 ShortDescription: An advanced ComputerCraft emulator for the desktop.
+Moniker: craftos-pc
 Tags:
 - computercraft
 - cpp

--- a/manifests/m/Microsoft/AzIPLogViewer/1.0/Microsoft.AzIPLogViewer.locale.en-US.yaml
+++ b/manifests/m/Microsoft/AzIPLogViewer/1.0/Microsoft.AzIPLogViewer.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: AzIP Log Viewer
 License: Proprietary
 ShortDescription: AzIP Log Viewer is an application to read both MSIP and AIP logs.
+Moniker: azip-log-viewer
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/ConfigMgr/CMPivot/5.2403.1171.1000/Microsoft.ConfigMgr.CMPivot.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMPivot/5.2403.1171.1000/Microsoft.ConfigMgr.CMPivot.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: ConfigMgr CMPivot
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
 ShortDescription: CMPivot allows you to quickly assess the state of devices in your environment and take action.
+Moniker: cmpivot
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/ConfigMgr/CMPivot/5.2503.1003.1000/Microsoft.ConfigMgr.CMPivot.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMPivot/5.2503.1003.1000/Microsoft.ConfigMgr.CMPivot.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: ConfigMgr CMPivot
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
 ShortDescription: CMPivot allows you to quickly assess the state of devices in your environment and take action.
+Moniker: cmpivot
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/CMPivot/5.2509.1036.1000/Microsoft.ConfigMgr.CMPivot.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMPivot/5.2509.1036.1000/Microsoft.ConfigMgr.CMPivot.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: ConfigMgr CMPivot
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
 ShortDescription: CMPivot allows you to quickly assess the state of devices in your environment and take action.
+Moniker: cmpivot
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9128.1007/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9128.1007/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: ConfigMgr CMTrace
 License: Proprietary
 Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
 ShortDescription: CMTrace is one of the Configuration Manager tools. It allows you to view and monitor log files.
+Moniker: cmtrace
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9133.1004/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9133.1004/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: ConfigMgr CMTrace
 License: Proprietary
 Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
 ShortDescription: CMTrace is one of the Configuration Manager tools. It allows you to view and monitor log files.
+Moniker: cmtrace
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9141.1002/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9141.1002/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: ConfigMgr CMTrace
 License: Proprietary
 Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
 ShortDescription: CMTrace is one of the Configuration Manager tools. It allows you to view and monitor log files.
+Moniker: cmtrace
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/ClientTools/5.0.9128.1007/Microsoft.ConfigMgr.ClientTools.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/ClientTools/5.0.9128.1007/Microsoft.ConfigMgr.ClientTools.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr Client Tools
 License: Proprietary
 ShortDescription: Use these tools to help support and troubleshoot your Configuration Manager infrastructure.
+Moniker: configmgr-client-tools
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/ClientTools/5.0.9133.1004/Microsoft.ConfigMgr.ClientTools.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/ClientTools/5.0.9133.1004/Microsoft.ConfigMgr.ClientTools.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr Client Tools
 License: Proprietary
 ShortDescription: Use these tools to help support and troubleshoot your Configuration Manager infrastructure.
+Moniker: configmgr-client-tools
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/ClientTools/5.0.9141.1002/Microsoft.ConfigMgr.ClientTools.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/ClientTools/5.0.9141.1002/Microsoft.ConfigMgr.ClientTools.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr Client Tools
 License: Proprietary
 ShortDescription: Use these tools to help support and troubleshoot your Configuration Manager infrastructure.
+Moniker: configmgr-client-tools
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/SupportCenter/5.2403.1209.1000/Microsoft.ConfigMgr.SupportCenter.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/SupportCenter/5.2403.1209.1000/Microsoft.ConfigMgr.SupportCenter.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr Support Center
 License: Proprietary
 ShortDescription: Use Support Center for client troubleshooting, real-time log viewing, or capturing the state of a Configuration Manager client computer for later analysis.
+Moniker: configmgr-support-center
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/SupportCenter/5.2503.1003.1000/Microsoft.ConfigMgr.SupportCenter.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/SupportCenter/5.2503.1003.1000/Microsoft.ConfigMgr.SupportCenter.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: ConfigMgr Support Center
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
 ShortDescription: Use Support Center for client troubleshooting, real-time log viewing, or capturing the state of a Configuration Manager client computer for later analysis.
+Moniker: configmgr-support-center
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/SupportCenter/5.2509.1065.1000/Microsoft.ConfigMgr.SupportCenter.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/SupportCenter/5.2509.1065.1000/Microsoft.ConfigMgr.SupportCenter.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: ConfigMgr Support Center
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
 ShortDescription: Use Support Center for client troubleshooting, real-time log viewing, or capturing the state of a Configuration Manager client computer for later analysis.
+Moniker: configmgr-support-center
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/UploadOfflineFeedback/5.0.9128.1007/Microsoft.ConfigMgr.UploadOfflineFeedback.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/UploadOfflineFeedback/5.0.9128.1007/Microsoft.ConfigMgr.UploadOfflineFeedback.locale.en-US.yaml
@@ -8,5 +8,8 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr UploadOfflineFeedback
 License: Proprietary
 ShortDescription: Save your product feedback locally and submit it later.
+Moniker: configmgr-uploadofflinefeedback
+Tags:
+- configmgr-upload-offline-feedback
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/UploadOfflineFeedback/5.0.9133.1004/Microsoft.ConfigMgr.UploadOfflineFeedback.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/UploadOfflineFeedback/5.0.9133.1004/Microsoft.ConfigMgr.UploadOfflineFeedback.locale.en-US.yaml
@@ -9,5 +9,8 @@ PackageName: ConfigMgr UploadOfflineFeedback
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
 ShortDescription: Save your product feedback locally and submit it later.
+Moniker: configmgr-uploadofflinefeedback
+Tags:
+- configmgr-upload-offline-feedback
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/ConfigMgr/UploadOfflineFeedback/5.0.9141.1002/Microsoft.ConfigMgr.UploadOfflineFeedback.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/UploadOfflineFeedback/5.0.9141.1002/Microsoft.ConfigMgr.UploadOfflineFeedback.locale.en-US.yaml
@@ -9,5 +9,8 @@ PackageName: ConfigMgr UploadOfflineFeedback
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
 ShortDescription: Save your product feedback locally and submit it later.
+Moniker: configmgr-uploadofflinefeedback
+Tags:
+- configmgr-upload-offline-feedback
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/DeploymentToolkit/6.3.8450.1000/Microsoft.DeploymentToolkit.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DeploymentToolkit/6.3.8450.1000/Microsoft.DeploymentToolkit.locale.en-US.yaml
@@ -12,6 +12,8 @@ ShortDescription: Microsoft Deployment Toolkit (MDT) provides a unified collecti
 Moniker: mdt
 Tags:
 - adk
+- deployment-toolkit
+- microsoft-deployment-toolkit
 - mdt
 - sccm
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/DeploymentToolkit/6.3.8456.1000/Microsoft.DeploymentToolkit.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DeploymentToolkit/6.3.8456.1000/Microsoft.DeploymentToolkit.locale.en-US.yaml
@@ -8,5 +8,12 @@ Publisher: Microsoft Corporation
 PackageName: Microsoft Deployment Toolkit
 License: Proprietary
 ShortDescription: Microsoft Deployment Toolkit (MDT) provides a unified collection of tools, processes, and guidance for automating desktop and server deployments.
+Moniker: mdt
+Tags:
+- adk
+- deployment-toolkit
+- microsoft-deployment-toolkit
+- mdt
+- sccm
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/GlobalSecureAccessClient/2.24.117/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
+++ b/manifests/m/Microsoft/GlobalSecureAccessClient/2.24.117/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
@@ -13,5 +13,8 @@ PackageUrl: https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-
 License: Proprietary
 Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
 ShortDescription: Windows client for Microsoft Entra Global Secure Access that acquires and forwards selected device traffic to Microsoft's Security Service Edge (Entra Internet Access / Private Access) based on configured forwarding profiles.
+Moniker: global-secure-access-client
+Tags:
+- microsoft-global-secure-access-client
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/GlobalSecureAccessClient/2.26.108/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
+++ b/manifests/m/Microsoft/GlobalSecureAccessClient/2.26.108/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
@@ -13,5 +13,8 @@ PackageUrl: https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-
 License: Proprietary
 Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
 ShortDescription: Windows client for Microsoft Entra Global Secure Access that acquires and forwards selected device traffic to Microsoft's Security Service Edge (Entra Internet Access / Private Access) based on configured forwarding profiles.
+Moniker: global-secure-access-client
+Tags:
+- microsoft-global-secure-access-client
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/IISExpress/10.0.2001.0/Microsoft.IISExpress.locale.en-US.yaml
+++ b/manifests/m/Microsoft/IISExpress/10.0.2001.0/Microsoft.IISExpress.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: IIS Express
 License: Proprietary
 ShortDescription: IIS 10.0 Express is a simple and self-contained version of IIS 10.0 that is optimized for developers.
+Moniker: iis-express
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/Intune/DeviceInventory/6.2511.10.2000/Microsoft.Intune.DeviceInventory.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Intune/DeviceInventory/6.2511.10.2000/Microsoft.Intune.DeviceInventory.locale.en-US.yaml
@@ -8,5 +8,8 @@ Publisher: Microsoft Corporation
 PackageName: Microsoft Device Inventory Agent
 License: Proprietary
 ShortDescription: Microsoft Device Inventory Agent
+Moniker: microsoft-device-inventory-agent
+Tags:
+- device-inventory-agent
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/Intune/EndpointPrivilegeManagement/6.2511.21.2000/Microsoft.Intune.EndpointPrivilegeManagement.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Intune/EndpointPrivilegeManagement/6.2511.21.2000/Microsoft.Intune.EndpointPrivilegeManagement.locale.en-US.yaml
@@ -8,5 +8,9 @@ Publisher: Microsoft Corporation
 PackageName: Microsoft Endpoint Privilege Management Agent
 License: Proprietary
 ShortDescription: Microsoft Endpoint Privilege Management Agent
+Moniker: microsoft-endpoint-privilege-management
+Tags:
+- endpoint-privilege-management
+- endpoint-privilege-management-agent
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/Intune/ManagementExtension/1.97.107.0/Microsoft.Intune.ManagementExtension.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Intune/ManagementExtension/1.97.107.0/Microsoft.Intune.ManagementExtension.locale.en-US.yaml
@@ -8,5 +8,8 @@ Publisher: Microsoft Corporation
 PackageName: Microsoft Intune Management Extension
 License: Proprietary
 ShortDescription: Microsoft Intune Management Extension
+Moniker: intune-management-extension
+Tags:
+- microsoft-intune-management-extension
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/m/Microsoft/Kusto/Explorer/1.0.3.1526/Microsoft.Kusto.Explorer.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Kusto/Explorer/1.0.3.1526/Microsoft.Kusto.Explorer.locale.en-US.yaml
@@ -9,5 +9,10 @@ PackageName: Kusto.Explorer
 PackageUrl: https://aka.ms/ke
 License: Proprietary
 ShortDescription: Kusto.Explorer allows you to query and analyze your data with Kusto Query Language (KQL) in a user-friendly interface.
+Moniker: kusto-explorer
+Tags:
+- kusto
+- Kusto-query-language
+- kql
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/MissionAppsCLI/1.0.0/Microsoft.MissionAppsCLI.locale.en-US.yaml
+++ b/manifests/m/Microsoft/MissionAppsCLI/1.0.0/Microsoft.MissionAppsCLI.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: Mission Apps CLI
 License: Proprietary
 ShortDescription: This tool is used for deploying Mission App workloads.
+Moniker: mission-apps-cli
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/RemoteBannerApp/2.0.02931.136/Microsoft.RemoteBannerApp.locale.en-US.yaml
+++ b/manifests/m/Microsoft/RemoteBannerApp/2.0.02931.136/Microsoft.RemoteBannerApp.locale.en-US.yaml
@@ -8,6 +8,7 @@ Publisher: Microsoft Corporation
 PackageName: Microsoft Remote Banner App
 License: Proprietary
 ShortDescription: This tool is used for displaying classified banners on specific applications on a desktop.
+Moniker: microsoft-remote-banner-app
 Agreements:
   - Agreement: "Before proceeding, ensure dependencies are installed by running: winget install Microsoft.VCRedist.2015+.x64"
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.locale.en-US.yaml
@@ -8,6 +8,7 @@ PackageName: Scribble MFC Application
 License: Unclear (Freeware)
 ShortDescription: A basic tool to draw black-on-white with a mouse.
 Description: A basic tool to draw black-on-white with a mouse. Created in 1992 as a sample app to demonstrate the then-new Microsoft Foundation Class Library, this Winget package is based on a 2019 .appx recompiling of one of the various sample app versions, which in turn was created at some point between 1992 and 2001.
+Moniker: scribble
 Tags:
 - microsoft-scribble
 - microsoftscribble

--- a/manifests/m/Microsoft/TeamsMeetingAddin/1.25.28902/Microsoft.TeamsMeetingAddin.locale.en-US.yaml
+++ b/manifests/m/Microsoft/TeamsMeetingAddin/1.25.28902/Microsoft.TeamsMeetingAddin.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: Microsoft Corporation
 PackageName: Microsoft Teams Meeting Add-in for Outlook
 License: Proprietary
 ShortDescription: Microsoft Teams Meeting Add-in for Outlook
+Moniker: teams-meeting-addin
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/VCRedist/2015+/arm32/14.0.23918.0/Microsoft.VCRedist.2015+.arm32.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2015+/arm32/14.0.23918.0/Microsoft.VCRedist.2015+.arm32.locale.en-US.yaml
@@ -8,6 +8,7 @@ PackageName: Microsoft Visual C++ 2015 Redistributable (Arm32)
 License: Proprietary
 Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: The Microsoft Visual C++ 2015 Redistributable Package (Arm32) installs runtime components of Visual C++ Libraries required to run Arm32/ARMv7 applications developed with Visual C++ 2015 on a computer that does not have Visual C++ 2015 installed.
+Moniker: vcredist-2015-arm32
 Agreements:
   - Agreement: "This package is untested, as no test environment was available. Please report any issues here: https://github.com/pl4nty/winget-extras/issues/new?template=package_issue.yml"
 Tags:

--- a/manifests/m/Microsoft/WindowsSDK/Orca/5.0.10011.0/Microsoft.WindowsSDK.Orca.locale.en-US.yaml
+++ b/manifests/m/Microsoft/WindowsSDK/Orca/5.0.10011.0/Microsoft.WindowsSDK.Orca.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: Windows Orca
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2320054
 License: Proprietary
 ShortDescription: Orca.exe is a database table editor for creating and editing Windows Installer packages and merge modules.
+Moniker: orca
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/m/Microsoft/eDiscoveryExportTool/15.20.1771.0/Microsoft.eDiscoveryExportTool.locale.en-US.yaml
+++ b/manifests/m/Microsoft/eDiscoveryExportTool/15.20.1771.0/Microsoft.eDiscoveryExportTool.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: eDiscovery Export Tool
 PackageUrl: https://complianceclientsdf.blob.core.windows.net/v16/Microsoft.Office.Client.Discovery.UnifiedExportTool.manifest
 License: Proprietary
 ShortDescription: Use the eDiscovery Export Tool to download Microsoft Purview Content Search or eDiscovery search results.
+Moniker: ediscovery-export-tool
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/n/NirSoft/NirCmd/2.87/NirSoft.NirCmd.locale.en-US.yaml
+++ b/manifests/n/NirSoft/NirCmd/2.87/NirSoft.NirCmd.locale.en-US.yaml
@@ -8,5 +8,6 @@ Publisher: NirSoft
 PackageName: NirCmd
 License: Freeware
 ShortDescription: NirCmd
+Moniker: nircmd
 ManifestType: defaultLocale
 ManifestVersion: 1.10.0

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/591.86/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/591.86/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
@@ -9,6 +9,7 @@ PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Proprietary (Freeware)
 Copyright: © 2011-2026 NVIDIA Corporation
 ShortDescription: Driver for Nvidia graphics cards.
+Moniker: nvidia-driver
 Tags:
 - nvidia-display-driver
 - nvidiadisplaydriver

--- a/manifests/p/Pantaray/SuperOrca/11.0.0.1/Pantaray.SuperOrca.locale.en-US.yaml
+++ b/manifests/p/Pantaray/SuperOrca/11.0.0.1/Pantaray.SuperOrca.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: QSetup Installation Suite
 License: Proprietary
 Copyright: Copyright (C) 2002-2012, Pantaray Research Ltd.
 ShortDescription: SuperOrca from "Pantaray Research Ltd." is a direct replacement to the "Orca" MSI Editor from Microsoft. SuperOrca may be used to examine and modify an MSI database in order to distribute a new MSI package.
+Moniker: super-orca
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/p/Purslane/RustDesk/1.4.6.29544831/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.6.29544831/Purslane.RustDesk.locale.en-US.yaml
@@ -8,6 +8,7 @@ PackageName: RustDesk
 PackageUrl: https://rustdesk.com
 License: AGPLv3
 ShortDescription: The fast open-source remote access and support software.
+Moniker: rustdesk
 Tags:
 - rust-desk
 - remote-desktop
@@ -16,9 +17,9 @@ Tags:
 - selfhosting
 Agreements:
 - Agreement: |-
-    The following is the official warning stated by the RustDesk developers on all their download pages：
+    The following is the official warning stated by the RustDesk developers on all their download pages:
 
-    «WARNING：YOU MAY BE BEING SCAMMED! If you are on the phone with someone you DON'T know AND TRUST who has asked you to install RustDesk, do not install and hang up immediately. They are likely a scammer trying to steal your money or other private information.»
+    «WARNING: YOU MAY BE BEING SCAMMED! If you are on the phone with someone you DON'T know AND TRUST who has asked you to install RustDesk, do not install and hang up immediately. They are likely a scammer trying to steal your money or other private information.»
 
     If you are not in this situation, you can say yes to this Winget agreement prompt.
 ManifestType: defaultLocale

--- a/manifests/r/ralish/CertUiExts/0.4.0/ralish.CertUiExts.locale.en-US.yaml
+++ b/manifests/r/ralish/CertUiExts/0.4.0/ralish.CertUiExts.locale.en-US.yaml
@@ -8,6 +8,7 @@ Publisher: ralish
 PackageName: CertUiExts
 License: MIT
 ShortDescription: A library which extends Windows cryptography support for displaying additional OIDs and associated certificate extensions.
+Moniker: certuiexts
 Agreements:
   - Agreement: Installing to a user-writeable location probably allows privilege escalation. Don't install this unless you accept the risk, or just move it afterwards.
 Tags:

--- a/manifests/r/ralish/CertUiExts/0.5.2/ralish.CertUiExts.locale.en-US.yaml
+++ b/manifests/r/ralish/CertUiExts/0.5.2/ralish.CertUiExts.locale.en-US.yaml
@@ -12,6 +12,7 @@ PackageUrl: https://github.com/ralish/CertUiExts
 License: MIT
 LicenseUrl: https://github.com/ralish/CertUiExts/blob/HEAD/LICENSE
 ShortDescription: A library which extends Windows cryptography support for displaying additional OIDs and associated certificate extensions.
+Moniker: certuiexts
 Tags:
 - certificates
 - security

--- a/manifests/s/ShunsukeSuzuki/AsciinemaTrim/0.1.2/ShunsukeSuzuki.AsciinemaTrim.locale.en-US.yaml
+++ b/manifests/s/ShunsukeSuzuki/AsciinemaTrim/0.1.2/ShunsukeSuzuki.AsciinemaTrim.locale.en-US.yaml
@@ -9,5 +9,6 @@ PackageName: Asciinema Trim
 PackageUrl: https://github.com/suzuki-shunsuke/asciinema-trim
 License: MIT
 ShortDescription: Trim and change the playback speed of asciinema's session
+Moniker: asciinema-trim
 ManifestType: defaultLocale
 ManifestVersion: 1.9.0

--- a/manifests/s/StackHawk/HawkScan/5.6/StackHawk.HawkScan.locale.en-US.yaml
+++ b/manifests/s/StackHawk/HawkScan/5.6/StackHawk.HawkScan.locale.en-US.yaml
@@ -8,6 +8,7 @@ PackageName: StackHawk HawkScan
 PackageUrl: https://docs.stackhawk.com/hawkscan/
 License: Proprietary (API key required for use)
 ShortDescription: A dynamic application security testing (DAST) tool built for developers. Requires command line use.
+Moniker: hawkscan
 Tags:
 - docker
 - antimalware

--- a/manifests/s/SwisslogForWindows/Swisslog/5.117/SwisslogForWindows.Swisslog.locale.en-US.yaml
+++ b/manifests/s/SwisslogForWindows/Swisslog/5.117/SwisslogForWindows.Swisslog.locale.en-US.yaml
@@ -10,5 +10,6 @@ PackageUrl: https://www.swisslogforwindows.com/
 License: Freeware
 Copyright: Copyright © 1987-2026 Walter Baur, HB9BJS
 ShortDescription: Amateur radio logging program for Windows.
+Moniker: swisslog
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
I don't like having to type out the full `PackageIdentifier` to install stuff