### PR TITLE
chore: add missing spaces in LSP header

### DIFF
--- a/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.installer.yaml
+++ b/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.installer.yaml
@@ -1,4 +1,4 @@
-﻿#yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 PackageIdentifier: Ginkgo.TimeTravel
 PackageVersion: 2.0.38
 InstallerType: zip

--- a/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.locale.en.yaml
+++ b/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.locale.en.yaml
@@ -1,4 +1,4 @@
-﻿#yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 PackageIdentifier: Ginkgo.TimeTravel
 PackageVersion: 2.0.38
 PackageLocale: en

--- a/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.yaml
+++ b/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.yaml
@@ -1,4 +1,4 @@
-﻿#yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+﻿# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 PackageIdentifier: Ginkgo.TimeTravel
 PackageVersion: 2.0.38
 DefaultLocale: en

--- a/manifests/g/gnome/BansheeMediaPlayer/2.4.0/gnome.BansheeMediaPlayer.installer.yaml
+++ b/manifests/g/gnome/BansheeMediaPlayer/2.4.0/gnome.BansheeMediaPlayer.installer.yaml
@@ -1,4 +1,4 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: gnome.BansheeMediaPlayer
 PackageVersion: 2.4.0

--- a/manifests/g/gnome/BansheeMediaPlayer/2.4.0/gnome.BansheeMediaPlayer.locale.en-US.yaml
+++ b/manifests/g/gnome/BansheeMediaPlayer/2.4.0/gnome.BansheeMediaPlayer.locale.en-US.yaml
@@ -1,4 +1,4 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: gnome.BansheeMediaPlayer
 PackageVersion: 2.4.0
@@ -9,10 +9,10 @@ PackageUrl: https://www.banshee-project.org
 License: MIT
 ShortDescription: Play your music and videos. Keep up with your podcasts and Internet radio. Discover new music and podcasts. Keep your portable device loaded with good stuff.
 Description: |-
-Moniker: banshee
   Play your music and videos. Keep up with your podcasts and Internet radio. Discover new music and podcasts. Keep your portable device loaded with good stuff.
 
   Note that as of January 9, 2025, the recentmost Windows version (2.4.0) lags noticeably behind the recentmost Linux version (2.9.1).
+Moniker: banshee
 Tags:
 - banshee-media-player
 - videos

--- a/manifests/g/gnome/BansheeMediaPlayer/2.4.0/gnome.BansheeMediaPlayer.yaml
+++ b/manifests/g/gnome/BansheeMediaPlayer/2.4.0/gnome.BansheeMediaPlayer.yaml
@@ -1,4 +1,4 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: gnome.BansheeMediaPlayer
 PackageVersion: 2.4.0

--- a/manifests/m/Microsoft/FactoryOrchestrator/10.3.7/Microsoft.FactoryOrchestrator.installer.yaml
+++ b/manifests/m/Microsoft/FactoryOrchestrator/10.3.7/Microsoft.FactoryOrchestrator.installer.yaml
@@ -1,4 +1,4 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.FactoryOrchestrator
 PackageVersion: 10.3.7

--- a/manifests/m/Microsoft/FactoryOrchestrator/10.3.7/Microsoft.FactoryOrchestrator.locale.en.yaml
+++ b/manifests/m/Microsoft/FactoryOrchestrator/10.3.7/Microsoft.FactoryOrchestrator.locale.en.yaml
@@ -1,4 +1,4 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.FactoryOrchestrator
 PackageVersion: 10.3.7

--- a/manifests/m/Microsoft/FactoryOrchestrator/10.3.7/Microsoft.FactoryOrchestrator.yaml
+++ b/manifests/m/Microsoft/FactoryOrchestrator/10.3.7/Microsoft.FactoryOrchestrator.yaml
@@ -1,4 +1,4 @@
-#yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
 PackageIdentifier: Microsoft.FactoryOrchestrator
 PackageVersion: 10.3.7


### PR DESCRIPTION
Removing the space between the `#` and `yaml-language-server:` breaks the YAML LSP integration in many editors.