### PR TITLE
fix: scope/architecture/installerType as preferences during validation

### DIFF
--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -80,9 +80,6 @@ $wingetSettings | ConvertTo-Json -Depth 100 | Set-Content -Path "$env:LOCALAPPDA
 winget settings --enable LocalManifestFiles
 winget settings --enable LocalArchiveMalwareScanOverride
 
-# Add the source so declared dependencies resolve. They'll be copied in from winget-pkgs during publishing
-winget source add --name winget-extras --type Microsoft.PreIndexed.Package --arg https://winget.tplant.com.au/cache --accept-source-agreements
-
 $programFilesBefore = Get-ChildItem $env:ProgramFiles -Directory | Select-Object -ExpandProperty FullName
 $programFilesx86Before = Get-ChildItem ${env:ProgramFiles(x86)} -Directory | Select-Object -ExpandProperty FullName
 $analyzerArgs = @(
@@ -106,6 +103,13 @@ if (-not (Test-Path asa.sqlite)) {
 }
 $installer = Start-Process winget -ArgumentList $wingetArgs -PassThru -NoNewWindow
 $success = $installer.WaitForExit(2 * 60 * 1000)
+if ($installer.ExitCode -eq "-1978334972") {
+    # Dependency not found, so try resolving it from our source
+    winget source add --name winget-extras --type Microsoft.PreIndexed.Package --arg https://winget.tplant.com.au/cache --accept-source-agreements
+    winget source remove --name winget-pkgs
+    $installer = Start-Process winget -ArgumentList $wingetArgs -PassThru -NoNewWindow
+    $success = $installer.WaitForExit(2 * 60 * 1000)
+}
 $log = Get-ChildItem "$env:LOCALAPPDATA\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\DiagOutputDir\" | Sort-Object LastWriteTime -Descending | Select-Object -First 1
 Copy-Item $log "$artifacts\$artifactName-winget.log"
 if (-not $success) {

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -63,16 +63,24 @@ Invoke-WebRequest -Uri $assetUrl -OutFile $wingetBundle
 Add-AppxPackage -Path $wingetBundle -ForceUpdateFromAnyVersion -ErrorAction Stop
 Write-Host "Installed latest WinGet pre-release: $(winget --version)"
 
-@{
+$wingetSettings = @{
     '$schema'            = 'https://aka.ms/winget-settings.schema.json'
     experimentalFeatures = @{
         fonts = $true
     }
-} | ConvertTo-Json | Set-Content -Path "$env:LOCALAPPDATA\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json" -Encoding UTF8
+    installBehavior      = @{
+        preferences = @{
+            architectures = @($Arch)
+        }
+    }
+}
+if ($Scope) { $wingetSettings.installBehavior.preferences.scope = $Scope }
+if ($InstallerType) { $wingetSettings.installBehavior.preferences.installerTypes = @($InstallerType) }
+$wingetSettings | ConvertTo-Json -Depth 100 | Set-Content -Path "$env:LOCALAPPDATA\Packages\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe\LocalState\settings.json" -Encoding UTF8
 winget settings --enable LocalManifestFiles
 winget settings --enable LocalArchiveMalwareScanOverride
 
-# Add the source so declared dependencies (copied in from winget-pkgs at publish) resolve
+# Add the source so declared dependencies resolve. They'll be copied in from winget-pkgs during publishing
 winget source add --name winget-extras --type Microsoft.PreIndexed.Package --arg https://winget.tplant.com.au/cache --accept-source-agreements
 
 $programFilesBefore = Get-ChildItem $env:ProgramFiles -Directory | Select-Object -ExpandProperty FullName
@@ -87,13 +95,10 @@ $analyzerArgs = @(
 $wingetArgs = @(
     "install", "--verbose",
     "--manifest", (Split-Path $ManifestPath),
-    "--architecture", $Arch,
     "--log", "$artifacts\$artifactName-installer.log",
     "--silent", "--ignore-local-archive-malware-scan",
     "--accept-package-agreements", "--accept-source-agreements"
 )
-if ($Scope) { $wingetArgs += '--scope', $Scope }
-if ($InstallerType) { $wingetArgs += '--installer-type', $InstallerType }
 
 if (-not (Test-Path asa.sqlite)) {
     Write-Host "asa collect --runid baseline $analyzerArgs"


### PR DESCRIPTION
So we can install dependencies. See https://github.com/microsoft/winget-pkgs/issues/152555

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
   <!-- Example: Resolves #328283 -->
  - Relates to microsoft/winget-pkgs#[Issue Number]

Manifests

- [ ] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
