### PR TITLE
chore: update Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,36 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:config:best-practices"]
+	"extends": ["config:best-practices"],
+	"packageRules": [
+		{
+			"matchManagers": "github-actions",
+			"minimumReleaseAge": "7 days"
+		},
+		{
+			"matchManagers": "mise",
+			"minimumReleaseAge": "3 days"
+		},
+		{
+			"matchPackageNames": ["jdx/mise"],
+			"minimumReleaseAge": "3 days"
+		},
+		{
+			"matchPackageNames": ["oxlint", "oxfmt"],
+			"groupName": "oxc ecosystem"
+		}
+	],
+	"customManagers": [
+		{
+			"customType": "regex",
+			"managerFilePatterns": ["/(^|/)\\.github/workflows/[^/]+\\.ya?ml$/"],
+			"depNameTemplate": "mise",
+			"packageNameTemplate": "jdx/mise",
+			"datasourceTemplate": "github-releases",
+			"versioningTemplate": "semver",
+			"extractVersionTemplate": "^v(?<version>.*)$",
+			"matchStrings": [
+				"uses:\\s+jdx/mise-action@[^\\s#]+(?:\\s+#[^\\r\\n]*)?\\r?\\n\\s+with:\\r?\\n\\s+version:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+			]
+		}
+	]
 }


### PR DESCRIPTION
- Corrects `config:best-practices` typo
- Adds dependency cooldowns
  - 3 days for npm (included in `config:best-practices`), 3 days for mise tools and mise itself, and 7 days for GitHub Actions
  - https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
  - https://blog.yossarian.net/2025/12/13/cooldowns-redux
 - Adds a custom manager so the `version` input for `jdx/mise-action` gets updated
 - Groups oxlint and oxfmt updates since they always update together