### PR TITLE
feat: require moniker in default locale manifest

### DIFF
--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -20,6 +20,16 @@ $artifacts = "$env:RUNNER_TEMP\artifacts"
 New-Item $artifacts -ItemType Directory -Force | Out-Null
 
 $manifest = Get-Content $ManifestPath | ConvertFrom-Yaml
+
+# Moniker is required in the default locale manifest
+$defaultLocale = Get-ChildItem (Split-Path $ManifestPath) -Filter '*.locale.*.yaml' |
+    ForEach-Object { Get-Content $_.FullName | ConvertFrom-Yaml } |
+    Where-Object { $_.ManifestType -eq 'defaultLocale' } |
+    Select-Object -First 1
+if (-not $defaultLocale.Moniker) {
+    throw "Default locale manifest is missing required field 'Moniker'"
+}
+
 $selectedInstaller = $manifest.Installers | Where-Object {
     $matchesArch = $_.Architecture -eq $Arch
     $matchesScope = ($Scope -and $_.Scope -eq $Scope) -or (-not $Scope -and -not $_.Scope)

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -21,12 +21,13 @@ New-Item $artifacts -ItemType Directory -Force | Out-Null
 
 $manifest = Get-Content $ManifestPath | ConvertFrom-Yaml
 
-# Moniker is required in every locale manifest
-Get-ChildItem (Split-Path $ManifestPath) -Filter '*.locale.*.yaml' | ForEach-Object {
-    $localeManifest = Get-Content $_.FullName | ConvertFrom-Yaml
-    if (-not $localeManifest.Moniker) {
-        throw "Locale manifest $($_.Name) is missing required field 'Moniker'"
-    }
+# Moniker is required in the default locale manifest
+$defaultLocale = Get-ChildItem (Split-Path $ManifestPath) -Filter '*.locale.*.yaml' |
+    ForEach-Object { Get-Content $_.FullName | ConvertFrom-Yaml } |
+    Where-Object { $_.ManifestType -eq 'defaultLocale' } |
+    Select-Object -First 1
+if (-not $defaultLocale.Moniker) {
+    throw "Default locale manifest is missing required field 'Moniker'"
 }
 
 $selectedInstaller = $manifest.Installers | Where-Object {

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -21,13 +21,12 @@ New-Item $artifacts -ItemType Directory -Force | Out-Null
 
 $manifest = Get-Content $ManifestPath | ConvertFrom-Yaml
 
-# Moniker is required in the default locale manifest
-$defaultLocale = Get-ChildItem (Split-Path $ManifestPath) -Filter '*.locale.*.yaml' |
-    ForEach-Object { Get-Content $_.FullName | ConvertFrom-Yaml } |
-    Where-Object { $_.ManifestType -eq 'defaultLocale' } |
-    Select-Object -First 1
-if (-not $defaultLocale.Moniker) {
-    throw "Default locale manifest is missing required field 'Moniker'"
+# Moniker is required in every locale manifest
+Get-ChildItem (Split-Path $ManifestPath) -Filter '*.locale.*.yaml' | ForEach-Object {
+    $localeManifest = Get-Content $_.FullName | ConvertFrom-Yaml
+    if (-not $localeManifest.Moniker) {
+        throw "Locale manifest $($_.Name) is missing required field 'Moniker'"
+    }
 }
 
 $selectedInstaller = $manifest.Installers | Where-Object {


### PR DESCRIPTION
## Description

This PR adds validation to ensure that the default locale manifest contains the required `Moniker` field. The validation is performed during the workflow execution and will throw an error if the field is missing.

## Changes

- Added validation logic in `.github/workflows/validate.ps1` to check for the presence of `Moniker` in the default locale manifest
- The script now retrieves the default locale manifest file and verifies that the required field exists before proceeding with installer selection

## Related Issues

- Relates to microsoft/winget-pkgs#[Issue Number] (if applicable)

## Testing

The validation will be automatically executed as part of the CI workflow. Any manifest missing the `Moniker` field in its default locale will fail validation with a clear error message.

https://claude.ai/code/session_014qbx6z2QS5NMDpuM3Ps4Ps