### PR TITLE
Fix publishing broken by unquoted date version in Microsoft.vcpkg

### DIFF
--- a/.github/workflows/merge.ps1
+++ b/.github/workflows/merge.ps1
@@ -112,7 +112,9 @@ $yqExpression = @'
 
 $normalizedTempManifests = $tempManifests.Replace('\', '/')
 $env:TMP_MANIFESTS = $normalizedTempManifests
-$splitExpression = 'strenv(TMP_MANIFESTS) + "/" + .PackageIdentifier + "-" + .PackageVersion + ".yaml"'
+# tostring guards against date-like versions (e.g. 2026-07-13) that yq parses as
+# a !!timestamp, where "datetime + string" is treated as duration arithmetic and fails
+$splitExpression = 'strenv(TMP_MANIFESTS) + "/" + .PackageIdentifier + "-" + (.PackageVersion | tostring) + ".yaml"'
 $packageGroups = @(
   Get-ChildItem manifests, fonts, $tempDependencies -Filter '*.yaml' -File -Recurse |
   Group-Object DirectoryName

--- a/manifests/m/Microsoft/vcpkg/2026-07-13/Microsoft.vcpkg.installer.yaml
+++ b/manifests/m/Microsoft/vcpkg/2026-07-13/Microsoft.vcpkg.installer.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
 
 PackageIdentifier: Microsoft.vcpkg
-PackageVersion: 2026-07-13
+PackageVersion: "2026-07-13"
 ReleaseDate: 2026-07-13
 InstallerType: portable
 Installers:

--- a/manifests/m/Microsoft/vcpkg/2026-07-13/Microsoft.vcpkg.locale.en.yaml
+++ b/manifests/m/Microsoft/vcpkg/2026-07-13/Microsoft.vcpkg.locale.en.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
 
 PackageIdentifier: Microsoft.vcpkg
-PackageVersion: 2026-07-13
+PackageVersion: "2026-07-13"
 PackageLocale: en
 Publisher: Microsoft
 PackageName: vcpkg (.exe version)

--- a/manifests/m/Microsoft/vcpkg/2026-07-13/Microsoft.vcpkg.yaml
+++ b/manifests/m/Microsoft/vcpkg/2026-07-13/Microsoft.vcpkg.yaml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
 
 PackageIdentifier: Microsoft.vcpkg
-PackageVersion: 2026-07-13
+PackageVersion: "2026-07-13"
 DefaultLocale: en
 ManifestType: version
 ManifestVersion: 1.28.0


### PR DESCRIPTION
## Summary

`Microsoft.vcpkg` `2026-07-13` (#363) set `PackageVersion` to an unquoted `2026-07-13`, which yq parses as a `!!timestamp` rather than a string. In `merge.ps1` the split expression concatenates the version with `".yaml"`; yq treats `datetime + string` as duration arithmetic, so it tries to parse `.yaml` as a duration and the **Merge Manifests** job fails:

```
Error: unable to parse duration [.yaml]: time: invalid duration ".yaml"
```

Because publishing merges the whole source, this one manifest took down the publish pipeline for every subsequent commit ([failed run](https://github.com/pl4nty/winget-extras/actions/runs/29630121580)).

## Changes

- Quote `PackageVersion` in the three vcpkg manifests (`"2026-07-13"`) so it is a string, as the WinGet spec requires.
- Coerce `PackageVersion` with `| tostring` in the merge split expression so a future unquoted date-like version can't break publishing again.

## Verification

- Reproduced the exact `unable to parse duration [.yaml]` error with mikefarah yq on the unquoted manifest.
- Confirmed the quoted manifest yields `PackageVersion: "2026-07-13"` (`!!str`), and that the full merge + split expression completes (exit 0) producing `Microsoft.vcpkg-2026-07-13.yaml`.
- Confirmed the `| tostring` guard produces identical split paths for normal semver versions.
- `bun scripts/lint-manifests.mjs` → `Manifests OK.`

## Checklist for Pull Requests

- Related winget-pkgs issue/PR: n/a — this fixes a publishing regression, not a package update.

Manifests

- [x] Checked there aren't other open pull requests for the same manifest change.
- [ ] Validated locally with `winget validate` (requires Windows; verified merge pipeline with yq instead).
- [ ] Tested locally with `winget install` (requires Windows).
- [x] Conforms to the 1.28 schema (only quoting of an existing field changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwbscsRE5sDkLXrxn4iU5A)_