### PR TITLE
New package: Microsoft.FluentUISystemIcons.Regular version 1.1.331

### DIFF
--- a/fonts/m/Microsoft/FluentUISystemIcons/Regular/1.1.331/Microsoft.FluentUISystemIcons.Regular.installer.yaml
+++ b/fonts/m/Microsoft/FluentUISystemIcons/Regular/1.1.331/Microsoft.FluentUISystemIcons.Regular.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: Microsoft.FluentUISystemIcons.Regular
+PackageVersion: 1.1.331
+ReleaseDate: 2026-06-26
+InstallerType: font
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://raw.githubusercontent.com/microsoft/fluentui-system-icons/6ea5ed16a36daba1ad2b1489c2ab07017edfbb21/fonts/FluentSystemIcons-Regular.ttf
+  InstallerSha256: 20FBFBB2D013D1E808ED4E65731312E0D88CE6D473ED1170B06E129991143DEC
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/fonts/m/Microsoft/FluentUISystemIcons/Regular/1.1.331/Microsoft.FluentUISystemIcons.Regular.locale.en.yaml
+++ b/fonts/m/Microsoft/FluentUISystemIcons/Regular/1.1.331/Microsoft.FluentUISystemIcons.Regular.locale.en.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: Microsoft.FluentUISystemIcons.Regular
+PackageVersion: 1.1.331
+PackageLocale: en
+Publisher: Microsoft
+PackageName: Fluent UI System Icons - Regular
+PackageUrl: https://github.com/microsoft/fluentui-system-icons
+License: MIT
+ShortDescription: A collection of familiar, friendly and modern icons from Microsoft.
+Moniker: fluentui
+Tags:
+- font
+- fluent-ui-system-icons-regular
+- fluentui-system-icons-regular
+- FluentSystemIcons-Regular.ttf
+- fluentsystemiconsregular
+- fluent-system-icons-regular
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/fonts/m/Microsoft/FluentUISystemIcons/Regular/1.1.331/Microsoft.FluentUISystemIcons.Regular.yaml
+++ b/fonts/m/Microsoft/FluentUISystemIcons/Regular/1.1.331/Microsoft.FluentUISystemIcons.Regular.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: Microsoft.FluentUISystemIcons.Regular
+PackageVersion: 1.1.331
+DefaultLocale: en
+ManifestType: version
+ManifestVersion: 1.28.0


### PR DESCRIPTION
Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
   <!-- Example: Resolves #328283 -->
  - Relates to microsoft/winget-pkgs#[Issue Number]

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [x] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
Notes from me:
* Sort-of fixes https://github.com/pl4nty/winget-extras/pull/254.
* There are 4 different "Fluent UI System Icons" fonts, and this package only includes 1 of them. During tests to add their whole repo's "Download ZIP" as an installer to cover all 4 fonts, the ZIP extraction took an ungodly amount of time. I clocked it at around 1 hour 20 minutes. Dedicated unpacker tools like PeaZip also went well past the 40-minute mark, so the problem is on the Fluent UI repo's end and not Winget-cli's.