### PR TITLE
chore: remove UTF-8 BOM from manifests

### DIFF
--- a/manifests/b/BegoniaHoldings/HopToDesk/1.45.10/BegoniaHoldings.HopToDesk.installer.yaml
+++ b/manifests/b/BegoniaHoldings/HopToDesk/1.45.10/BegoniaHoldings.HopToDesk.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: BegoniaHoldings.HopToDesk
 PackageVersion: 1.45.10

--- a/manifests/b/BegoniaHoldings/HopToDesk/1.45.10/BegoniaHoldings.HopToDesk.locale.en-US.yaml
+++ b/manifests/b/BegoniaHoldings/HopToDesk/1.45.10/BegoniaHoldings.HopToDesk.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: BegoniaHoldings.HopToDesk
 PackageVersion: 1.45.10

--- a/manifests/b/BegoniaHoldings/HopToDesk/1.45.10/BegoniaHoldings.HopToDesk.yaml
+++ b/manifests/b/BegoniaHoldings/HopToDesk/1.45.10/BegoniaHoldings.HopToDesk.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: BegoniaHoldings.HopToDesk
 PackageVersion: 1.45.10

--- a/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.installer.yaml
+++ b/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.installer.yaml
@@ -1,4 +1,4 @@
-﻿#yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+#yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Ginkgo.TimeTravel
 PackageVersion: 2.0.38
 InstallerType: zip

--- a/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.locale.en.yaml
+++ b/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.locale.en.yaml
@@ -1,4 +1,4 @@
-﻿#yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+#yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Ginkgo.TimeTravel
 PackageVersion: 2.0.38
 PackageLocale: en

--- a/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.yaml
+++ b/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.yaml
@@ -1,4 +1,4 @@
-﻿#yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+#yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Ginkgo.TimeTravel
 PackageVersion: 2.0.38
 DefaultLocale: en

--- a/manifests/m/Microsoft/CsWinRT/2.2/Microsoft.CsWinRT.installer.yaml
+++ b/manifests/m/Microsoft/CsWinRT/2.2/Microsoft.CsWinRT.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Microsoft.CsWinRT
 PackageVersion: "2.2"
 ReleaseDate: 2024-11-12

--- a/manifests/m/Microsoft/CsWinRT/2.2/Microsoft.CsWinRT.locale.en-GB.yaml
+++ b/manifests/m/Microsoft/CsWinRT/2.2/Microsoft.CsWinRT.locale.en-GB.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
 PackageIdentifier: Microsoft.CsWinRT
 PackageVersion: "2.2"
 PackageLocale: en-GB

--- a/manifests/m/Microsoft/CsWinRT/2.2/Microsoft.CsWinRT.locale.en-US.yaml
+++ b/manifests/m/Microsoft/CsWinRT/2.2/Microsoft.CsWinRT.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Microsoft.CsWinRT
 PackageVersion: "2.2"
 PackageLocale: en-US

--- a/manifests/m/Microsoft/CsWinRT/2.2/Microsoft.CsWinRT.yaml
+++ b/manifests/m/Microsoft/CsWinRT/2.2/Microsoft.CsWinRT.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Microsoft.CsWinRT
 PackageVersion: "2.2"
 DefaultLocale: en-US

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x64.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x64.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10.x64
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x64.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x64.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10.x64
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x64.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x64.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10.x64
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x86.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x86.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10.x86
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x86.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x86.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10.x86
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x86.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.9/Microsoft.DotNet.DesktopRuntime.10.x86.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10.x86
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x64/8.0.28/Microsoft.DotNet.DesktopRuntime.8.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x64/8.0.28/Microsoft.DotNet.DesktopRuntime.8.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8.x64
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x64/8.0.28/Microsoft.DotNet.DesktopRuntime.8.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x64/8.0.28/Microsoft.DotNet.DesktopRuntime.8.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8.x64
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x64/8.0.28/Microsoft.DotNet.DesktopRuntime.8.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x64/8.0.28/Microsoft.DotNet.DesktopRuntime.8.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8.x64
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x86/8.0.28/Microsoft.DotNet.DesktopRuntime.8.x86.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x86/8.0.28/Microsoft.DotNet.DesktopRuntime.8.x86.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8.x86
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x86/8.0.28/Microsoft.DotNet.DesktopRuntime.8.x86.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x86/8.0.28/Microsoft.DotNet.DesktopRuntime.8.x86.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8.x86
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x86/8.0.28/Microsoft.DotNet.DesktopRuntime.8.x86.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/8/x86/8.0.28/Microsoft.DotNet.DesktopRuntime.8.x86.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.8.x86
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x64/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x64.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x64/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x64.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.9.x64
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x64/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x64.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x64/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x64.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.9.x64
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x64/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x64.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x64/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x64.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.9.x64
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x86/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x86.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x86/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x86.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.9.x86
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x86/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x86.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x86/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x86.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.9.x86
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x86/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x86.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/9/x86/9.0.17/Microsoft.DotNet.DesktopRuntime.9.x86.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.DesktopRuntime.9.x86
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/DotNet/Runtime/10/x86/10.0.9/Microsoft.DotNet.Runtime.10.x86.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/10/x86/10.0.9/Microsoft.DotNet.Runtime.10.x86.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.10.x86
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/Runtime/10/x86/10.0.9/Microsoft.DotNet.Runtime.10.x86.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/10/x86/10.0.9/Microsoft.DotNet.Runtime.10.x86.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.10.x86
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/Runtime/10/x86/10.0.9/Microsoft.DotNet.Runtime.10.x86.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/10/x86/10.0.9/Microsoft.DotNet.Runtime.10.x86.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.10.x86
 PackageVersion: 10.0.9

