### PR TITLE
fix(shard/Composer.WindowsSetup): resolve version via GitHub Releases API

### DIFF
--- a/shards/json/Composer.WindowsSetup.json
+++ b/shards/json/Composer.WindowsSetup.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
 	"strategy": "github-release",
-	"github": { "owner": "composer", "repo": "windows-setup" },
+	"github": { "owner": "composer", "repo": "windows-setup", "fetchLatest": true },
 	"urls": ["https://getcomposer.org/Composer-Setup.exe|x86"]
 }


### PR DESCRIPTION
## Summary

The `Composer.WindowsSetup` shard generated a manifest with `PackageVersion: releases` in #453 (now closed).

The default `github-release` strategy resolves the version from the **last path segment** of the `https://github.com/<owner>/<repo>/releases/latest` redirect (`getLatestReleaseFromRedirect`). When that redirect lands on the releases index (`.../releases`) instead of a tagged release, the version silently becomes the literal string `releases` — which is exactly what happened here.

This enables `fetchLatest` so version detection uses GitHub's latest-release **API** endpoint. That returns a structured `tag_name` (`v6.3.0` → normalized `6.3.0`) and throws loudly if no release is found, rather than producing garbage.

```diff
-	"github": { "owner": "composer", "repo": "windows-setup" },
+	"github": { "owner": "composer", "repo": "windows-setup", "fetchLatest": true },
```

## Related

- Closes #453 (bot PR with the incorrect `releases` version)

## Manifests

- No manifest changes. Only the shard `shards/json/Composer.WindowsSetup.json` is modified; the correct `6.3.0` manifest already exists on `main`. The next automated run will now detect `6.3.0` from the API rather than `releases`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PDdz4MruAPnYAvprSPoym3

---
_Generated by [Claude Code](https://claude.ai/code/session_01PDdz4MruAPnYAvprSPoym3)_