### PR TITLE
fix(publish): fetch mise config via API

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,14 +82,13 @@ jobs:
             env:
               GITHUB_TOKEN: ${{ github.token }}
 
-          - name: Checkout mise configuration
-            uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-            with:
-              persist-credentials: false
-              sparse-checkout: |
-                mise.lock
-                mise.toml
-              sparse-checkout-cone-mode: false
+          - name: Download mise configuration
+            shell: bash
+            run: |
+              gh api -H 'Accept: application/vnd.github.raw+json' "repos/$GITHUB_REPOSITORY/contents/mise.toml?ref=$GITHUB_SHA" > mise.toml
+              gh api -H 'Accept: application/vnd.github.raw+json' "repos/$GITHUB_REPOSITORY/contents/mise.lock?ref=$GITHUB_SHA" > mise.lock
+            env:
+              GITHUB_TOKEN: ${{ github.token }}
 
       - parallel:
           - name: Setup and run IndexCreationTool


### PR DESCRIPTION
Checking out a repo will wipe out the current directory. If the repo initialization happens be slightly slower than usual, the downloaded index will be wiped and the index creation fails. This switches the checkout step to fetch from the API instead which also has the added benefit of being slightly faster than a sparse checkout.