### PR TITLE
fix: validation screenshot capture on arm64 runners

### DIFF
--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -14,37 +14,6 @@ function New-Screenshot([string]$Path) {
     $bmp.Save($Path); $gfx.Dispose(); $bmp.Dispose()
 }
 
-# Minimize console windows (e.g. the runner's hosted-compute-agent debug console)
-# so they don't clutter the app screenshot. The target app is not a console, so it's untouched.
-function Hide-DebugWindows {
-    Add-Type @"
-using System;
-using System.Text;
-using System.Runtime.InteropServices;
-public static class WinApi {
-    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
-    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
-    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
-    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-}
-"@ -ErrorAction SilentlyContinue
-    $SW_MINIMIZE = 6
-    $consoleClasses = 'ConsoleWindowClass', 'CASCADIA_HOSTING_WINDOW_CLASS'
-    $callback = [WinApi+EnumWindowsProc] {
-        param($hWnd, $lParam)
-        if ([WinApi]::IsWindowVisible($hWnd)) {
-            $sb = [System.Text.StringBuilder]::new(256)
-            [WinApi]::GetClassName($hWnd, $sb, $sb.Capacity) | Out-Null
-            if ($consoleClasses -contains $sb.ToString()) {
-                [WinApi]::ShowWindow($hWnd, $SW_MINIMIZE) | Out-Null
-            }
-        }
-        return $true
-    }
-    [WinApi]::EnumWindows($callback, [IntPtr]::Zero) | Out-Null
-}
-
 Install-Module powershell-yaml -Force
 
 $artifacts = "$env:RUNNER_TEMP\artifacts"
@@ -162,12 +131,15 @@ if ($appPath) {
     }
 
     $env:PATH = "$([Environment]::GetEnvironmentVariable('PATH', 'Machine'));$([Environment]::GetEnvironmentVariable('PATH', 'User'))"
+
+    # Minimize all windows (e.g. the runner's debug console) so only the app shows in the screenshot
+    (New-Object -ComObject Shell.Application).MinimizeAll()
+
     Write-Host "Starting $appPath"
     # https://github.com/PowerShell/PowerShell/issues/10996
     try { $app = Start-Process $appPath -PassThru } catch {}
-    
+
     Start-Sleep 10
