### PR TITLE
New package: tetunori.FluentEmojiWebfont.Flat version 0.8.5

### DIFF
--- a/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.installer.yaml
+++ b/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.installer.yaml
@@ -6,7 +6,7 @@ ReleaseDate: 2025-09-06
 InstallerType: font
 Installers:
 - Architecture: neutral
-  InstallerUrl: https://tetunori.github.io/fluent-emoji-webfont/dist/FluentEmojiFlat.ttf
+  InstallerUrl: https://raw.githubusercontent.com/tetunori/fluent-emoji-webfont/5ef6d2a4af81d79b7750df443511360b14df6858/dist/FluentEmojiFlat.ttf
   InstallerSha256: 951da552e63bd9e6b4ee375fe711a0cf523553568dd9c203888a43f872ab0dbb
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.installer.yaml
+++ b/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: tetunori.FluentEmojiWebfont.Flat
+PackageVersion: 0.8.5
+ReleaseDate: 2025-09-06
+InstallerType: font
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://tetunori.github.io/fluent-emoji-webfont/dist/FluentEmojiFlat.ttf
+  InstallerSha256: 951da552e63bd9e6b4ee375fe711a0cf523553568dd9c203888a43f872ab0dbb
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.locale.en.yaml
+++ b/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.locale.en.yaml
@@ -1,0 +1,30 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: tetunori.FluentEmojiWebfont.Flat
+PackageVersion: 0.8.5
+PackageLocale: en
+Publisher: Tetsunori Nakayama
+PackageName: Fluent Emoji Webfont - Flat
+PackageUrl: https://github.com/tetunori/fluent-emoji-webfont
+License: MIT
+ShortDescription: An installable .ttf font built from the source code of Microsoft's Fluent Emoji open-source repository files.
+Moniker: fluentemojiflat
+Tags:
+- font
+- fluent-emoji-webfont-flat
+- fluentemojiwebfontflat
+- fluent-emoji-flat
+- FluentEmojiFlat.ttf
+- emojis
+- emotes
+- fluentui-emoji
+- fluent-ui-emoji
+- fluentuiemoji
+- segoe-ui-emoji
+- segoeuiemoji
+- fewf
+Documentations:
+- DocumentLabel: Microsoft's Fluent Emoji source code
+  DocumentUrl: https://github.com/microsoft/fluentui-emoji
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.locale.ja-JP.yaml
+++ b/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.locale.ja-JP.yaml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: tetunori.FluentEmojiWebfont.Flat
+PackageVersion: 0.8.5
+PackageLocale: ja-JP
+Publisher: 中山 哲徳
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.yaml
+++ b/fonts/t/tetunori/FluentEmojiWebfont/Flat/0.8.5/tetunori.FluentEmojiWebfont.Flat.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: tetunori.FluentEmojiWebfont.Flat
+PackageVersion: 0.8.5
+DefaultLocale: en
+ManifestType: version
+ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
   <!-- Example: Resolves #328283 -->
  - Relates to microsoft/winget-pkgs#[Issue Number]

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* The situation is much the same as for #228: While Microsoft have seemingly fully open-sourced the visual assets of its Segoe UI Emoji font(s), they have for goodness knows what reason never freely published the font that is compiled from that free, open-source code. So another GitHub user took care of compiling it for them.