### PR TITLE
Fix manifest linter mis-parsing dash-separated digit versions

### DIFF
--- a/scripts/manifest-linter/parser.test.ts
+++ b/scripts/manifest-linter/parser.test.ts
@@ -46,6 +46,14 @@ describe('manifest parser', () => {
 		expect(result.diagnostics[0]?.location?.start.line).toBeGreaterThan(1);
 	});
 
+	test('keeps dash-separated digit versions as strings', async () => {
+		const result = await parse(
+			VALID_VERSION_MANIFEST.replace("PackageVersion: '1.0'", 'PackageVersion: 2020-0514'),
+		);
+		expect(result.diagnostics).toEqual([]);
+		expect(result.manifest).toMatchObject({ PackageVersion: '2020-0514' });
+	});
+
 	test('continues to report schema errors after native parsing', async () => {
 		const result = await parse(`${VALID_VERSION_MANIFEST}Unexpected: true\n`);
 		expect(result.manifest).toBeUndefined();

--- a/scripts/manifest-linter/parser.ts
+++ b/scripts/manifest-linter/parser.ts
@@ -8,6 +8,18 @@ type MappingFrame = { indent: number; keys: Set<string> };
 const SIMPLE_KEY = /^([A-Za-z][A-Za-z0-9]*):(?:\s|$)/;
 const BLOCK_SCALAR = /^[|>](?:[+-]?\d?|\d?[+-]?)(?:\s|$)/;
 const QUOTED_KEY = /^(?:"(?:[^"\\]|\\.)*"|'(?:[^']|'')*')\s*:/;
+const DASHED_DIGITS = /^[\d_]*[-+][\d_+-]*$/;
+const FULL_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Bun's native parser resolves a dash-separated digit run such as `2020-0514`
+ * to its leading integer instead of a string. Complete dates resolve to the
+ * same string in both parsers, so only the remaining forms need the full one.
+ */
+function resolvesAmbiguously(value: string): boolean {
+	const scalar = value.split(/\s+#/)[0]!.trimEnd();
+	return DASHED_DIGITS.test(scalar.replace(/^[-+]/, '')) && !FULL_DATE.test(scalar);
+}
 
 /**
  * Bun's native parser intentionally accepts duplicate mapping keys. Detect the
@@ -54,7 +66,10 @@ function requiresDetailedParser(raw: string): boolean {
 		}
 
 		const match = SIMPLE_KEY.exec(candidate);
-		if (!match) continue;
+		if (!match) {
+			if (sequenceItem && resolvesAmbiguously(candidate)) return true;
+			continue;
+		}
 		let frame = frames.at(-1);
 		if (!frame || frame.indent !== mappingIndent) {
 			frame = { indent: mappingIndent, keys: new Set() };
@@ -64,7 +79,10 @@ function requiresDetailedParser(raw: string): boolean {
 		const key = match[1]!;
 		if (frame.keys.has(key)) return true;
 		frame.keys.add(key);
-		if (BLOCK_SCALAR.test(candidate.slice(match[0].length).trimStart())) {
+
+		const value = candidate.slice(match[0].length).trimStart();
+		if (resolvesAmbiguously(value)) return true;
+		if (BLOCK_SCALAR.test(value)) {
 			blockScalarIndent = mappingIndent;
 		}
 	}


### PR DESCRIPTION
Fixes the `Check Manifests` failure on `main` ([run 30187417066](https://github.com/pl4nty/winget-extras/actions/runs/30187417066/job/89754462809)), which reported 6 errors for `BrailleInstitute.AtkinsonHyperlegible` version `2020-0514`:

```
error[repository/contents] --> fonts/b/BrailleInstitute:1:1  directory does not belong to a package
error[schema]              --> ...AtkinsonHyperlegible.installer.yaml:5:1  PackageVersion must be a string
```

**Cause:** the linter's fast path uses `Bun.YAML.parse`, which resolves a plain scalar like `2020-0514` to the integer `2020` rather than a string (`Bun.YAML.parse("a: 2020-0514")` → `{a: 2020}`, while the `yaml` package returns `"2020-0514"`). So the schema saw a numeric `PackageVersion`, and the version directory `2020-0514` no longer matched the parsed version, cascading into the three `directory does not belong to a package` errors. The manifests themselves are valid — no manifest changes needed.

**Fix:** `requiresDetailedParser` now also routes these scalars to the full parser, alongside the duplicate-key and complex-syntax cases it already handles. Complete `YYYY-MM-DD` dates resolve identically in both parsers, so `ReleaseDate` values stay on the fast path — the manifest check still runs in ~0.3s over 1237 files.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? — no, this is a repository tooling fix.

Manifests

Not applicable — this PR changes `scripts/manifest-linter` only and adds no manifests. Verified locally:

- `bun scripts/manifest-linter` → `Manifests OK (1237 files).`
- `bun test scripts` → 61 pass, 0 fail (adds a regression test covering `PackageVersion: 2020-0514`)
- `bun --bun oxfmt --check` and `bun --bun oxlint --type-check --type-aware scripts/` → clean

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sk93m4wJi38YkbrajXf4Jy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sk93m4wJi38YkbrajXf4Jy)_