--- a/manifests/m/Microsoft/DotNet/Runtime/8/x86/8.0.28/Microsoft.DotNet.Runtime.8.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/8/x86/8.0.28/Microsoft.DotNet.Runtime.8.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.8.x86
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/Runtime/8/x86/8.0.28/Microsoft.DotNet.Runtime.8.locale.en.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/8/x86/8.0.28/Microsoft.DotNet.Runtime.8.locale.en.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.8.x86
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/Runtime/8/x86/8.0.28/Microsoft.DotNet.Runtime.8.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/8/x86/8.0.28/Microsoft.DotNet.Runtime.8.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.8.x86
 PackageVersion: 8.0.28

--- a/manifests/m/Microsoft/DotNet/Runtime/9/x86/9.0.17/Microsoft.DotNet.Runtime.9.x86.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/9/x86/9.0.17/Microsoft.DotNet.Runtime.9.x86.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.9.x86
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/DotNet/Runtime/9/x86/9.0.17/Microsoft.DotNet.Runtime.9.x86.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/9/x86/9.0.17/Microsoft.DotNet.Runtime.9.x86.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.9.x86
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/DotNet/Runtime/9/x86/9.0.17/Microsoft.DotNet.Runtime.9.x86.yaml
+++ b/manifests/m/Microsoft/DotNet/Runtime/9/x86/9.0.17/Microsoft.DotNet.Runtime.9.x86.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.DotNet.Runtime.9.x86
 PackageVersion: 9.0.17

--- a/manifests/m/Microsoft/OneNote/16.0.20026.20112/Microsoft.OneNote.installer.yaml
+++ b/manifests/m/Microsoft/OneNote/16.0.20026.20112/Microsoft.OneNote.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.OneNote
 PackageVersion: 16.0.20026.20112

--- a/manifests/m/Microsoft/OneNote/16.0.20026.20112/Microsoft.OneNote.locale.en-US.yaml
+++ b/manifests/m/Microsoft/OneNote/16.0.20026.20112/Microsoft.OneNote.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.OneNote
 PackageVersion: 16.0.20026.20112

--- a/manifests/m/Microsoft/OneNote/16.0.20026.20112/Microsoft.OneNote.yaml
+++ b/manifests/m/Microsoft/OneNote/16.0.20026.20112/Microsoft.OneNote.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.OneNote
 PackageVersion: 16.0.20026.20112

--- a/manifests/m/Microsoft/SystemCenter/Orchestrator/RunbookDesigner/10.25.1.7/Microsoft.SystemCenter.Orchestrator.RunbookDesigner.installer.yaml
+++ b/manifests/m/Microsoft/SystemCenter/Orchestrator/RunbookDesigner/10.25.1.7/Microsoft.SystemCenter.Orchestrator.RunbookDesigner.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
 
 PackageIdentifier: Microsoft.SystemCenter.Orchestrator.RunbookDesigner
 PackageVersion: 10.25.1.7

--- a/manifests/m/Microsoft/SystemCenter/Orchestrator/RunbookDesigner/10.25.1.7/Microsoft.SystemCenter.Orchestrator.RunbookDesigner.locale.en-GB.yaml
+++ b/manifests/m/Microsoft/SystemCenter/Orchestrator/RunbookDesigner/10.25.1.7/Microsoft.SystemCenter.Orchestrator.RunbookDesigner.locale.en-GB.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.28.0.schema.json
 PackageIdentifier: Microsoft.SystemCenter.Orchestrator.RunbookDesigner
 PackageVersion: 10.25.1.7
 PackageLocale: en-GB

--- a/manifests/m/Microsoft/SystemCenter/Orchestrator/RunbookDesigner/10.25.1.7/Microsoft.SystemCenter.Orchestrator.RunbookDesigner.locale.en-US.yaml
+++ b/manifests/m/Microsoft/SystemCenter/Orchestrator/RunbookDesigner/10.25.1.7/Microsoft.SystemCenter.Orchestrator.RunbookDesigner.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
 PackageIdentifier: Microsoft.SystemCenter.Orchestrator.RunbookDesigner
 PackageVersion: 10.25.1.7
 PackageLocale: en-US

