### PR TITLE
perf: set `MISE_EXEC_AUTO_INSTALL` and run checkout step in parallel

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -58,16 +58,9 @@ jobs:
     defaults:
       run:
         shell: pwsh
+    env:
+      MISE_EXEC_AUTO_INSTALL: 'false'
     steps:
-      - name: Checkout mise configuration
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          persist-credentials: false
-          sparse-checkout: |
-            mise.lock
-            mise.toml
-          sparse-checkout-cone-mode: false
-
       - parallel:
           - name: Download index
             uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -89,11 +82,14 @@ jobs:
             env:
               GITHUB_TOKEN: ${{ github.token }}
 
-          - name: Install Tools
-            uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+          - name: Checkout mise configuration
+            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
             with:
-              version: 2026.7.7
-              install_args: rclone aqua:vcsjones/AzureSignTool
+              persist-credentials: false
+              sparse-checkout: |
+                mise.lock
+                mise.toml
+              sparse-checkout-cone-mode: false
 
       - parallel:
           - name: Setup and run IndexCreationTool
@@ -111,6 +107,12 @@ jobs:
               client-id: ${{ vars.AZURE_CLIENT_ID }}
               tenant-id: ${{ vars.AZURE_TENANT_ID }}
               subscription-id: ${{ vars.AZURE_SUBSCRIPTION_ID }}
+
+          - name: Install Tools
+            uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+            with:
+              version: 2026.7.7
+              install_args: rclone aqua:vcsjones/AzureSignTool
 
       - name: Sign source package
         working-directory: index


### PR DESCRIPTION
mise automatically installs the other missing tools in `mise.toml` when running a tool on Windows. Doesn't happen on Linux for some reason.

```
> $msixFiles = Get-ChildItem cache -Recurse -Filter *.msix | Select-Object -ExpandProperty FullName
> AzureSignTool sign -kvu $env:KEY_VAULT_URL -kvc $env:KEY_VAULT_CERT -kvm -tr http://timestamp.acs.microsoft.com/ -td sha256 -fd sha256 $msixFiles
mise bun@1.3.14                  [1/3] install
mise zizmor@1.27.0               [1/3] install
mise actionlint@1.7.12           [1/3] install
mise shellcheck@0.11.0           [1/3] install
mise bun@1.3.14                  [1/3] download bun-windows-x64.zip
mise shellcheck@0.11.0           [1/3] download shellcheck-v0.11.0.zip
mise zizmor@1.27.0               [1/3] download zizmor-x86_64-pc-windows-msvc.zip
mise actionlint@1.7.12           [1/3] download actionlint_1.7.12_windows_amd64.zip
mise actionlint@1.7.12           [2/3] checksum actionlint_1.7.12_windows_amd64.zip
mise actionlint@1.7.12           [3/3] extract actionlint_1.7.12_windows_amd64.zip
mise shellcheck@0.11.0           [1/3] checksum shellcheck-v0.11.0.zip
mise zizmor@1.27.0               [1/3] checksum zizmor-x86_64-pc-windows-msvc.zip
mise zizmor@1.27.0               [2/3] extract zizmor-x86_64-pc-windows-msvc.zip
mise shellcheck@0.11.0           [2/3] extract shellcheck-v0.11.0.zip
mise actionlint@1.7.12         ✓ installed
mise zizmor@1.27.0             ✓ installed
mise shellcheck@0.11.0         ✓ installed
mise bun@1.3.14                  [2/3] checksum bun-windows-x64.zip
mise bun@1.3.14                  [3/3] extract bun-windows-x64.zip
mise bun@1.3.14                  [3/3] bun -v
mise bun@1.3.14                  [3/3] 1.3.14
mise bun@1.3.14                ✓ installed
info: AzureSignTool.SignCommand[0]
      => File: D:\a\winget-extras\winget-extras\index\cache\source2.msix
      Signing file.
info: AzureSignTool.SignCommand[0]
      => File: D:\a\winget-extras\winget-extras\index\cache\source.msix
      Signing file.
info: AzureSignTool.SignCommand[0]
      => File: D:\a\winget-extras\winget-extras\index\cache\source2.msix
      Signing completed successfully.
info: AzureSignTool.SignCommand[0]
      => File: D:\a\winget-extras\winget-extras\index\cache\source.msix
      Signing completed successfully.
info: AzureSignTool.SignCommand[0]
      Successful operations: 2
info: AzureSignTool.SignCommand[0]
      Failed operations: 0
```