### PR TITLE
ci(label): fetch manifest via GitHub API

### DIFF
--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -29,10 +29,16 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           CHANGED: ${{ steps.changed.outputs.all_changed_files }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PR: ${{ github.event.pull_request.number }}
         run: |
           $archs = $env:CHANGED -split '\s+' | Where-Object { $_ } | ForEach-Object {
-            yq '.Architecture, .Installers[].Architecture' $_
+            $path = ($_ -split '/' | ForEach-Object { [uri]::EscapeDataString($_) }) -join '/'
+            gh api --method GET "repos/$env:HEAD_REPOSITORY/contents/$path" `
+              -f "ref=$env:HEAD_SHA" `
+              -H 'Accept: application/vnd.github.raw+json' |
+              yq '.Architecture, .Installers[].Architecture' -
           } | Select-Object -Unique
           if ($archs -contains 'arm') {
             gh pr edit $env:PR --add-label 'Validation-arm32' --repo $env:GITHUB_REPOSITORY


### PR DESCRIPTION
I forgot that the `Label arm32` step required the manifests to be on the filesystem. This changes that to fetch the manifest via API instead of reintroducing the checkout step. The newest `actions/checkout` version won't allow checking out the fork's repository on `pull_request_target` events anyway unless `allow-unsafe-pr-checkout` is set due to it being an extremely common source of supply chain attacks.

https://github.blog/changelog/2026-06-18-safer-pull_request_target-defaults-for-github-actions-checkout/
https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target