--- a/manifests/m/Microsoft/SystemCenter/Orchestrator/RunbookDesigner/10.25.1.7/Microsoft.SystemCenter.Orchestrator.RunbookDesigner.yaml
+++ b/manifests/m/Microsoft/SystemCenter/Orchestrator/RunbookDesigner/10.25.1.7/Microsoft.SystemCenter.Orchestrator.RunbookDesigner.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
 PackageIdentifier: Microsoft.SystemCenter.Orchestrator.RunbookDesigner
 PackageVersion: 10.25.1.7
 DefaultLocale: en-US

--- a/manifests/m/Microsoft/VisualStudio/TeamExplorer/18.2.11415.280/Microsoft.VisualStudio.TeamExplorer.installer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/TeamExplorer/18.2.11415.280/Microsoft.VisualStudio.TeamExplorer.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
 PackageIdentifier: Microsoft.VisualStudio.TeamExplorer
 PackageVersion: 18.2.11415.280
 ReleaseDate: 2026-01-20

--- a/manifests/m/Microsoft/VisualStudio/TeamExplorer/18.2.11415.280/Microsoft.VisualStudio.TeamExplorer.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VisualStudio/TeamExplorer/18.2.11415.280/Microsoft.VisualStudio.TeamExplorer.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
 PackageIdentifier: Microsoft.VisualStudio.TeamExplorer
 PackageVersion: 18.2.11415.280
 PackageLocale: en-US

--- a/manifests/m/Microsoft/VisualStudio/TeamExplorer/18.2.11415.280/Microsoft.VisualStudio.TeamExplorer.yaml
+++ b/manifests/m/Microsoft/VisualStudio/TeamExplorer/18.2.11415.280/Microsoft.VisualStudio.TeamExplorer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
 PackageIdentifier: Microsoft.VisualStudio.TeamExplorer
 PackageVersion: 18.2.11415.280
 DefaultLocale: en-US

--- a/manifests/m/ModMii/ModMii/8.0.6/ModMii.ModMii.installer.yaml
+++ b/manifests/m/ModMii/ModMii/8.0.6/ModMii.ModMii.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
 
 PackageIdentifier: ModMii.ModMii
 PackageVersion: 8.0.6

--- a/manifests/m/ModMii/ModMii/8.0.6/ModMii.ModMii.locale.en-US.yaml
+++ b/manifests/m/ModMii/ModMii/8.0.6/ModMii.ModMii.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
 PackageIdentifier: ModMii.ModMii
 PackageVersion: 8.0.6
 PackageLocale: en-US

--- a/manifests/m/ModMii/ModMii/8.0.6/ModMii.ModMii.yaml
+++ b/manifests/m/ModMii/ModMii/8.0.6/ModMii.ModMii.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
 PackageIdentifier: ModMii.ModMii
 PackageVersion: 8.0.6
 DefaultLocale: en-US

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.installer.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Nvidia.Driver.GeForceGameReady
 PackageVersion: "610.74"

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.en.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Nvidia.Driver.GeForceGameReady
 PackageVersion: "610.74"

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.nb.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.nb.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
 
 PackageIdentifier: Nvidia.Driver.GeForceGameReady
 PackageVersion: "610.74"

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Nvidia.Driver.GeForceGameReady
 PackageVersion: "610.74"

--- a/manifests/s/StackHawk/HawkScan/5.6/StackHawk.HawkScan.locale.en-US.yaml
+++ b/manifests/s/StackHawk/HawkScan/5.6/StackHawk.HawkScan.locale.en-US.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: StackHawk.HawkScan
 PackageVersion: "5.6"

--- a/manifests/s/StackHawk/HawkScan/5.6/StackHawk.HawkScan.yaml
+++ b/manifests/s/StackHawk/HawkScan/5.6/StackHawk.HawkScan.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: StackHawk.HawkScan
 PackageVersion: "5.6"

--- a/manifests/w/WebTorrent/WebTorrentDesktop/0.24/WebTorrent.WebTorrentDesktop.installer.yaml
+++ b/manifests/w/WebTorrent/WebTorrentDesktop/0.24/WebTorrent.WebTorrentDesktop.installer.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
 
 PackageIdentifier: WebTorrent.WebTorrentDesktop
 PackageVersion: "0.24"

--- a/manifests/w/WebTorrent/WebTorrentDesktop/0.24/WebTorrent.WebTorrentDesktop.locale.en.yaml
+++ b/manifests/w/WebTorrent/WebTorrentDesktop/0.24/WebTorrent.WebTorrentDesktop.locale.en.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
 
 PackageIdentifier: WebTorrent.WebTorrentDesktop
 PackageVersion: "0.24"

--- a/manifests/w/WebTorrent/WebTorrentDesktop/0.24/WebTorrent.WebTorrentDesktop.yaml
+++ b/manifests/w/WebTorrent/WebTorrentDesktop/0.24/WebTorrent.WebTorrentDesktop.yaml
@@ -1,4 +1,4 @@
-﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
 PackageIdentifier: WebTorrent.WebTorrentDesktop
 PackageVersion: "0.24"
 DefaultLocale: en


### PR DESCRIPTION
Don't think we should have BOM in this repo as a lot of tools expect UTF-8 with no BOM. CI should probably also check for this.