### PR TITLE
Use GitHub API for authenticated dependency downloads

### DIFF
--- a/.github/workflows/merge.ps1
+++ b/.github/workflows/merge.ps1
@@ -86,9 +86,12 @@ if ($missingDependencies) {
     $destination = Join-Path $using:tempDependencies $path
     New-Item $destination -ItemType Directory -Force | Out-Null
 
+    $curlArguments = @('--fail', '--silent', '--show-error', '--location', '--parallel')
     foreach ($file in $files) {
-      & gh api $file.url --header 'Accept: application/vnd.github.raw' > (Join-Path $destination $file.name)
+      $uri = "https://cdn.jsdelivr.net/gh/microsoft/winget-pkgs@master/$(& $encodePath "$path/$($file.name)")"
+      $curlArguments += @('--output', (Join-Path $destination $file.name), $uri)
     }
+    & curl @curlArguments
   }
 }
 

--- a/.github/workflows/merge.ps1
+++ b/.github/workflows/merge.ps1
@@ -86,7 +86,10 @@ if ($missingDependencies) {
     $destination = Join-Path $using:tempDependencies $path
     New-Item $destination -ItemType Directory -Force | Out-Null
 
-    $curlArguments = @('--fail', '--silent', '--show-error', '--location', '--parallel')
+    $curlArguments = @(
+      '--fail', '--silent', '--show-error', '--location', '--parallel'
+      '--write-out', '%{onerror}%{url_effective} failed: HTTP %{http_code} %{errormsg}\n'
+    )
     foreach ($file in $files) {
       $uri = "https://cdn.jsdelivr.net/gh/microsoft/winget-pkgs@master/$(& $encodePath "$path/$($file.name)")"
       $curlArguments += @('--output', (Join-Path $destination $file.name), $uri)

--- a/.github/workflows/merge.ps1
+++ b/.github/workflows/merge.ps1
@@ -86,12 +86,11 @@ if ($missingDependencies) {
     $destination = Join-Path $using:tempDependencies $path
     New-Item $destination -ItemType Directory -Force | Out-Null
 
-    $curlArguments = @('--fail', '--silent', '--show-error', '--location', '--parallel')
+    # Download via the authenticated GitHub API (gh) rather than raw.githubusercontent.com,
+    # which is unauthenticated and rate-limited (HTTP 429).
     foreach ($file in $files) {
-      $uri = "https://raw.githubusercontent.com/microsoft/winget-pkgs/refs/heads/master/$(& $encodePath "$path/$($file.name)")"
-      $curlArguments += @('--output', (Join-Path $destination $file.name), $uri)
+      & gh api $file.url --header 'Accept: application/vnd.github.raw' > (Join-Path $destination $file.name)
     }
-    & curl @curlArguments
   }
 }
 

--- a/.github/workflows/merge.ps1
+++ b/.github/workflows/merge.ps1
@@ -86,8 +86,6 @@ if ($missingDependencies) {
     $destination = Join-Path $using:tempDependencies $path
     New-Item $destination -ItemType Directory -Force | Out-Null
 
-    # Download via the authenticated GitHub API (gh) rather than raw.githubusercontent.com,
-    # which is unauthenticated and rate-limited (HTTP 429).
     foreach ($file in $files) {
       & gh api $file.url --header 'Accept: application/vnd.github.raw' > (Join-Path $destination $file.name)
     }


### PR DESCRIPTION
## Description

This change replaces the unauthenticated `raw.githubusercontent.com` download method with the authenticated GitHub API (`gh`) to avoid rate limiting issues (HTTP 429 errors).

### Changes

- Replaced `curl` with `gh api` for downloading dependency files
- Uses the GitHub API's raw content endpoint with proper authentication
- Removes the parallel curl approach in favor of sequential API calls
- Eliminates rate limiting issues by using authenticated requests

### Rationale

The previous implementation downloaded files from `raw.githubusercontent.com`, which is unauthenticated and subject to strict rate limits. This caused failures when downloading multiple dependencies. The GitHub API provides authenticated access with higher rate limits, making the workflow more reliable.

### Testing

The merge workflow will be tested during the next scheduled run or manual trigger. The change maintains the same functionality while improving reliability through authenticated API access.

https://claude.ai/code/session_01FuhaPaPHXpV2SCzKAg1A5h