### PR TITLE
perf: improve merge speed and support localization

### DIFF
--- a/.github/workflows/merge.ps1
+++ b/.github/workflows/merge.ps1
@@ -1,0 +1,133 @@
+$ErrorActionPreference = 'Stop'
+$PSNativeCommandUseErrorActionPreference = $true
+
+$tempRoot = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [IO.Path]::GetTempPath() }
+$tempManifests = Join-Path $tempRoot 'manifests'
+$tempDependencies = Join-Path $tempRoot 'winget-extras-dependencies'
+
+Remove-Item $tempManifests, $tempDependencies -Recurse -Force -ErrorAction SilentlyContinue
+New-Item $tempManifests, $tempDependencies -ItemType Directory -Force | Out-Null
+
+# winget can't resolve dependencies across sources (microsoft/winget-cli#3271), so
+# copy each declared winget-pkgs dependency in to be merged alongside our packages.
+$installerFiles = @(git ls-files -- 'manifests/*.installer.yaml' 'fonts/*.installer.yaml')
+$dependencies = @(
+  & yq ea @'
+[.]
+| map((.Dependencies, .Installers[].Dependencies).PackageDependencies[].PackageIdentifier)
+| flatten
+| map(select(. != null))
+| unique
+| .[]
+'@ @installerFiles
+)
+
+$token = $env:GH_TOKEN
+if (-not $token) {
+  $token = & gh auth token
+  if ($LASTEXITCODE -ne 0) {
+    throw 'GitHub authentication is required to resolve dependencies'
+  }
+}
+
+$missingDependencies = @(
+  foreach ($dependency in $dependencies) {
+    $first = $dependency.Substring(0, 1).ToLowerInvariant()
+    $path = "manifests/$first/$($dependency.Replace('.', '/'))"
+    $fontPath = $path -replace '^manifests', 'fonts'
+
+    $existingManifest = Get-ChildItem $path, $fontPath -Filter "$dependency.yaml" -File -Recurse -ErrorAction SilentlyContinue |
+    Select-Object -First 1
+    if ($existingManifest) {
+      continue
+    }
+
+    [pscustomobject]@{
+      Dependency = $dependency
+      Path       = $path
+    }
+  }
+)
+
+if ($missingDependencies) {
+  $headers = @{
+    Accept                 = 'application/vnd.github+json'
+    Authorization          = "Bearer $token"
+    'User-Agent'           = 'winget-extras'
+    'X-GitHub-Api-Version' = '2026-03-10'
+  }
+
+  $missingDependencies | ForEach-Object -ThrottleLimit 8 -Parallel {
+    $ErrorActionPreference = 'Stop'
+    $item = $_
+    $encodePath = {
+      param([string]$Path)
+      ($Path.Split('/') | ForEach-Object { [Uri]::EscapeDataString($_) }) -join '/'
+    }
+
+    $apiBase = 'https://api.github.com/repos/microsoft/winget-pkgs/contents'
+    $versions = Invoke-RestMethod `
+      -Headers $using:headers `
+      -Uri "$apiBase/$(& $encodePath $item.Path)"
+    $version = $versions |
+    Where-Object type -eq 'dir' |
+    Select-Object -ExpandProperty name |
+    & sort --version-sort |
+    Select-Object -Last 1
+    if (-not $version) {
+      throw "No version found for dependency $($item.Dependency)"
+    }
+
+    $path = "$($item.Path)/$version"
+    $files = Invoke-RestMethod `
+      -Headers $using:headers `
+      -Uri "$apiBase/$(& $encodePath $path)" |
+    Where-Object { $_.type -eq 'file' -and $_.name -like '*.yaml' }
+    $destination = Join-Path $using:tempDependencies $path
+    New-Item $destination -ItemType Directory -Force | Out-Null
+
+    $curlArguments = @('--fail', '--silent', '--show-error', '--location', '--parallel')
+    foreach ($file in $files) {
+      $uri = "https://raw.githubusercontent.com/microsoft/winget-pkgs/refs/heads/master/$(& $encodePath "$path/$($file.name)")"
+      $curlArguments += @('--output', (Join-Path $destination $file.name), $uri)
+    }
+    & curl @curlArguments
+  }
+}
+
+$yqExpression = @'
+[.]
+| group_by(.PackageIdentifier + "\u0000" + .PackageVersion)[]
+| . as $docs
+| ($docs | map(select(.ManifestType != "locale")) | .[] as $item ireduce ({}; . * $item))
+| .Localization = ($docs | map(select(.ManifestType == "locale") | del(.PackageIdentifier, .PackageVersion, .ManifestType, .ManifestVersion)))
+| del(.Localization | select(length == 0))
+| .ManifestType = "merged"
+| sort_keys(..)
+| ... comments=""
+'@
+
+$normalizedTempManifests = $tempManifests.Replace('\', '/')
+$env:TMP_MANIFESTS = $normalizedTempManifests
+$splitExpression = 'strenv(TMP_MANIFESTS) + "/" + .PackageIdentifier + "-" + .PackageVersion + ".yaml"'
+$packageGroups = @(
+  Get-ChildItem manifests, fonts, $tempDependencies -Filter '*.yaml' -File -Recurse |
+  Group-Object DirectoryName
+)
+
+$workerCount = [Math]::Min([Environment]::ProcessorCount, $packageGroups.Count)
+$shards = [object[]]::new($workerCount)
+for ($worker = 0; $worker -lt $workerCount; $worker++) {
+  $shards[$worker] = [Collections.Generic.List[string]]::new()
+}
+for ($index = 0; $index -lt $packageGroups.Count; $index++) {
+  $shards[$index % $workerCount].AddRange(
+    [string[]]$packageGroups[$index].Group.FullName
+  )
+}
+
+$shards | ForEach-Object -ThrottleLimit $workerCount -Parallel {
+  $env:TMP_MANIFESTS = $using:normalizedTempManifests
+  $files = @($_)
+  & yq ea --split-exp $using:splitExpression $using:yqExpression @files
+}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,83 +5,93 @@ on:
     branches:
       - main
     paths:
-      - "index/**"
-      - "manifests/**"
-      - "fonts/**"
+      - 'index/**'
+      - 'manifests/**'
+      - 'fonts/**'
   workflow_dispatch:
   workflow_call:
 
+permissions: {}
+
 jobs:
-  main:
-    runs-on: windows-2025
-    permissions:
-      contents: read
-      id-token: write
+  merge:
+    runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
-      # TODO improve speed, takes 30s
       - name: Merge manifests
+        shell: pwsh
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          choco install yq
+          ./.github/workflows/merge.ps1
 
-          $TMP_MANIFESTS = "$env:TEMP\manifests"
-          New-Item -ItemType Directory -Path $TMP_MANIFESTS -Force
+      - parallel:
+          - name: Upload merged manifests
+            uses: actions/upload-artifact@v7
+            with:
+              name: merged-manifests
+              path: ${{ runner.temp }}/manifests/*.yaml
+              if-no-files-found: error
 
-          # winget can't resolve dependencies across sources (microsoft/winget-cli#3271), so
-          # copy each declared winget-pkgs dependency in to be merged alongside our packages.
-          $deps = Get-ChildItem manifests,fonts -Recurse -Filter *.installer.yaml | ForEach-Object { & yq '(.Dependencies, .Installers[].Dependencies).PackageDependencies[].PackageIdentifier' $_ } | Where-Object { $_ } | Sort-Object -Unique
-          foreach ($dep in $deps) {
-            $path = "manifests/$($dep.Substring(0,1).ToLower())/$($dep -replace '\.','/')"
-            if ((Test-Path $path) -or (Test-Path ($path -replace '^manifests','fonts'))) { continue }  # already in winget-extras
-            $version = gh api "repos/microsoft/winget-pkgs/contents/$path" | ConvertFrom-Json | Where-Object type -eq dir | Select-Object -ExpandProperty name | Sort-Object | Select-Object -Last 1
-            New-Item "$path/$version" -ItemType Directory -Force | Out-Null
-            gh api "repos/microsoft/winget-pkgs/contents/$path/$version" | ConvertFrom-Json | Where-Object name -like *.yaml | ForEach-Object { Invoke-WebRequest $_.download_url -OutFile "$path/$version/$($_.name)" }
-          }
+          - name: Upload index
+            uses: actions/upload-artifact@v7
+            with:
+              name: index
+              path: index
+              if-no-files-found: error
 
-          $leafDirs = Get-ChildItem -Path "manifests","fonts" -Recurse -Directory | Where-Object {
-            (Get-ChildItem -Path $_.FullName -Filter "*.yaml").Count -gt 0
-          }
+  main:
+    needs: merge
+    runs-on: windows-2025
+    permissions:
+      id-token: write
+    steps:
+      - parallel:
+          - name: Download index
+            uses: actions/download-artifact@v7
+            with:
+              name: index
+              path: index
 
-          foreach ($dir in $leafDirs) {
-            $yamlFiles = Get-ChildItem -Path $dir.FullName -Filter "*.yaml" | Select-Object -ExpandProperty FullName
+          - name: Download merged manifests
+            uses: actions/download-artifact@v7
+            with:
+              name: merged-manifests
+              path: ${{ runner.temp }}/manifests
 
-            if ($yamlFiles.Count -gt 0) {
-              $packageId = $dir.Parent.Name
-              $version = $dir.Name
-              $outputFile = Join-Path -Path $TMP_MANIFESTS -ChildPath "$packageId-$version.yaml"
+          - name: Download IndexCreationTool
+            shell: bash
+            run: |
+              curl -LO https://github.com/pl4nty/winget-pkgs-selfhost/releases/latest/download/AppInstallerCLIE2ETests.zip
+              7z x ./AppInstallerCLIE2ETests.zip -o"./index" -y
 
-              # Start-Process and wildcards don't work
-              & yq ea '. as $item ireduce ({}; . * $item )' $yamlFiles[0] $yamlFiles[1] $yamlFiles[2] > $outputFile
-              & yq -i '.ManifestType = "merged"' $outputFile
-              & yq -i '... comments=""' $outputFile
-            }
-          }
+      - parallel:
+          - name: Setup and run IndexCreationTool
+            working-directory: index
+            run: |
+              $version = Get-Date -Format yyyy.M.d.hm
+              (Get-Content -Path AppxManifest.xml) -replace "<VERSION>", $version | Set-Content -Path AppxManifest.xml
+              .\AppInstallerCLIE2ETests\IndexCreationTool.exe -f source.json
+            env:
+              TEMP: ${{ runner.temp }}
 
-      - name: Setup and run IndexCreationTool
-        working-directory: index
-        run: |
-            Invoke-WebRequest "https://github.com/pl4nty/winget-pkgs-selfhost/releases/latest/download/AppInstallerCLIE2ETests.zip" -OutFile AppInstallerCLIE2ETests.zip
-            Expand-Archive AppInstallerCLIE2ETests.zip -DestinationPath .
+          - uses: azure/login@v3
+            with:
+              client-id: ${{ vars.AZURE_CLIENT_ID }}
+              tenant-id: ${{ vars.AZURE_TENANT_ID }}
+              subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
 
-            $version = Get-Date -Format yyyy.M.d.hm
-            (Get-Content -Path AppxManifest.xml) -replace "<VERSION>", $version | Set-Content -Path AppxManifest.xml
-            .\AppInstallerCLIE2ETests\IndexCreationTool.exe -f source.json
-
-      - uses: azure/login@v2
-        with:
-          client-id: ${{ vars.AZURE_CLIENT_ID }}
-          tenant-id: ${{ vars.AZURE_TENANT_ID }}
-          subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+          - name: Install AzureSignTool
+            run: dotnet tool install --global AzureSignTool
 
       - name: Sign source package
         working-directory: index
         run: |
-            dotnet tool install --global AzureSignTool
-            $msixFiles = Get-ChildItem cache -Recurse -Filter *.msix | Select-Object -ExpandProperty FullName
-            AzureSignTool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 $msixFiles
+          $msixFiles = Get-ChildItem cache -Recurse -Filter *.msix | Select-Object -ExpandProperty FullName
+          AzureSignTool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com -td sha256 -fd sha256 $msixFiles
         env:
           KEY_VAULT_URL: ${{ vars.KEY_VAULT_URL }}
           KEY_VAULT_CERT: ${{ vars.KEY_VAULT_CERT }}


### PR DESCRIPTION
This PR speeds up the publish CI and adds support for localization in merged manifest files. In my testing, manifest merging takes ~5-8s with these changes (down from 90-120s).

Test run: https://github.com/UnownPlain/winget-extras/actions/runs/28212313698/job/83576083376
Merged manifests: https://github.com/UnownPlain/winget-extras/actions/runs/28212313698/artifacts/7895380810