-    Hide-DebugWindows
     New-Screenshot "$artifacts\$artifactName.png"
     if ($app) {
         if ($app.HasExited) {

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -14,11 +14,10 @@ function New-Screenshot([string]$Path) {
     $bmp.Save($Path); $gfx.Dispose(); $bmp.Dispose()
 }
 
-# Tidy the desktop just before a screenshot: bring the app to the foreground (which dismisses
-# the Start menu that the post-OOBE shell pops on arm64) and minimize console windows like the
-# runner's debug console. Targeted minimize keeps the app visible, unlike Shell.MinimizeAll.
+# Tidy the desktop just before a screenshot: minimize console windows like the runner's debug
+# console, close the Start menu (the post-OOBE shell auto-opens it on arm64) and bring the app
+# forward. Targeted minimize keeps the app visible, unlike Shell.MinimizeAll.
 function Hide-DebugWindows([System.Diagnostics.Process]$App) {
-    Add-Type -AssemblyName System.Windows.Forms
     Add-Type @"
 using System;
 using System.Text;
@@ -48,14 +47,16 @@ public static class WinApi {
     }
     [WinApi]::EnumWindows($callback, [IntPtr]::Zero) | Out-Null
 
-    # Activate the app so the Start menu loses focus and closes; fall back to Esc if it has no window.
+    # Close the Start menu (killing the host closes the flyout; it respawns in the background).
+    Stop-Process -Name StartMenuExperienceHost -Force -ErrorAction SilentlyContinue
+
+    # Bring the app to the foreground so it's the focused window in the shot.
     if ($App) { $App.Refresh() }
     if ($App -and $App.MainWindowHandle -ne [IntPtr]::Zero) {
         [WinApi]::SetForegroundWindow($App.MainWindowHandle) | Out-Null
     }
-    else {
-        [System.Windows.Forms.SendKeys]::SendWait('{ESC}')
-    }
+
+    Start-Sleep 1
 }
 
 Install-Module powershell-yaml -Force

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -143,9 +143,10 @@ if ($appPath) {
 
     Start-Sleep 10
 
-    # Hide the runner's debug console and the Start menu (the post-OOBE shell auto-opens it) with a
-    # single "show desktop", then restore just the app window so only it shows in the screenshot.
+    # Close the Start menu (the post-OOBE shell auto-opens it), hide the runner's debug console
+    # via "show desktop", then restore just the app window so only it shows in the screenshot.
     Add-Type 'using System;using System.Runtime.InteropServices;public static class Win{[DllImport("user32.dll")]public static extern bool ShowWindow(IntPtr h,int c);}' -ErrorAction SilentlyContinue
+    Stop-Process -Name StartMenuExperienceHost -Force -ErrorAction SilentlyContinue
     (New-Object -ComObject Shell.Application).MinimizeAll()
     if ($app) { $app.Refresh(); [Win]::ShowWindow($app.MainWindowHandle, 9) | Out-Null }
     Start-Sleep 1

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -132,6 +132,11 @@ if ($appPath) {
 
     $env:PATH = "$([Environment]::GetEnvironmentVariable('PATH', 'Machine'));$([Environment]::GetEnvironmentVariable('PATH', 'User'))"
 
+    # arm64 runners can sit on the Windows OOBE (privacy settings) screen, which covers the
+    # desktop. Mark privacy consent complete and close the OOBE host so it doesn't reappear.
+    Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE' -Name PrivacyConsentStatus -Value 1 -Type DWord -Force -ErrorAction SilentlyContinue
+    Stop-Process -Name WWAHost, FirstLogonAnim -Force -ErrorAction SilentlyContinue
+
     # Minimize all windows (e.g. the runner's debug console) so only the app shows in the screenshot
     (New-Object -ComObject Shell.Application).MinimizeAll()
 

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -14,6 +14,50 @@ function New-Screenshot([string]$Path) {
     $bmp.Save($Path); $gfx.Dispose(); $bmp.Dispose()
 }
 
+# Tidy the desktop just before a screenshot: bring the app to the foreground (which dismisses
+# the Start menu that the post-OOBE shell pops on arm64) and minimize console windows like the
+# runner's debug console. Targeted minimize keeps the app visible, unlike Shell.MinimizeAll.
+function Hide-DebugWindows([System.Diagnostics.Process]$App) {
+    Add-Type -AssemblyName System.Windows.Forms
+    Add-Type @"
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+public static class WinApi {
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
+}
+"@ -ErrorAction SilentlyContinue
+
+    $SW_MINIMIZE = 6
+    $consoleClasses = 'ConsoleWindowClass', 'CASCADIA_HOSTING_WINDOW_CLASS'
+    $callback = [WinApi+EnumWindowsProc] {
+        param($hWnd, $lParam)
+        if ([WinApi]::IsWindowVisible($hWnd)) {
+            $sb = [System.Text.StringBuilder]::new(256)
+            [WinApi]::GetClassName($hWnd, $sb, $sb.Capacity) | Out-Null
+            if ($consoleClasses -contains $sb.ToString()) {
+                [WinApi]::ShowWindow($hWnd, $SW_MINIMIZE) | Out-Null
+            }
+        }
+        return $true
+    }
+    [WinApi]::EnumWindows($callback, [IntPtr]::Zero) | Out-Null
+
+    # Activate the app so the Start menu loses focus and closes; fall back to Esc if it has no window.
+    if ($App) { $App.Refresh() }
+    if ($App -and $App.MainWindowHandle -ne [IntPtr]::Zero) {
+        [WinApi]::SetForegroundWindow($App.MainWindowHandle) | Out-Null
+    }
+    else {
+        [System.Windows.Forms.SendKeys]::SendWait('{ESC}')
+    }
+}
+
 Install-Module powershell-yaml -Force
 
 $artifacts = "$env:RUNNER_TEMP\artifacts"
@@ -137,14 +181,12 @@ if ($appPath) {
     Set-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\OOBE' -Name PrivacyConsentStatus -Value 1 -Type DWord -Force -ErrorAction SilentlyContinue
     Stop-Process -Name WWAHost, FirstLogonAnim -Force -ErrorAction SilentlyContinue
 
-    # Minimize all windows (e.g. the runner's debug console) so only the app shows in the screenshot
-    (New-Object -ComObject Shell.Application).MinimizeAll()
-
     Write-Host "Starting $appPath"
     # https://github.com/PowerShell/PowerShell/issues/10996
     try { $app = Start-Process $appPath -PassThru } catch {}
 
     Start-Sleep 10
+    Hide-DebugWindows $app
     New-Screenshot "$artifacts\$artifactName.png"
     if ($app) {
         if ($app.HasExited) {

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -14,6 +14,37 @@ function New-Screenshot([string]$Path) {
     $bmp.Save($Path); $gfx.Dispose(); $bmp.Dispose()
 }
 
+# Minimize console windows (e.g. the runner's hosted-compute-agent debug console)
+# so they don't clutter the app screenshot. The target app is not a console, so it's untouched.
+function Hide-DebugWindows {
+    Add-Type @"
+using System;
+using System.Text;
+using System.Runtime.InteropServices;
+public static class WinApi {
+    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
+    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+}
+"@ -ErrorAction SilentlyContinue
+    $SW_MINIMIZE = 6
+    $consoleClasses = 'ConsoleWindowClass', 'CASCADIA_HOSTING_WINDOW_CLASS'
+    $callback = [WinApi+EnumWindowsProc] {
+        param($hWnd, $lParam)
+        if ([WinApi]::IsWindowVisible($hWnd)) {
+            $sb = [System.Text.StringBuilder]::new(256)
+            [WinApi]::GetClassName($hWnd, $sb, $sb.Capacity) | Out-Null
+            if ($consoleClasses -contains $sb.ToString()) {
+                [WinApi]::ShowWindow($hWnd, $SW_MINIMIZE) | Out-Null
+            }
+        }
+        return $true
+    }
+    [WinApi]::EnumWindows($callback, [IntPtr]::Zero) | Out-Null
+}
+
 Install-Module powershell-yaml -Force
 
 $artifacts = "$env:RUNNER_TEMP\artifacts"
@@ -136,6 +167,7 @@ if ($appPath) {
     try { $app = Start-Process $appPath -PassThru } catch {}
     
     Start-Sleep 10
+    Hide-DebugWindows
     New-Screenshot "$artifacts\$artifactName.png"
     if ($app) {
         if ($app.HasExited) {

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -14,51 +14,6 @@ function New-Screenshot([string]$Path) {
     $bmp.Save($Path); $gfx.Dispose(); $bmp.Dispose()
 }
 
-# Tidy the desktop just before a screenshot: minimize console windows like the runner's debug
-# console, close the Start menu (the post-OOBE shell auto-opens it on arm64) and bring the app
-# forward. Targeted minimize keeps the app visible, unlike Shell.MinimizeAll.
-function Hide-DebugWindows([System.Diagnostics.Process]$App) {
-    Add-Type @"
-using System;
-using System.Text;
-using System.Runtime.InteropServices;
-public static class WinApi {
-    public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
-    [DllImport("user32.dll")] public static extern bool EnumWindows(EnumWindowsProc lpEnumFunc, IntPtr lParam);
-    [DllImport("user32.dll")] public static extern bool IsWindowVisible(IntPtr hWnd);
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)] public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
-    [DllImport("user32.dll")] public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
-    [DllImport("user32.dll")] public static extern bool SetForegroundWindow(IntPtr hWnd);
-}
-"@ -ErrorAction SilentlyContinue
-
-    $SW_MINIMIZE = 6
-    $consoleClasses = 'ConsoleWindowClass', 'CASCADIA_HOSTING_WINDOW_CLASS'
-    $callback = [WinApi+EnumWindowsProc] {
-        param($hWnd, $lParam)
-        if ([WinApi]::IsWindowVisible($hWnd)) {
-            $sb = [System.Text.StringBuilder]::new(256)
-            [WinApi]::GetClassName($hWnd, $sb, $sb.Capacity) | Out-Null
-            if ($consoleClasses -contains $sb.ToString()) {
-                [WinApi]::ShowWindow($hWnd, $SW_MINIMIZE) | Out-Null
-            }
-        }
-        return $true
-    }
-    [WinApi]::EnumWindows($callback, [IntPtr]::Zero) | Out-Null
-
-    # Close the Start menu (killing the host closes the flyout; it respawns in the background).
-    Stop-Process -Name StartMenuExperienceHost -Force -ErrorAction SilentlyContinue
-
-    # Bring the app to the foreground so it's the focused window in the shot.
-    if ($App) { $App.Refresh() }
-    if ($App -and $App.MainWindowHandle -ne [IntPtr]::Zero) {
-        [WinApi]::SetForegroundWindow($App.MainWindowHandle) | Out-Null
-    }
-
-    Start-Sleep 1
-}
-
 Install-Module powershell-yaml -Force
 
 $artifacts = "$env:RUNNER_TEMP\artifacts"
@@ -187,7 +142,14 @@ if ($appPath) {
     try { $app = Start-Process $appPath -PassThru } catch {}
 
     Start-Sleep 10
-    Hide-DebugWindows $app
+
+    # Hide the runner's debug console and the Start menu (the post-OOBE shell auto-opens it) with a
+    # single "show desktop", then restore just the app window so only it shows in the screenshot.
+    Add-Type 'using System;using System.Runtime.InteropServices;public static class Win{[DllImport("user32.dll")]public static extern bool ShowWindow(IntPtr h,int c);}' -ErrorAction SilentlyContinue
+    (New-Object -ComObject Shell.Application).MinimizeAll()
+    if ($app) { $app.Refresh(); [Win]::ShowWindow($app.MainWindowHandle, 9) | Out-Null }
+    Start-Sleep 1
+
     New-Screenshot "$artifacts\$artifactName.png"
     if ($app) {
         if ($app.HasExited) {


### PR DESCRIPTION
## Description

This PR fixes screenshot capture issues on arm64 Windows runners by addressing the Windows Out-of-Box Experience (OOBE) screen that can appear and cover the desktop.

### Changes

- Mark privacy consent as complete in the registry to prevent OOBE from appearing
- Close the OOBE host process (`WWAHost`) and first logon animation process
- Close the Start menu that auto-opens after OOBE
- Hide the runner's debug console using "show desktop" functionality
- Restore and show only the application window before taking the screenshot
- Added P/Invoke declaration to call Windows API for window management

### Why

On arm64 runners, the Windows OOBE privacy settings screen can persist and cover the desktop, resulting in screenshots that don't show the application. These changes ensure the desktop is clean and only the target application is visible when the screenshot is captured.

### Testing

The changes will be validated through the existing CI/CD pipeline that runs the validation script on arm64 runners.

https://claude.ai/code/session_01PNvfD7yS1tAVRhJGiu2mdg