### PR TITLE
ci: trigger validation from monolith workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
     permissions:
       security-events: write # Required for upload-sarif to upload SARIF files.
 
+  validate:
+    name: Validate
+    uses: ./.github/workflows/validate.yml
+
   all-checks-pass:
     name: All Checks Pass
     if: always()
@@ -41,6 +45,7 @@ jobs:
       - lint
       - test
       - lint-actions
+      - validate
     steps:
       - name: Validate Required Checks
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -74,8 +74,14 @@ jobs:
               }
             }
           })
-          # -InputObject, not the pipeline: piping $null would emit [null] instead of []
-          "installers=$(ConvertTo-Json -InputObject $installers -Compress -Depth 5 -AsArray)" >> $env:GITHUB_OUTPUT
+
+          # ConvertTo-Json can't produce [] for an empty set: an empty array binds to
+          # -InputObject as $null, which -AsArray then wraps into [null] - a matrix entry
+          # with every field empty. Emit the literal instead.
+          $json = if ($installers.Count) {
+            ConvertTo-Json -InputObject $installers -Compress -Depth 5 -AsArray
+          } else { '[]' }
+          "installers=$json" >> $env:GITHUB_OUTPUT
 
   validate:
     name: Installation Validation

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,6 +1,7 @@
-name: validate
+name: Validate
 
 on:
+  workflow_call:
   workflow_dispatch:
     inputs:
       package_id:
@@ -11,24 +12,20 @@ on:
         description: 'Package version (e.g., 1.0)'
         required: true
         type: string
-  pull_request:
-    paths:
-      - 'manifests/**'
-      - 'fonts/**'
   # schedule:
   #   # Daily run on main to populate the Attack Surface Analyzer baseline cache
   #   - cron: '0 0 * * *'
 
 permissions: {}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   detect:
     name: Detect
     runs-on: ubuntu-slim
+    timeout-minutes: 5
+    concurrency:
+      group: validate-detect-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     outputs:
       installers: ${{ steps.matrix.outputs.installers }}
     steps:
@@ -52,19 +49,20 @@ jobs:
         id: matrix
         shell: pwsh
         env:
-          PACKAGE_ID: ${{ inputs.package_id || 'Microsoft.ConfigMgr.SupportCenter' }}
-          VERSION: ${{ inputs.version || '5.2509.1065.1000' }}
+          # The schedule fallback populates the Attack Surface Analyzer baseline cache
+          PACKAGE_ID: ${{ inputs.package_id || (github.event_name == 'schedule' && 'Microsoft.ConfigMgr.SupportCenter' || '') }}
+          VERSION: ${{ inputs.version || (github.event_name == 'schedule' && '5.2509.1065.1000' || '') }}
           CHANGED: ${{ steps.changed.outputs.all_changed_files }}
         run: |
           Install-Module powershell-yaml -Force
-          $packages = @(if ($env:GITHUB_EVENT_NAME -ne 'pull_request') {
+          $packages = @(if ($env:PACKAGE_ID) {
             $relativePath = "$($env:PACKAGE_ID.Substring(0,1).ToLower())/$($env:PACKAGE_ID -replace '\.', '/')/$($env:VERSION)"
             if (Test-Path "fonts/$relativePath") { "fonts/$relativePath" } else { "manifests/$relativePath" }
-          } else {
-            $env:CHANGED | ConvertFrom-Json | Select-Object -Unique
+          } elseif ($env:CHANGED) {
+            $env:CHANGED | ConvertFrom-Json | Select-Object -Unique | Where-Object { Test-Path $_ }
           })
 
-          $installers = $packages | ForEach-Object {
+          $installers = @($packages | ForEach-Object {
             $manifestPath = Get-ChildItem $_ -Filter *.installer.yaml
             $manifest = $manifestPath | Get-Content | ConvertFrom-Yaml
             $manifest.Installers | ForEach-Object {
@@ -75,12 +73,14 @@ jobs:
                 type = $_.InstallerType ?? $manifest.InstallerType
               }
             }
-          }
-          "installers=$($installers | ConvertTo-Json -Compress -Depth 5 -AsArray)" >> $env:GITHUB_OUTPUT
+          })
+          # -InputObject, not the pipeline: piping $null would emit [null] instead of []
+          "installers=$(ConvertTo-Json -InputObject $installers -Compress -Depth 5 -AsArray)" >> $env:GITHUB_OUTPUT
 
   validate:
     name: Installation Validation
     needs: detect
+    if: needs.detect.outputs.installers != '[]'
     runs-on: ${{ matrix.installer.arch == 'arm64' && 'windows-11-arm' || 'windows-latest' }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Merges the `validate` workflow into the main CI workflow, so installation validation is covered by the existing **All Checks Pass** job instead of reporting as a separate status check. That single check can then be used as the branch protection requirement for new package/version PRs.

<!-- The PR checklist template covers manifest submissions; this PR only touches workflows, so no manifest sections apply. -->

## Changes

**`ci.yml`**
- New `validate` job calling `./.github/workflows/validate.yml`, added to `all-checks-pass`'s `needs`.

**`validate.yml`**
- `pull_request` trigger replaced with `workflow_call`; CI's own `pull_request` trigger now drives it. `workflow_dispatch` is unchanged.
- Workflow-level `concurrency` removed. Under `workflow_call`, `github.workflow` resolves to the *caller*, so the group would have matched CI's own group and, with `cancel-in-progress: true`, cancelled the run that started it. CI's workflow-level group already covers nested jobs; `detect` gets a job-level group like the other reusable workflows.
- Package selection now keys off whether a package ID was supplied rather than `github.event_name != 'pull_request'`. Previously any non-PR event fell through to validating a hardcoded package, which would have meant a full Windows validation run on every push to `main` and every CI `workflow_dispatch`. The hardcoded package is now reached only by the (still commented out) schedule that seeds the Attack Surface Analyzer baseline cache.
- The Windows matrix is skipped when there is nothing to validate. CI has no `paths` filter, so an empty installer list is the common case now — worth noting that `$installers | ConvertTo-Json -AsArray` emits `[null]` rather than `[]` when the pipeline input is `$null`, so the output is built with `-InputObject` and the job is gated on `!= '[]'`.
- Changed manifest directories that no longer exist are filtered out, so PRs that only delete manifests don't fail detection.

## Behaviour

| Event | Before | After |
| --- | --- | --- |
| PR touching `manifests/**` or `fonts/**` | separate `validate` check | `Validate / Installation Validation` inside CI, gating `All Checks Pass` |
| PR touching nothing else | no validate run | `detect` runs (ubuntu-slim), matrix skipped |
| Push to `main` | no validate run | `detect` runs, matrix skipped |

No change to `validate.ps1` or to what any individual installer validation actually does.

## Follow-up

Branch protection needs `All Checks Pass` as the required check; the old standalone `validate` check should be dropped from any required list, since it no longer runs on `pull_request`.

## Testing

YAML parses and job wiring was checked locally. `actionlint`/`zizmor` aren't installed in this environment, so the Lint Actions job in CI is the first real lint of these files.

---
_Generated by [Claude Code](https://claude.ai/code/session_0138VzC3CCbmgHaM1V4GeppQ)_