### PR TITLE
chore: remove architecture suffixes from commands

### DIFF
--- a/manifests/b/bol-van/zapret2/1.0.2/bol-van.Zapret2.installer.yaml
+++ b/manifests/b/bol-van/zapret2/1.0.2/bol-van.Zapret2.installer.yaml
@@ -13,14 +13,6 @@ Installers:
   - RelativeFilePath: zapret2-v1.0.2\binaries\windows-x86_64\killall.exe
   - RelativeFilePath: zapret2-v1.0.2\binaries\windows-x86_64\mdig.exe
   - RelativeFilePath: zapret2-v1.0.2\binaries\windows-x86_64\winws2.exe
-  - RelativeFilePath: zapret2-v1.0.2\binaries\windows-x86\ip2net.exe
-    PortableCommandAlias: ip2net86
-  - RelativeFilePath: zapret2-v1.0.2\binaries\windows-x86\killall.exe
-    PortableCommandAlias: killall86
-  - RelativeFilePath: zapret2-v1.0.2\binaries\windows-x86\mdig.exe
-    PortableCommandAlias: mdig86
-  - RelativeFilePath: zapret2-v1.0.2\binaries\windows-x86\winws2.exe
-    PortableCommandAlias: winws286
   InstallerUrl: https://github.com/bol-van/zapret2/releases/download/v1.0.2/zapret2-v1.0.2.zip
   InstallerSha256: 45f90e1c70db104a735cd0f99e5644cea84689bf05dadb498953f334999b1ebb
 - Architecture: x86

--- a/manifests/h/Hanselman/WingetTUI/0.13/Hanselman.WingetTUI.installer.yaml
+++ b/manifests/h/Hanselman/WingetTUI/0.13/Hanselman.WingetTUI.installer.yaml
@@ -6,7 +6,7 @@ ReleaseDate: 2026-06-08
 InstallerType: portable
 UpgradeBehavior: uninstallPrevious
 Commands:
-- winget-tui-arm64
+- winget-tui
 Installers:
 # - Architecture: x64 (Commented out due to the x64 version having been added to pkgs in the time since, whereas the ARM64 version hasn't.)
 #   InstallerUrl: https://github.com/shanselman/winget-tui/releases/download/v0.13.0/winget-tui-x64.exe

--- a/manifests/l/laoo/Felix/0.6.4/laoo.Felix.installer.yaml
+++ b/manifests/l/laoo/Felix/0.6.4/laoo.Felix.installer.yaml
@@ -4,20 +4,18 @@ PackageIdentifier: laoo.Felix
 PackageVersion: 0.6.4
 ReleaseDate: 2025-04-29
 InstallerType: portable
+Commands:
+- felixemulator
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/laoo/Felix/releases/download/v0.6.4/Felix.exe
   InstallerSha256: F507AB2B2A4D203018E82275F38BEF9626CB080AE71B01D96E33E6953158D801
-  Commands:
-  - felixemulator
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x64
 - Architecture: x86
   InstallerUrl: https://github.com/laoo/Felix/releases/download/v0.6.4/Felix32.exe
   InstallerSha256: afccd22d92e324df4016367d155adcc127ea88f612dafe4fd2ce99e75d6ec8fe
-  Commands:
-  - felixemulator86
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.VCRedist.2015+.x86


### PR DESCRIPTION
I think most people would prefer to not have the architecture at the end of commands.