### PR TITLE
feat(linter): warn on non-SPDX License values

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ komac new Publisher.Package
 komac update Publisher.Package --version 1.2.3 --urls https://example.com/setup-1.2.3.exe
 ```
 
+### License identifiers
+
+Use the [SPDX short identifier](https://spdx.org/licenses/) for `License` when the package's license is on the SPDX License List, so `MIT`, `Apache-2.0` and `GPL-3.0-or-later` rather than `MIT License`, `Apache 2.0` or `GPLv3`. Free text stays fine for anything unlisted, such as `Proprietary (Freeware)`. The linter warns and names the identifier when a value looks like one without matching exactly.
+
 ### Automated updates
 
 Add a shard at `shards/json/<PackageIdentifier>.json` describing how to detect new versions, and they'll be added automatically. Font shards append `.Font` to the identifier, like `shards/json/<PackageIdentifier>.Font.json`. See Anthelion's [CONTRIBUTING.md](https://github.com/UnownPlain/anthelion/blob/main/CONTRIBUTING.md) for the shard format, strategies for common sources, and how to test a shard locally with `bun test:shard <PackageIdentifier> --dry-run`.

--- a/README.md
+++ b/README.md
@@ -57,10 +57,6 @@ komac new Publisher.Package
 komac update Publisher.Package --version 1.2.3 --urls https://example.com/setup-1.2.3.exe
 ```
 
-### License identifiers
-
-Use the [SPDX short identifier](https://spdx.org/licenses/) for `License` when the package's license is on the SPDX License List, so `MIT`, `Apache-2.0` and `GPL-3.0-or-later` rather than `MIT License`, `Apache 2.0` or `GPLv3`. Free text stays fine for anything unlisted, such as `Proprietary (Freeware)`. The linter warns and names the identifier when a value looks like one without matching exactly.
-
 ### Automated updates
 
 Add a shard at `shards/json/<PackageIdentifier>.json` describing how to detect new versions, and they'll be added automatically. Font shards append `.Font` to the identifier, like `shards/json/<PackageIdentifier>.Font.json`. See Anthelion's [CONTRIBUTING.md](https://github.com/UnownPlain/anthelion/blob/main/CONTRIBUTING.md) for the shard format, strategies for common sources, and how to test a shard locally with `bun test:shard <PackageIdentifier> --dry-run`.

--- a/fonts/1/13rac1/TwitterColorEmojiSVGinOTFont/15.1.0/13rac1.TwitterColorEmojiSVGinOTFont.locale.en-US.yaml
+++ b/fonts/1/13rac1/TwitterColorEmojiSVGinOTFont/15.1.0/13rac1.TwitterColorEmojiSVGinOTFont.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://github.com/13rac1
 PublisherSupportUrl: https://github.com/13rac1/twemoji-color-font/issues
 PackageName: Twitter Color Emoji SVGinOT Font
 PackageUrl: https://github.com/13rac1/twemoji-color-font
-License: Various
+License: CC-BY-4.0
 LicenseUrl: https://github.com/13rac1/twemoji-color-font/blob/main/LICENSE.md
 ShortDescription: A color and B&W emoji SVG-OpenType / SVGinOT font built from the Twitter Emoji for Everyone artwork with support for ZWJ, skin tone diversity and country flags.
 Moniker: twemojicolorfont

--- a/fonts/a/ArtoHatanpaa/NouveauIBM/1.600/ArtoHatanpaa.NouveauIBM.locale.en.yaml
+++ b/fonts/a/ArtoHatanpaa/NouveauIBM/1.600/ArtoHatanpaa.NouveauIBM.locale.en.yaml
@@ -7,7 +7,7 @@ PackageLocale: en
 Publisher: Arto Hatanpää
 PackageName: Nouveau IBM
 PackageUrl: https://www.dafont.com/nouveau-ibm.font
-License: Presumed proprietary (Freeware)
+License: Freeware
 ShortDescription: TTF version of the IBM PC font. Good for terminal programs. Size 12 represents the original.
 Moniker: nouveauibm
 Tags:

--- a/fonts/b/BabelStone/Han/16.0.3/BabelStone.Han.locale.en.yaml
+++ b/fonts/b/BabelStone/Han/16.0.3/BabelStone.Han.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: BabelStone Fonts
 PackageName: BabelStone Han
 PackageUrl: https://www.babelstone.co.uk/Fonts/Han.html
-License: Arphic Public License 1999
+License: Arphic-1999
 LicenseUrl: https://ftp.gnu.org/non-gnu/chinese-fonts-truetype/LICENSE
 ShortDescription: A thin-shaped font with ≥64,000 characters designed mostly for Chinese, but also has rare Unicode characters for Japanese (including recent kana character blocks), Korean, Vietnamese, and Zhuang.
 Moniker: babelstonehan

--- a/fonts/b/BabelStone/TangutYinchuan/16.004/BabelStone.TangutYinchuan.locale.en.yaml
+++ b/fonts/b/BabelStone/TangutYinchuan/16.004/BabelStone.TangutYinchuan.locale.en.yaml
@@ -7,7 +7,7 @@ Publisher: BabelStone
 Author: Prof. Jǐng Yǒngshí, Andrew West, and Michael Everson
 PackageName: Tangut Yinchuan
 PackageUrl: https://www.babelstone.co.uk/Fonts/Yinchuan.html
-License: Proprietary (Freeware, share-alike, no derivatives)
+License: Freeware
 ShortDescription: A font for the extinct Tangut script that supports the full set of Tangut characters defined in Unicode 16.0 (Tangut, Tangut Supplement, and Tangut Components code charts). It is based on a font named XXZT that was designed by Prof. Jǐng Yǒngshí.
 Moniker: tangutyinchuan
 Tags:

--- a/fonts/b/Bitstream/Vera/1.10/Bitstream.Vera.locale.en-US.yaml
+++ b/fonts/b/Bitstream/Vera/1.10/Bitstream.Vera.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Bitstream Inc.
 Author: Bitstream Inc.
 PackageName: Bitstream Vera
 PackageUrl: https://web.archive.org/web/20210314185159/https://www.gnome.org/fonts/
-License: Bitstream Vera License
+License: Bitstream-Vera
 Copyright: Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
 ShortDescription: A digital typeface superfamily with generous open-source licensing
 Description: Bitstream Vera is a comprehensive digital typeface superfamily designed by Jim Lyles at Bitstream Inc., featuring serif, sans-serif, and monospace font families. Released in 2003 with liberal open-source licensing terms, it provides full TrueType hinting instructions for improved rendering on low-resolution displays. The monospace variant is particularly well-suited for technical work, clearly distinguishing similar characters like lowercase "l" from "1" and "0" from "O". Bitstream Vera Sans is also the default font for the Python Matplotlib library.

--- a/fonts/c/CITPC/IPAexFont/4.01/CITPC.IPAexFont.locale.en.yaml
+++ b/fonts/c/CITPC/IPAexFont/4.01/CITPC.IPAexFont.locale.en.yaml
@@ -7,7 +7,7 @@ Publisher: Information-technology Promotion Agency, Japan
 PublisherUrl: https://moji.or.jp
 PackageName: IPAex Font
 PackageUrl: https://moji.or.jp/ipafont/
-License: IPA Font License V1.0
+License: IPA
 LicenseUrl: https://moji.or.jp/ipafont/ipaex00401/
 ShortDescription: 2 fonts primarily for Japanese (IPAex Mincho and IPAex Gothic).
 Moniker: ipaex

--- a/fonts/c/CITPC/IPAexFont/4.01/CITPC.IPAexFont.locale.ja.yaml
+++ b/fonts/c/CITPC/IPAexFont/4.01/CITPC.IPAexFont.locale.ja.yaml
@@ -5,7 +5,7 @@ PackageVersion: "4.01"
 PackageLocale: ja
 Publisher: 文字情報技術促進協議会
 PackageName: IPAexフォント
-License: IPAフォントライセンスV1.0
+License: IPA
 ShortDescription: IPAでは2003年末よりIPAが全権利を所有する「IPAフォント*」を公開して参りました。2010年2月には、ドキュメント用日本語フォントの標準的な実装を行った「IPAexフォント（IPAex明朝、IPAexゴシックの2フォント）」をラインナップに加えました。 「IPAexフォント」は、和文文字（仮名や漢字など）は固定幅、欧文文字は文字幅に合わせた変動幅を基本とした実装を行い、日本語文書作成の利便性の向上を目指したフォントです。
 Tags:
 - ipaexフォント

--- a/fonts/d/DJR/Input/1.1/DJR.Input.locale.en-US.yaml
+++ b/fonts/d/DJR/Input/1.1/DJR.Input.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://djr.com/
 Author: David Jonathan Ross
 PackageName: Input
 PackageUrl: https://input.djr.com/
-License: Input Font Software License Agreement
+License: Proprietary
 LicenseUrl: https://input.djr.com/license/
 Copyright: Copyright 2014 DJR and The Font Bureau, Inc.
 ShortDescription: Flexible system of monospaced and proportional fonts designed specifically for code.

--- a/fonts/d/DejaVuFonts/DejaVu/2.37/DejaVuFonts.DejaVu.locale.en-US.yaml
+++ b/fonts/d/DejaVuFonts/DejaVu/2.37/DejaVuFonts.DejaVu.locale.en-US.yaml
@@ -9,10 +9,7 @@ PublisherUrl: https://dejavu-fonts.github.io/
 PublisherSupportUrl: https://github.com/dejavu-fonts/dejavu-fonts/
 PackageName: DejaVu Fonts
 PackageUrl: https://dejavu-fonts.github.io/
-License: |-
-  Bitstream Vera Fonts
-  Copyright Arev Fonts
-  Copyright Public Domain
+License: Bitstream-Vera
 LicenseUrl: https://github.com/dejavu-fonts/dejavu-fonts/blob/HEAD/LICENSE
 ShortDescription: A comprehensive font family based on Bitstream Vera, providing extensive Unicode character coverage and multilingual support.
 Description: DejaVu fonts are a font family based upon Bitstream Vera, designed to provide a wider range of characters while maintaining the original look and feel. The family includes Sans, Serif, and Mono variants, each available in multiple weights and styles (Regular, Bold, Oblique, Bold Oblique, Condensed, etc.). DejaVu supports numerous scripts including Latin, Greek, Cyrillic, Armenian, Georgian, Hebrew, Arabic, N'ko, Lao, Canadian Aboriginal Syllabics, Ogham, Tifinagh, and Lisu. Additionally, the fonts contain extensive mathematical symbols, arrows, braille patterns, and other special characters. DejaVu LGC variants provide a subset covering only Latin, Greek, and Cyrillic scripts.

--- a/fonts/g/GNU/FreeFont/FreeSans/20120503/GNU.FreeFont.FreeSans.locale.en.yaml
+++ b/fonts/g/GNU/FreeFont/FreeSans/20120503/GNU.FreeFont.FreeSans.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Free Software Foundation, Inc.
 PackageName: Free UCS Outline Fonts - FreeSans
 PackageUrl: https://savannah.gnu.org/projects/freefont/
-License: GPLv3
+License: GPL-3.0-or-later
 Moniker: gnufreesans
 ShortDescription: A free family of scalable outline fonts, suitable for general use on computers and for desktop publishing. It is Unicode-encoded for compatibility with all modern operating systems.
 Tags:

--- a/fonts/g/Google/OpenSans/3.003/Google.OpenSans.locale.en.yaml
+++ b/fonts/g/Google/OpenSans/3.003/Google.OpenSans.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Google Fonts
 PackageName: Open Sans
 PackageUrl: https://github.com/googlefonts/opensans
-License: SIL Open Font License 1.1
+License: OFL-1.1
 ShortDescription: A humanist sans serif typeface.
 Moniker: opensans
 Tags:

--- a/fonts/k/KreativeKorp/PetMe/1.0/KreativeKorp.PetMe.locale.en.yaml
+++ b/fonts/k/KreativeKorp/PetMe/1.0/KreativeKorp.PetMe.locale.en.yaml
@@ -7,7 +7,7 @@ PackageLocale: en
 Publisher: Kreative Korporation
 PackageName: Pet Me
 PackageUrl: https://www.kreativekorp.com/software/fonts/c64/
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: The world's most complete Commodore text font set, in TrueType format.
 Moniker: petme
 Tags:

--- a/fonts/m/Microsoft/EquationEditor/Font/3.01/Microsoft.EquationEditor.Font.locale.en.yaml
+++ b/fonts/m/Microsoft/EquationEditor/Font/3.01/Microsoft.EquationEditor.Font.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Microsoft
 PackageName: Font to display equations created by Microsoft Equation Editor 3.0 (MT Extra)
 PackageUrl: https://www.microsoft.com/en-us/download/details.aspx?id=56828
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: This font will enable display of Math equations created using Microsoft Equation Editor 3.0, an Office tool that was removed in January 2018.
 Moniker: mtextra
 Tags:

--- a/fonts/m/Microsoft/FluentCalibri/1.0/Microsoft.FluentCalibri.locale.en.yaml
+++ b/fonts/m/Microsoft/FluentCalibri/1.0/Microsoft.FluentCalibri.locale.en.yaml
@@ -7,7 +7,7 @@ PackageLocale: en
 Publisher: Microsoft
 PackageName: Microsoft Fluent Calibri
 PackageUrl: https://www.microsoft.com/en-us/download/details.aspx?id=50721
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: A variant of the Microsoft font Calibri in which the letters are spaced further apart, which is intended to help readers with visual crowding. Visual crowding is sometimes associated with dyslexia.
 Moniker: fluentcalibri
 Tags:

--- a/fonts/s/Shinmera/PromptFont/1.14/Shinmera.PromptFont.locale.en.yaml
+++ b/fonts/s/Shinmera/PromptFont/1.14/Shinmera.PromptFont.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Shinmera (Yukari Hafner)
 PackageName: PromptFont
 PackageUrl: https://shinmera.com/docs/promptfont/
-License: SIL Open Font License 1.1
+License: OFL-1.1
 ShortDescription: A font designed for user interfaces and button prompts in games. It includes the base alphabet, icons for keys, gamepad buttons, devices, and a wide variety of general user interface icons like stats, actions, items, attributes, and more.
 Moniker: promptfont
 Tags:

--- a/fonts/s/Style64/C64TrueType/1.2.1/Style64.C64TrueType.locale.en.yaml
+++ b/fonts/s/Style64/C64TrueType/1.2.1/Style64.C64TrueType.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Style64
 PackageName: C64 TrueType
 PackageUrl: https://style64.org/release/c64-truetype-v1.2.1-style
-License: Proprietary (Freeware). Its metadata, abbr.：«You MAY NOT：sell this font; include/redistribute the font in any font collection regardless of price; provide it for direct download from any website. You MAY：link to https://style64.org/c64-truetype so others can download/install the font; embed the font (…) for display on any website using font-face rules; use the font in static images and vector art; include the font as part of a software package but ONLY if said software (…) is freely provided to users.»
+License: Freeware
 ShortDescription: Our C64 TrueType fonts provide monospace and variable pitch versions of the legendary C64 character set. Our goal is to provide all 304 necessary glyphs in the C64 character set in as small a file as possible while still being programmer/builder friendly.
 Moniker: c64tt
 Tags:

--- a/fonts/u/umihotaru/Nishiki-teki/4.0.5/umihotaru.Nishiki-teki.locale.en-US.yaml
+++ b/fonts/u/umihotaru/Nishiki-teki/4.0.5/umihotaru.Nishiki-teki.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: umihotaru
 PackageName: Nishiki-teki
 PackageUrl: https://umihotaru.work/
-License: Open Font License
+License: OFL-1.1
 ShortDescription: A bold, curvy font with very wide support for languages, even more so for Japanese.
 Moniker: nishiki-teki
 Tags:

--- a/manifests/a/ArtifexSoftware/GhostScript/10.07.1/ArtifexSoftware.GhostScript.locale.en-US.yaml
+++ b/manifests/a/ArtifexSoftware/GhostScript/10.07.1/ArtifexSoftware.GhostScript.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Artifex Software, Inc.
 PublisherUrl: https://www.artifex.com/
 PackageName: Ghostscript
 PackageUrl: https://www.ghostscript.com/
-License: AGPL-3.0
+License: AGPL-3.0-or-later
 LicenseUrl: https://www.gnu.org/licenses/agpl-3.0.html
 ShortDescription: An interpreter for the PostScript language and PDF files.
 ReleaseNotes: Ghostscript/GhostPDL 10.07.1 release

--- a/manifests/a/Audiveris/Audiveris/5.10.2/Audiveris.Audiveris.locale.en-US.yaml
+++ b/manifests/a/Audiveris/Audiveris/5.10.2/Audiveris.Audiveris.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://github.com/Audiveris
 PublisherSupportUrl: https://github.com/Audiveris/audiveris/issues
 PackageName: Audiveris
 PackageUrl: https://audiveris.github.io/audiveris/
-License: AGPL-3.0
+License: AGPL-3.0-or-later
 LicenseUrl: https://github.com/Audiveris/audiveris/blob/master/LICENSE
 ShortDescription: Open-source optical music recognition (OMR) software.
 Moniker: audiveris

--- a/manifests/a/Audiveris/Audiveris/5.11.0/Audiveris.Audiveris.locale.en-US.yaml
+++ b/manifests/a/Audiveris/Audiveris/5.11.0/Audiveris.Audiveris.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://github.com/Audiveris
 PublisherSupportUrl: https://github.com/Audiveris/audiveris/issues
 PackageName: Audiveris
 PackageUrl: https://audiveris.github.io/audiveris/
-License: AGPL-3.0
+License: AGPL-3.0-or-later
 LicenseUrl: https://github.com/Audiveris/audiveris/blob/master/LICENSE
 ShortDescription: Open-source optical music recognition (OMR) software.
 Moniker: audiveris

--- a/manifests/b/Bluegrams/ScreenRuler/0.10.0/Bluegrams.ScreenRuler.locale.en-US.yaml
+++ b/manifests/b/Bluegrams/ScreenRuler/0.10.0/Bluegrams.ScreenRuler.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Bluegrams
 PackageName: Screen Ruler
 PackageUrl: https://sourceforge.net/projects/screenruler/
-License: BSD-3
+License: BSD-3-Clause
 ShortDescription: A lightweight and configurable ruler tool for Windows Desktop. It allows you to measure the size of elements on the screen in different units, including pixels, centimeters and inches.
 Moniker: screenruler
 Tags:

--- a/manifests/b/bol-van/zapret2/1.0.2/bol-van.zapret2.locale.en.yaml
+++ b/manifests/b/bol-van/zapret2/1.0.2/bol-van.zapret2.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: bol-van
 PackageName: zapret2
 PackageUrl: https://github.com/bol-van/zapret2
-License: None stated
+License: Proprietary
 ShortDescription: A standalone DPI countermeasure that does not require connection to any third-party servers. It can help bypass blocks or throttling of HTTP(S) websites, can do signature analysis of TCP/UDP, and can be used for partial transparent protocol obfuscation.
 Moniker: zapret2bolvan
 Tags:

--- a/manifests/b/bol-van/zapret2/1.0.2/bol-van.zapret2.locale.ru.yaml
+++ b/manifests/b/bol-van/zapret2/1.0.2/bol-van.zapret2.locale.ru.yaml
@@ -5,7 +5,7 @@ PackageVersion: 1.0.2
 PackageLocale: ru
 Publisher: bol-van (бол-ван)
 PackageName: запрет2
-License: Не указано
+License: Proprietary
 ShortDescription: Автономное средство противодействия DPI, которое не требует подключения каких-либо сторонних серверов. Может помочь обойти блокировки/замедление сайтов HTTP(S), может сигнатурный анализ TCP и UDP, и частичной прозрачной обфускации протоколов.
 Tags:
 - запрет-2

--- a/manifests/b/bol-van/zapret2/1.0.3/bol-van.zapret2.locale.en.yaml
+++ b/manifests/b/bol-van/zapret2/1.0.3/bol-van.zapret2.locale.en.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://github.com/bol-van
 PublisherSupportUrl: https://github.com/bol-van/zapret2/issues
 PackageName: zapret2
 PackageUrl: https://github.com/bol-van/zapret2
-License: None stated
+License: Proprietary
 ShortDescription: A standalone DPI countermeasure that does not require connection to any third-party servers. It can help bypass blocks or throttling of HTTP(S) websites, can do signature analysis of TCP/UDP, and can be used for partial transparent protocol obfuscation.
 Moniker: zapret2bolvan
 Tags:

--- a/manifests/b/bol-van/zapret2/1.0.3/bol-van.zapret2.locale.ru.yaml
+++ b/manifests/b/bol-van/zapret2/1.0.3/bol-van.zapret2.locale.ru.yaml
@@ -6,7 +6,7 @@ PackageVersion: 1.0.3
 PackageLocale: ru
 Publisher: bol-van (бол-ван)
 PackageName: запрет2
-License: Не указано
+License: Proprietary
 ShortDescription: Автономное средство противодействия DPI, которое не требует подключения каких-либо сторонних серверов. Может помочь обойти блокировки/замедление сайтов HTTP(S), может сигнатурный анализ TCP и UDP, и частичной прозрачной обфускации протоколов.
 Tags:
 - deep-packet-inspection-обход

--- a/manifests/e/EqualizerAPO/EqualizerAPO/1.4.2/EqualizerAPO.EqualizerAPO.locale.en-US.yaml
+++ b/manifests/e/EqualizerAPO/EqualizerAPO/1.4.2/EqualizerAPO.EqualizerAPO.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Jonas Thedering
 PublisherUrl: https://sourceforge.net/projects/equalizerapo/
 PackageName: Equalizer APO
 PackageUrl: https://sourceforge.net/projects/equalizerapo/
-License: LGPL-3.0
+License: LGPL-3.0-only
 LicenseUrl: https://sourceforge.net/projects/equalizerapo/
 ShortDescription: A parametric / graphic equalizer for Windows providing system-wide audio effects.
 Moniker: equalizerapo

--- a/manifests/f/Famatech/AdvancedPortScanner/2.5.3869/Famatech.AdvancedPortScanner.locale.en-US.yaml
+++ b/manifests/f/Famatech/AdvancedPortScanner/2.5.3869/Famatech.AdvancedPortScanner.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageLocale: en-US
 Publisher: Famatech Corp.
 PackageName: Advanced Port Scanner
 PackageUrl: https://www.advanced-port-scanner.com
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © 2002-2019 Famatech Corp. and its licensors. All rights reserved.
 ShortDescription: A free network scanner allowing you to quickly find open ports on network computers and retrieve versions of programs running on the detected ports. The program has a user-friendly interface and rich functionality.
 Moniker: advancedportscanner

--- a/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.locale.en.yaml
+++ b/manifests/g/Ginkgo/TimeTravel/2.0.38/Ginkgo.TimeTravel.locale.en.yaml
@@ -5,7 +5,7 @@ PackageLocale: en
 Publisher: Ginkgo LLC
 PackageUrl: https://www.serialporttool.com/GK/time-travel/
 PackageName: Time Travel
-License: Proprietary (Freeware)
+License: Freeware
 Moniker: ginkgott
 ShortDescription: A free tool to change the running speed of the computer clock. It can also override the current computer clock with any time value, including to any year from 1753 to 8907.
 Tags:

--- a/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Nmap Software LLC
 PublisherUrl: https://nmap.org/
 PackageName: Nmap
 PackageUrl: https://nmap.org/
-License: Nmap Public Source License
+License: Proprietary
 LicenseUrl: https://nmap.org/npsl/
 Copyright: Copyright (c) Nmap Software LLC (fyodor@nmap.org)
 ShortDescription: Free and open source utility for network discovery and security auditing.

--- a/manifests/i/Insecure/Nmap/7.99/Insecure.Nmap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Nmap/7.99/Insecure.Nmap.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Nmap Software LLC
 PublisherUrl: https://nmap.org/
 PackageName: Nmap
 PackageUrl: https://nmap.org/
-License: Nmap Public Source License
+License: Proprietary
 LicenseUrl: https://nmap.org/npsl/
 Copyright: Copyright (c) Nmap Software LLC (fyodor@nmap.org)
 ShortDescription: Free and open source utility for network discovery and security auditing.

--- a/manifests/i/Insecure/Npcap/1.88/Insecure.Npcap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Npcap/1.88/Insecure.Npcap.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://npcap.com/
 PublisherSupportUrl: https://npcap.com/
 PackageName: Npcap
 PackageUrl: https://npcap.com/
-License: Npcap License
+License: Proprietary
 LicenseUrl: https://npcap.com/#license
 Copyright: Copyright (c) 2025, Nmap Software LLC.  All rights reserved.
 ShortDescription: Windows packet capture and transmission library and driver, the WinPcap successor.

--- a/manifests/m/Microsoft/DeploymentToolkit/6.3.8450.1000/Microsoft.DeploymentToolkit.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DeploymentToolkit/6.3.8450.1000/Microsoft.DeploymentToolkit.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Microsoft Corporation
 PackageName: Microsoft Deployment Toolkit
 PackageUrl: https://docs.microsoft.com/en-us/mem/configmgr/mdt/
-License: Copyright (c) Microsoft Corporation
+License: Proprietary
 ShortDescription: Microsoft Deployment Toolkit (MDT) provides a unified collection of tools, processes, and guidance for automating desktop and server deployments.
 Moniker: mdt
 Tags:

--- a/manifests/m/Microsoft/DotNet/CoreFramework/Debug/2/2/2.2.31327.1/Microsoft.DotNet.CoreFramework.Debug.2.2.locale.en.yaml
+++ b/manifests/m/Microsoft/DotNet/CoreFramework/Debug/2/2/2.2.31327.1/Microsoft.DotNet.CoreFramework.Debug.2.2.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Microsoft Corporation
 PackageName: Microsoft.NET.CoreFramework.Debug.2.2
 PackageUrl: https://www.nuget.org/packages/runtime.win10-x64.Microsoft.Net.UWPCoreRuntimeSdk
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: AppX installer for the Microsoft.NET.CoreFramework.Debug.2.2 dependency that other AppX and MSIX files may occasionally require.
 Description: |-
   AppX installer for the Microsoft.NET.CoreFramework.Debug.2.2 dependency that other AppX and MSIX files may occasionally require.

--- a/manifests/m/Microsoft/DotNet/CoreRuntime/2/2/2.2.31331.1/Microsoft.DotNet.CoreRuntime.2.2.locale.en.yaml
+++ b/manifests/m/Microsoft/DotNet/CoreRuntime/2/2/2.2.31331.1/Microsoft.DotNet.CoreRuntime.2.2.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Microsoft Corporation
 PackageName: Microsoft.NET.CoreRuntime.2.2
 PackageUrl: https://www.nuget.org/packages/runtime.win10-x64.Microsoft.Net.UWPCoreRuntimeSdk
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: AppX installer for the Microsoft.NET.CoreRuntime.2.2 dependency that other AppX and MSIX files may occasionally require.
 Description: |-
   AppX installer for the Microsoft.NET.CoreRuntime.2.2 dependency that other AppX and MSIX files may occasionally require.

--- a/manifests/m/Microsoft/DotNet/Framework/Runtime/3/3.5.5101014/Microsoft.DotNet.Framework.Runtime.3.locale.en-US.yaml
+++ b/manifests/m/Microsoft/DotNet/Framework/Runtime/3/3.5.5101014/Microsoft.DotNet.Framework.Runtime.3.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Microsoft Corporation
 PackageName: Microsoft .NET Framework Runtime 3.5 for Windows 11 ≥26H1
 PackageUrl: https://learn.microsoft.com/en-us/dotnet/framework/install/dotnet-35-windows-11
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: Starting with Windows 11 26H1 (build 28000), .NET Framework 3.5 is only available as a standalone installer.
 Description: |-

--- a/manifests/m/Microsoft/MSXML/4/4.0-SP3/Microsoft.MSXML.4.locale.en.yaml
+++ b/manifests/m/Microsoft/MSXML/4/4.0-SP3/Microsoft.MSXML.4.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Microsoft
 PackageName: Microsoft MSXML (XML Core Services) 4.0 Parser
 PackageUrl: https://www.microsoft.com/en-gb/download/details.aspx?id=36292
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: Installer for Microsoft XML Core Services (MSXML) 4.0 Service Pack 3.
 Moniker: msxml4
 Tags:

--- a/manifests/m/Microsoft/OneNote/16.0.20131.20090/Microsoft.OneNote.locale.en-US.yaml
+++ b/manifests/m/Microsoft/OneNote/16.0.20131.20090/Microsoft.OneNote.locale.en-US.yaml
@@ -11,7 +11,7 @@ PrivacyUrl: https://privacy.microsoft.com/
 Author: Microsoft Corporation
 PackageName: Microsoft OneNote (Standalone)
 PackageUrl: https://www.microsoft.com/microsoft-365/onenote/digital-note-taking-app
-License: Proprietary (Freeware)
+License: Freeware
 LicenseUrl: https://docs.microsoft.com/legal/termsofuse
 Copyright: © Microsoft Corporation
 CopyrightUrl: https://docs.microsoft.com/legal/termsofuse

--- a/manifests/m/Microsoft/OneNote/16.0.20131.20090/Microsoft.OneNote.locale.nb.yaml
+++ b/manifests/m/Microsoft/OneNote/16.0.20131.20090/Microsoft.OneNote.locale.nb.yaml
@@ -5,7 +5,7 @@ PackageIdentifier: Microsoft.OneNote
 PackageVersion: 16.0.20131.20090
 PackageLocale: nb
 PackageName: Microsoft OneNote (Frittstående)
-License: Proprietær (Gratis)
+License: Freeware
 ShortDescription: Den digitale notatblokken din for registrering og organisering av alt på alle enhetene dine. Skriv ned ideer, hold oversikt over klasserommet og møtenotater, klipp fra nettet, eller opprett en gjøremålsliste, samt tegne og skissere ideene dine.
 Tags:
 - 1note

--- a/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Scribble/1/Microsoft.Scribble.locale.en-US.yaml
@@ -5,7 +5,7 @@ PackageVersion: "1"
 PackageLocale: en-US
 Publisher: Microsoft
 PackageName: Scribble MFC Application
-License: Unclear (Freeware)
+License: Freeware
 ShortDescription: A basic tool to draw black-on-white with a mouse.
 Description: A basic tool to draw black-on-white with a mouse. Created in 1992 as a sample app to demonstrate the then-new Microsoft Foundation Class Library, this Winget package is based on a 2019 .appx recompiling of one of the various sample app versions, which in turn was created at some point between 1992 and 2001.
 Moniker: scribble

--- a/manifests/m/Microsoft/VCLibs/12/12.0.21005.1/Microsoft.VCLibs.12.locale.en.yaml
+++ b/manifests/m/Microsoft/VCLibs/12/12.0.21005.1/Microsoft.VCLibs.12.locale.en.yaml
@@ -7,7 +7,7 @@ Publisher: Microsoft Platform Extensions
 PublisherUrl: https://www.microsoft.com/
 PackageName: Microsoft Visual C++ Runtime Package
 PackageUrl: https://learn.microsoft.com/en-us/troubleshoot/developer/visualstudio/cpp/libraries/c-runtime-packages-desktop-bridge
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: One of the various Visual C++ 2013 Runtime framework packages.
 Description: |-
   One of the various Visual C++ 2013 Runtime framework packages.

--- a/manifests/m/Microsoft/VCRedist/2012/arm32/11.0.61030.0/Microsoft.VCRedist.2012.arm32.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2012/arm32/11.0.61030.0/Microsoft.VCRedist.2012.arm32.locale.en-US.yaml
@@ -10,7 +10,7 @@ PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
 Author: Microsoft Corporation
 PackageName: Microsoft Visual C++ 2012 Redistributable (Arm32)
 PackageUrl: https://www.microsoft.com/en-gb/download/details.aspx?id=30679
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © Microsoft Corporation
 ShortDescription: The Microsoft Visual C++ 2012 Redistributable Package (Arm32) installs runtime components of Visual C++ Libraries required to run Arm32/ARMv7 applications developed with Visual C++ 2012 on a computer that does not have Visual C++ 2012 installed.
 Agreements:

--- a/manifests/m/Microsoft/VCRedist/2013/arm32/12.0.40660.0/Microsoft.VCRedist.2013.arm32.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2013/arm32/12.0.40660.0/Microsoft.VCRedist.2013.arm32.locale.en-US.yaml
@@ -10,7 +10,7 @@ PrivacyUrl: https://privacy.microsoft.com/en-us/privacystatement
 Author: Microsoft Corporation
 PackageName: Microsoft Visual C++ 2013 Redistributable (Arm32)
 PackageUrl: https://www.microsoft.com/en-gb/download/details.aspx?id=40784
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: Copyright © Microsoft Corporation
 ShortDescription: The Microsoft Visual C++ 2013 Redistributable Package (Arm32).
 Description: |-

--- a/manifests/m/Microsoft/VisualStudioCode/1.129.1/Microsoft.VisualStudioCode.locale.en-GB.yaml
+++ b/manifests/m/Microsoft/VisualStudioCode/1.129.1/Microsoft.VisualStudioCode.locale.en-GB.yaml
@@ -3,7 +3,7 @@
 PackageIdentifier: Microsoft.VisualStudioCode
 PackageVersion: 1.129.1
 PackageLocale: en-GB
-License: Microsoft Software Licence
+License: Proprietary
 ShortDescription: A code editor redefined and optimised for building and debugging modern web and cloud applications. Microsoft Visual Studio Code is free and available on your favourite platform - Linux, macOS, and Windows.
 ManifestType: locale
 ManifestVersion: 1.28.0

--- a/manifests/m/Microsoft/VisualStudioCode/1.129.1/Microsoft.VisualStudioCode.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VisualStudioCode/1.129.1/Microsoft.VisualStudioCode.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherUrl: https://www.microsoft.com/
 PrivacyUrl: https://privacy.microsoft.com/
 PackageName: Microsoft Visual Studio Code
 PackageUrl: https://code.visualstudio.com/
-License: Microsoft Software License
+License: Proprietary
 LicenseUrl: https://code.visualstudio.com/license
 ShortDescription: A code editor redefined and optimized for building and debugging modern web and cloud applications. Microsoft Visual Studio Code is free and available on your favorite platform - Linux, macOS, and Windows.
 Moniker: vscode

--- a/manifests/m/Microsoft/VisualStudioCode/1.130.0/Microsoft.VisualStudioCode.locale.en-GB.yaml
+++ b/manifests/m/Microsoft/VisualStudioCode/1.130.0/Microsoft.VisualStudioCode.locale.en-GB.yaml
@@ -3,7 +3,7 @@
 PackageIdentifier: Microsoft.VisualStudioCode
 PackageVersion: 1.130.0
 PackageLocale: en-GB
-License: Microsoft Software Licence
+License: Proprietary
 ShortDescription: A code editor redefined and optimised for building and debugging modern web and cloud applications. Microsoft Visual Studio Code is free and available on your favourite platform - Linux, macOS, and Windows.
 ManifestType: locale
 ManifestVersion: 1.28.0

--- a/manifests/m/Microsoft/VisualStudioCode/1.130.0/Microsoft.VisualStudioCode.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VisualStudioCode/1.130.0/Microsoft.VisualStudioCode.locale.en-US.yaml
@@ -8,7 +8,7 @@ PublisherUrl: https://www.microsoft.com/
 PrivacyUrl: https://privacy.microsoft.com/
 PackageName: Microsoft Visual Studio Code
 PackageUrl: https://code.visualstudio.com/
-License: Microsoft Software License
+License: Proprietary
 LicenseUrl: https://code.visualstudio.com/license
 ShortDescription: A code editor redefined and optimized for building and debugging modern web and cloud applications. Microsoft Visual Studio Code is free and available on your favorite platform - Linux, macOS, and Windows.
 Moniker: vscode

--- a/manifests/m/Mozilla/MozillaBuild/4.2.1/Mozilla.MozillaBuild.locale.en.yaml
+++ b/manifests/m/Mozilla/MozillaBuild/4.2.1/Mozilla.MozillaBuild.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Mozilla
 PackageName: MozillaBuild
 PackageUrl: https://wiki.mozilla.org/MozillaBuild
-License: Spread across multiple licenses (Freeware)
+License: Freeware
 LicenseUrl: https://hg-edge.mozilla.org/mozilla-build/file/tip/license.rtf
 ShortDescription: A meta-installer that provides everything needed to build Mozilla on Windows.
 Moniker: mozillabuild

--- a/manifests/n/NRaas/Packer/1.0.0.7/NRaas.Packer.locale.en-US.yaml
+++ b/manifests/n/NRaas/Packer/1.0.0.7/NRaas.Packer.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageLocale: en-US
 Publisher: NRaas Industries
 PackageName: NRaas Packer
 PackageUrl: https://www.nraas.net/Packer
-License: Unclear (Freeware)
+License: Freeware
 ShortDescription: Translator tool for the STBL subfiles in The Sims 3 .package files.
 Moniker: nraaspacker
 Tags:

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.53/Nvidia.Driver.GeForceGameReady.10x0.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.53/Nvidia.Driver.GeForceGameReady.10x0.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © 2011-2026 NVIDIA Corporation
 ShortDescription: Drivers for NVIDIA series 10x0, 9x0, and 7x0 graphics cards.
 Description: |-

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.66/Nvidia.Driver.GeForceGameReady.10x0.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.66/Nvidia.Driver.GeForceGameReady.10x0.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver (10x0/9x0/7x0 cards)
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © 2011-2026 NVIDIA Corporation
 ShortDescription: Drivers for NVIDIA series 10x0, 9x0, and 7x0 graphics cards.
 Description: |-

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.66/Nvidia.Driver.GeForceGameReady.10x0.locale.nb.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.66/Nvidia.Driver.GeForceGameReady.10x0.locale.nb.yaml
@@ -5,7 +5,7 @@ PackageVersion: "582.66"
 PackageLocale: nb
 PackageName: NVIDIA GeForce «Game Ready» grafikkdriver (for 10x0-/9x0-/7x0-kort)
 PackageUrl: https://www.nvidia.com/en-eu/geforce/drivers/
-License: Proprietær (Gratis)
+License: Freeware
 ShortDescription: Drivere for NVIDIAs 10x0-, 9x0-, og 7x0-skjermkortserier.
 Description: |-
   Grafikk- og lyddrivere for NVIDIAs 10x0-, 9x0-, og 7x0-serier med skjermkort.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/391.35/Nvidia.Driver.GeForceGameReady.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/391.35/Nvidia.Driver.GeForceGameReady.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © 2011-2026 NVIDIA Corporation
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/591.86/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/591.86/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageLocale: en-US
 Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © 2011-2026 NVIDIA Corporation
 ShortDescription: Driver for Nvidia graphics cards.
 Moniker: nvidia-driver

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.47/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.47/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageLocale: en-US
 Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © 2011-2026 NVIDIA Corporation
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.62/Nvidia.Driver.GeForceGameReady.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.62/Nvidia.Driver.GeForceGameReady.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © 2011-2026 NVIDIA Corporation
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.62/Nvidia.Driver.GeForceGameReady.locale.nb-NO.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.62/Nvidia.Driver.GeForceGameReady.locale.nb-NO.yaml
@@ -5,7 +5,7 @@ PackageVersion: "610.62"
 PackageLocale: nb-NO
 PackageName: NVIDIA GeForce «Game Ready» grafikkdriver
 PackageUrl: https://www.nvidia.com/en-eu/drivers/details/272788/
-License: Proprietær (Gratis)
+License: Freeware
 ShortDescription: Drivere for NVIDIA-skjermkort.
 Description: |-
   Grafikk- og lyddrivere for NVIDIA-skjermkort.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.da.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.da.yaml
@@ -5,7 +5,7 @@ PackageVersion: "610.74"
 PackageLocale: da
 PackageName: NVIDIA GeForce «Game Ready» skærmdriver
 PackageUrl: https://www.nvidia.com/en-eu/drivers/details/272788/
-License: Proprietær (Gratis)
+License: Freeware
 ShortDescription: Drivere for NVIDIA-skærmkort.
 Description: |-
   Grafik- og lyddrivere for NVIDIA-skærmkort.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © 2011-2026 NVIDIA Corporation
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.nb.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.nb.yaml
@@ -5,7 +5,7 @@ PackageVersion: "610.74"
 PackageLocale: nb
 PackageName: NVIDIA GeForce «Game Ready» grafikkdriver
 PackageUrl: https://www.nvidia.com/en-eu/drivers/details/272788/
-License: Proprietær (Gratis)
+License: Freeware
 ShortDescription: Drivere for NVIDIA-skjermkort.
 Description: |-
   Grafikk- og lyddrivere for NVIDIA-skjermkort.

--- a/manifests/o/opengribs/XyGrib/1.2.6.1/opengribs.XyGrib.locale.en-US.yaml
+++ b/manifests/o/opengribs/XyGrib/1.2.6.1/opengribs.XyGrib.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://opengribs.org/
 PublisherSupportUrl: https://github.com/opengribs/XyGrib/issues
 PackageName: XyGrib
 PackageUrl: https://opengribs.org/
-License: GPL-3.0
+License: GPL-3.0-or-later
 LicenseUrl: https://github.com/opengribs/XyGrib/blob/master/LICENSE
 ShortDescription: GRIB file viewer for weather forecast data visualization.
 Tags:

--- a/manifests/p/Purslane/RustDesk/1.4.6/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.6/Purslane.RustDesk.locale.en-US.yaml
@@ -11,7 +11,7 @@ PrivacyUrl: https://rustdesk.com/privacy/
 Author: Purslane Tech Pte. Ltd.
 PackageName: RustDesk
 PackageUrl: https://rustdesk.com/
-License: AGPL-3.0
+License: AGPL-3.0-only
 LicenseUrl: https://github.com/rustdesk/rustdesk/blob/HEAD/LICENCE
 Copyright: Copyright © 2026 Purslane Ltd. All rights reserved.
 ShortDescription: The fast and open-source remote access and support software. 

--- a/manifests/p/Purslane/RustDesk/1.4.8/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.8/Purslane.RustDesk.locale.en-US.yaml
@@ -11,7 +11,7 @@ PrivacyUrl: https://rustdesk.com/privacy/
 Author: Purslane Tech Pte. Ltd.
 PackageName: RustDesk
 PackageUrl: https://rustdesk.com/
-License: AGPL-3.0
+License: AGPL-3.0-only
 LicenseUrl: https://github.com/rustdesk/rustdesk/blob/HEAD/LICENCE
 Copyright: Copyright © 2026 Purslane Ltd. All rights reserved.
 ShortDescription: The fast and open-source remote access and support software. 

--- a/manifests/p/Purslane/RustDesk/1.4.9/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.9/Purslane.RustDesk.locale.en-US.yaml
@@ -11,7 +11,7 @@ PrivacyUrl: https://rustdesk.com/privacy/
 Author: Purslane Tech Pte. Ltd.
 PackageName: RustDesk
 PackageUrl: https://rustdesk.com/
-License: AGPL-3.0
+License: AGPL-3.0-only
 LicenseUrl: https://github.com/rustdesk/rustdesk/blob/HEAD/LICENCE
 Copyright: Copyright © 2026 Purslane Ltd. All rights reserved.
 ShortDescription: The fast and open-source remote access and support software.

--- a/manifests/r/reaConverter/reaConverterLite/8.0.234/reaConverter.reaConverterLite.locale.en-US.yaml
+++ b/manifests/r/reaConverter/reaConverterLite/8.0.234/reaConverter.reaConverterLite.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: reaConverter LLC
 PackageName: reaConverter Lite
 PackageUrl: https://www.reaconverter.com/free/
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: Our brand-new free edition that brings the power of batch image conversion to everyone. Whether you're resizing, reformatting, or organizing your files, Lite delivers smooth performance with support for the most popular formats.
 Moniker: reaconverterlite
 Tags:

--- a/manifests/s/Samsung/NVMeDriver/3.3.0.2003/Samsung.NVMeDriver.locale.en-US.yaml
+++ b/manifests/s/Samsung/NVMeDriver/3.3.0.2003/Samsung.NVMeDriver.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Samsung Electronics Co., Ltd
 PackageName: Samsung NVMe Driver
 PackageUrl: https://semiconductor.samsung.com/consumer-storage/support/tools/
-License: Proprietary (Freeware)
+License: Freeware
 Copyright: © Samsung Electronics Co., Ltd 2020.
 ShortDescription: Driver installer for Samsung NVMe 970, 960, and 950 series.
 Moniker: samsungnvmedriver

--- a/manifests/s/StackHawk/HawkScan/5.6/StackHawk.HawkScan.locale.en-US.yaml
+++ b/manifests/s/StackHawk/HawkScan/5.6/StackHawk.HawkScan.locale.en-US.yaml
@@ -6,7 +6,7 @@ PackageLocale: en-US
 Publisher: StackHawk, Inc
 PackageName: StackHawk HawkScan
 PackageUrl: https://docs.stackhawk.com/hawkscan/
-License: Proprietary (API key required for use)
+License: Proprietary
 ShortDescription: A dynamic application security testing (DAST) tool built for developers. Requires command line use.
 Moniker: hawkscan
 Tags:

--- a/manifests/s/StackHawk/HawkScan/6.0.0/StackHawk.HawkScan.locale.en-US.yaml
+++ b/manifests/s/StackHawk/HawkScan/6.0.0/StackHawk.HawkScan.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: StackHawk, Inc.
 PackageName: hawk CLI
 PackageUrl: https://docs.stackhawk.com/hawkscan/
-License: Proprietary (API key required for use)
+License: Proprietary
 ShortDescription: A dynamic application security testing (DAST) tool built for developers. Requires command line use.
 Moniker: hawkscan
 Tags:

--- a/manifests/s/StackHawk/HawkScan/6.1.0/StackHawk.HawkScan.locale.en-US.yaml
+++ b/manifests/s/StackHawk/HawkScan/6.1.0/StackHawk.HawkScan.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: StackHawk, Inc.
 PackageName: hawk CLI
 PackageUrl: https://docs.stackhawk.com/hawkscan/
-License: Proprietary (API key required for use)
+License: Proprietary
 ShortDescription: A dynamic application security testing (DAST) tool built for developers. Requires command line use.
 Moniker: hawkscan
 Tags:

--- a/manifests/s/StackHawk/HawkScan/6.2.0/StackHawk.HawkScan.locale.en-US.yaml
+++ b/manifests/s/StackHawk/HawkScan/6.2.0/StackHawk.HawkScan.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: StackHawk, Inc.
 PackageName: hawk CLI
 PackageUrl: https://docs.stackhawk.com/hawkscan/
-License: Proprietary (API key required for use)
+License: Proprietary
 ShortDescription: A dynamic application security testing (DAST) tool built for developers. Requires command line use.
 Moniker: hawkscan
 Tags:

--- a/manifests/u/Utopia/Eden/Zen4/0.2.1/Utopia.Eden.Zen4.locale.en.yaml
+++ b/manifests/u/Utopia/Eden/Zen4/0.2.1/Utopia.Eden.Zen4.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: Utopia LLC
 PackageName: Eden (AMD Zen 4)
 PackageUrl: https://git.eden-emu.dev/eden-emu/eden
-License: GPLv3
+License: GPL-3.0-or-later
 LicenseUrl: https://git.eden-emu.dev/eden-emu/eden/src/branch/master/LICENSE.txt
 ShortDescription: The Eden Nintendo Switch Emulator.
 Description: |-

--- a/manifests/u/unpn-org/Komac/0.0.51/unpn-org.Komac.locale.en.yaml
+++ b/manifests/u/unpn-org/Komac/0.0.51/unpn-org.Komac.locale.en.yaml
@@ -9,7 +9,7 @@ PublisherSupportUrl: https://github.com/unpn-org/Komac/issues
 Author: UnownPlain
 PackageName: Komac Anthelion
 PackageUrl: https://github.com/unpn-org/Komac
-License: GPLv3
+License: GPL-3.0-or-later
 LicenseUrl: https://github.com/unpn-org/Komac/blob/anthelion/LICENSE.md
 ShortDescription: Custom build of komac for use with https://github.com/UnownPlain/anthelion
 Moniker: ath

--- a/manifests/u/unpn-org/Komac/0.0.52/unpn-org.Komac.locale.en.yaml
+++ b/manifests/u/unpn-org/Komac/0.0.52/unpn-org.Komac.locale.en.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://github.com/unpn-org/Komac/issues
 Author: UnownPlain
 PackageName: Komac Anthelion
 PackageUrl: https://github.com/unpn-org/Komac
-License: GPLv3
+License: GPL-3.0-or-later
 LicenseUrl: https://github.com/unpn-org/Komac/blob/anthelion/LICENSE.md
 ShortDescription: Custom build of komac for use with https://github.com/UnownPlain/anthelion
 Moniker: ath

--- a/manifests/w/Wishingtooth/Wishingtooth/4.3.4.31067/Wishingtooth.Wishingtooth.locale.en.yaml
+++ b/manifests/w/Wishingtooth/Wishingtooth/4.3.4.31067/Wishingtooth.Wishingtooth.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: TRC Family Entertainment
 PackageName: 'The Wishingtooth: Storybook Adventure'
 PackageUrl: https://wishingtooth.ie/schools.html
-License: Proprietary (Freeware)
+License: Freeware
 ShortDescription: An interactive book which evolves a story about the Wishingtooth Fairy and her world, told through experiences of a little boy and girl at home, who are visited by the fairy.
 Moniker: wishingtooth
 Tags:

--- a/manifests/w/wxWidgets/wxWidgets/3.2.10/wxWidgets.wxWidgets.locale.en.yaml
+++ b/manifests/w/wxWidgets/wxWidgets/3.2.10/wxWidgets.wxWidgets.locale.en.yaml
@@ -6,7 +6,7 @@ PackageLocale: en
 Publisher: wxWidgets
 PackageName: wxWidgets
 PackageUrl: https://wxwidgets.org/downloads/
-License: wxWindows Library Licence
+License: LGPL-2.0-or-later WITH WxWindows-exception-3.1
 LicenseUrl: https://raw.githubusercontent.com/wxWidgets/wxWidgets/refs/heads/master/docs/licence.txt
 ShortDescription: Cross-platform GUI library for C++.
 Moniker: wxw

--- a/manifests/w/wxWidgets/wxWidgets/3.3.3/wxWidgets.wxWidgets.locale.en.yaml
+++ b/manifests/w/wxWidgets/wxWidgets/3.3.3/wxWidgets.wxWidgets.locale.en.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://github.com/wxWidgets
 PublisherSupportUrl: https://github.com/wxWidgets/wxWidgets/issues
 PackageName: wxWidgets
 PackageUrl: https://wxwidgets.org/downloads/
-License: wxWindows Library Licence
+License: LGPL-2.0-or-later WITH WxWindows-exception-3.1
 LicenseUrl: https://raw.githubusercontent.com/wxWidgets/wxWidgets/refs/heads/master/docs/licence.txt
 ShortDescription: Cross-platform GUI library for C++.
 Moniker: wxw

--- a/scripts/manifest-linter/rules/index.ts
+++ b/scripts/manifest-linter/rules/index.ts
@@ -8,6 +8,7 @@ import { returnCodesRule } from '@/scripts/manifest-linter/rules/installer/retur
 import { switchesRule } from '@/scripts/manifest-linter/rules/installer/switches';
 import { repositoryContentsRule } from '@/scripts/manifest-linter/rules/repository/contents';
 import { identifierCasingRule } from '@/scripts/manifest-linter/rules/repository/identifier-casing';
+import { licenseSpdxRule } from '@/scripts/manifest-linter/rules/repository/license-spdx';
 import { manifestPathRule } from '@/scripts/manifest-linter/rules/repository/manifest-path';
 import { manifestSetRule } from '@/scripts/manifest-linter/rules/repository/manifest-set';
 import { packageKindRule } from '@/scripts/manifest-linter/rules/repository/package-kind';
@@ -32,6 +33,7 @@ export const defaultRules: readonly Rule[] = [
 	packageKindRule,
 	repositoryContentsRule,
 	shardCoverageRule,
+	licenseSpdxRule,
 	upstreamVersionsRule,
 	installerMetadataRule,
 	archiveRule,

--- a/scripts/manifest-linter/rules/repository/license-spdx.test.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.test.ts
@@ -33,12 +33,13 @@ async function checkLicense(license: string | undefined, response?: Response | E
 	}
 }
 
-test('license rule accepts published identifiers and expressions over them', async () => {
+test('license rule accepts published identifiers, expressions and the house values', async () => {
 	for (const license of [
 		'MIT',
 		'MIT OR Apache-2.0',
 		'GPL-3.0-only WITH Autoconf-exception-3.0',
-		'LicenseRef-Acme-Eula',
+		'Proprietary',
+		'Freeware',
 		'  ',
 		undefined,
 	]) {
@@ -53,7 +54,7 @@ test('license rule warns for values that are not published identifiers', async (
 	expect(issues.at(0)?.level).toBe('warning');
 	expect(issues.at(0)?.search).toBe('License:');
 	expect(issues.at(0)?.hints).toEqual([
-		'use an identifier from https://spdx.org/licenses/, or LicenseRef-<name> for a license SPDX does not list',
+		'use an identifier from https://spdx.org/licenses/, or Proprietary or Freeware for a license SPDX does not list',
 	]);
 
 	expect(messages((await checkLicense('GPLv3')).issues)).toEqual([

--- a/scripts/manifest-linter/rules/repository/license-spdx.test.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.test.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'bun:test';
+import { describe, expect, test } from 'bun:test';
 
 import { licenseSpdxRule } from '@/scripts/manifest-linter/rules/repository/license-spdx';
 import { checkRule, manifest, messages, record } from '@/scripts/manifest-linter/rules/test-utils';
@@ -33,66 +33,70 @@ async function checkLicense(license: string | undefined, response?: Response | E
 	}
 }
 
-test('license rule accepts published identifiers, expressions and the house values', async () => {
-	for (const license of [
-		'MIT',
-		'MIT OR Apache-2.0',
-		'GPL-3.0-only WITH Autoconf-exception-3.0',
-		'Proprietary',
-		'Freeware',
-		'  ',
-		undefined,
-	]) {
-		expect((await checkLicense(license)).issues).toEqual([]);
-	}
-	expect((await checkLicense('MIT')).requests).toEqual(['https://spdx.org/licenses/licenses.json']);
-});
+describe('license spdx rule', () => {
+	test('accepts published identifiers, expressions and the house values', async () => {
+		for (const license of [
+			'MIT',
+			'MIT OR Apache-2.0',
+			'GPL-3.0-only WITH Autoconf-exception-3.0',
+			'Proprietary',
+			'Freeware',
+			'  ',
+			undefined,
+		]) {
+			expect((await checkLicense(license)).issues).toEqual([]);
+		}
+		expect((await checkLicense('MIT')).requests).toEqual([
+			'https://spdx.org/licenses/licenses.json',
+		]);
+	});
 
-test('license rule warns for values that are not published identifiers', async () => {
-	const { issues } = await checkLicense('Proprietary (Freeware)');
-	expect(messages(issues)).toEqual(['License Proprietary (Freeware) is not an SPDX identifier']);
-	expect(issues.at(0)?.level).toBe('warning');
-	expect(issues.at(0)?.search).toBe('License:');
-	expect(issues.at(0)?.hints).toEqual([
-		'use an identifier from https://spdx.org/licenses/, or Proprietary or Freeware for a license SPDX does not list',
-	]);
+	test('warns for values that are not published identifiers', async () => {
+		const { issues } = await checkLicense('Proprietary (Freeware)');
+		expect(messages(issues)).toEqual(['License Proprietary (Freeware) is not an SPDX identifier']);
+		expect(issues[0]?.level).toBe('warning');
+		expect(issues[0]?.search).toBe('License');
+		expect(issues[0]?.hints).toEqual([
+			'use an identifier from https://spdx.org/licenses/, or Proprietary or Freeware for a license SPDX does not list',
+		]);
 
-	expect(messages((await checkLicense('GPLv3')).issues)).toEqual([
-		'License GPLv3 is not an SPDX identifier',
-	]);
-	// Only the unknown operand of an expression is reported.
-	expect(messages((await checkLicense('MIT OR Nonesuch')).issues)).toEqual([
-		'License Nonesuch is not an SPDX identifier',
-	]);
-});
+		expect(messages((await checkLicense('GPLv3')).issues)).toEqual([
+			'License GPLv3 is not an SPDX identifier',
+		]);
+		// Only the unknown operand of an expression is reported.
+		expect(messages((await checkLicense('MIT OR Nonesuch')).issues)).toEqual([
+			'License Nonesuch is not an SPDX identifier',
+		]);
+	});
 
-test('license rule points a deprecated identifier at its SPDX page', async () => {
-	const { issues } = await checkLicense('GPL-3.0');
-	expect(messages(issues)).toEqual(['License GPL-3.0 is a deprecated SPDX identifier']);
-	expect(issues.at(0)?.hints).toEqual([
-		'see https://spdx.org/licenses/GPL-3.0.html for its replacement',
-	]);
-});
+	test('points a deprecated identifier at its SPDX page', async () => {
+		const { issues } = await checkLicense('GPL-3.0');
+		expect(messages(issues)).toEqual(['License GPL-3.0 is a deprecated SPDX identifier']);
+		expect(issues[0]?.hints).toEqual([
+			'see https://spdx.org/licenses/GPL-3.0.html for its replacement',
+		]);
+	});
 
-test('license rule reports nothing without a reachable list or a localization manifest', async () => {
-	expect((await checkLicense('GPLv3', new Error('offline'))).issues).toEqual([]);
-	expect((await checkLicense('GPLv3', new Response(undefined, { status: 503 }))).issues).toEqual(
-		[],
-	);
-	expect((await checkLicense('GPLv3', Response.json({ licenses: [] }))).issues).toEqual([]);
+	test('reports nothing without a reachable list or a localization manifest', async () => {
+		expect((await checkLicense('GPLv3', new Error('offline'))).issues).toEqual([]);
+		expect((await checkLicense('GPLv3', new Response(undefined, { status: 503 }))).issues).toEqual(
+			[],
+		);
+		expect((await checkLicense('GPLv3', Response.json({ licenses: [] }))).issues).toEqual([]);
 
-	const original = globalThis.fetch;
-	const requests: string[] = [];
-	globalThis.fetch = (async (url: string) => {
-		requests.push(url);
-		return Response.json({ licenses: LICENSES });
-	}) as typeof globalThis.fetch;
-	try {
-		expect(
-			await checkRule(licenseSpdxRule, { records: [record('installer'), record('version')] }),
-		).toEqual([]);
-	} finally {
-		globalThis.fetch = original;
-	}
-	expect(requests).toEqual([]);
+		const original = globalThis.fetch;
+		const requests: string[] = [];
+		globalThis.fetch = (async (url: string) => {
+			requests.push(url);
+			return Response.json({ licenses: LICENSES });
+		}) as typeof globalThis.fetch;
+		try {
+			expect(
+				await checkRule(licenseSpdxRule, { records: [record('installer'), record('version')] }),
+			).toEqual([]);
+		} finally {
+			globalThis.fetch = original;
+		}
+		expect(requests).toEqual([]);
+	});
 });

--- a/scripts/manifest-linter/rules/repository/license-spdx.test.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.test.ts
@@ -1,0 +1,154 @@
+import { expect, test } from 'bun:test';
+
+import { licenseSpdxRule } from '@/scripts/manifest-linter/rules/repository/license-spdx';
+import { checkRule, manifest, messages, record } from '@/scripts/manifest-linter/rules/test-utils';
+import type { ReportedDiagnostic } from '@/scripts/manifest-linter/types';
+
+const LICENSES = [
+	{ licenseId: 'MIT', name: 'MIT License' },
+	{ licenseId: 'Apache-2.0', name: 'Apache License 2.0' },
+	{ licenseId: 'BSD-3-Clause', name: 'BSD 3-Clause "New" or "Revised" License' },
+	{ licenseId: 'OFL-1.1', name: 'SIL Open Font License 1.1' },
+	{ licenseId: 'GPL-3.0-only', name: 'GNU General Public License v3.0 only' },
+	{ licenseId: 'GPL-3.0-or-later', name: 'GNU General Public License v3.0 or later' },
+	{ licenseId: 'GPL-3.0', name: 'GNU General Public License v3.0', isDeprecatedLicenseId: true },
+	{
+		licenseId: 'GPL-3.0+',
+		name: 'GNU General Public License v3.0 or later',
+		isDeprecatedLicenseId: true,
+	},
+	{ licenseId: 'BSD-2-Clause-Views', name: 'BSD 2-Clause with views sentence' },
+	{
+		licenseId: 'BSD-2-Clause-FreeBSD',
+		name: 'BSD 2-Clause FreeBSD License',
+		isDeprecatedLicenseId: true,
+	},
+	{ licenseId: 'wxWindows', name: 'wxWindows Library License', isDeprecatedLicenseId: true },
+];
+
+async function checkLicense(
+	license: string | undefined,
+	options: { type?: 'locale' | 'defaultLocale'; response?: Response | Error } = {},
+): Promise<ReportedDiagnostic[]> {
+	const original = globalThis.fetch;
+	globalThis.fetch = (async (url: string) => {
+		expect(url).toBe('https://spdx.org/licenses/licenses.json');
+		if (options.response instanceof Error) throw options.response;
+		return options.response ?? Response.json({ licenseListVersion: '3.28.0', licenses: LICENSES });
+	}) as typeof globalThis.fetch;
+	try {
+		const type = options.type ?? 'defaultLocale';
+		return await checkRule(licenseSpdxRule, {
+			records: [record(type, { manifest: { ...manifest(type), License: license } as never })],
+		});
+	} finally {
+		globalThis.fetch = original;
+	}
+}
+
+test('license rule accepts current identifiers and expressions over them', async () => {
+	expect(await checkLicense('MIT')).toEqual([]);
+	expect(await checkLicense('GPL-3.0-only')).toEqual([]);
+	expect(await checkLicense('OFL-1.1 OR MIT')).toEqual([]);
+	expect(await checkLicense('MIT AND Apache-2.0')).toEqual([]);
+	expect(await checkLicense('LicenseRef-Acme-Eula')).toEqual([]);
+});
+
+test('license rule stays silent for custom and unrecognized text', async () => {
+	expect(await checkLicense('Proprietary (Freeware)')).toEqual([]);
+	expect(await checkLicense('Nmap Public Source License')).toEqual([]);
+	expect(await checkLicense('Не указано')).toEqual([]);
+	expect(await checkLicense('Copyright (c) Acme Corporation')).toEqual([]);
+	expect(await checkLicense('  ')).toEqual([]);
+	expect(await checkLicense(undefined)).toEqual([]);
+	expect(await checkLicense('GPL-3.0-only WITH Autoconf-exception-3.0')).toEqual([]);
+	// An unknown operand inside an expression is more likely custom than a typo.
+	expect(await checkLicense('MIT OR Nmap Public Source License')).toEqual([]);
+});
+
+test('license rule suggests the identifier for a close variation', async () => {
+	const issues = await checkLicense('MIT License');
+	expect(messages(issues)).toEqual(['License MIT License looks like the SPDX identifier MIT']);
+	expect(issues.at(0)?.level).toBe('warning');
+	expect(issues.at(0)?.search).toBe('License:');
+	expect(issues.at(0)?.hints).toEqual([
+		'use MIT (MIT License), see https://spdx.org/licenses/MIT.html',
+	]);
+
+	expect(messages(await checkLicense('Apache 2.0'))).toEqual([
+		'License Apache 2.0 looks like the SPDX identifier Apache-2.0',
+	]);
+	expect(messages(await checkLicense('SIL Open Font License 1.1'))).toEqual([
+		'License SIL Open Font License 1.1 looks like the SPDX identifier OFL-1.1',
+	]);
+	expect(messages(await checkLicense('mit'))).toEqual([
+		'License mit looks like the SPDX identifier MIT',
+	]);
+	expect(messages(await checkLicense('BSD-3'))).toEqual([
+		'License BSD-3 looks like the SPDX identifier BSD-3-Clause',
+	]);
+});
+
+test('license rule replaces deprecated identifiers where SPDX defines a successor', async () => {
+	expect(messages(await checkLicense('GPL-3.0'))).toEqual([
+		'License GPL-3.0 is a deprecated SPDX identifier',
+	]);
+	expect((await checkLicense('GPL-3.0')).at(0)?.hints).toEqual([
+		'use GPL-3.0-only (GNU General Public License v3.0 only), see https://spdx.org/licenses/GPL-3.0-only.html',
+	]);
+	expect((await checkLicense('GPL-3.0+')).at(0)?.hints).toEqual([
+		'use GPL-3.0-or-later (GNU General Public License v3.0 or later), see https://spdx.org/licenses/GPL-3.0-or-later.html',
+	]);
+	expect((await checkLicense('BSD-2-Clause-FreeBSD')).at(0)?.hints).toEqual([
+		'use BSD-2-Clause-Views (BSD 2-Clause with views sentence), see https://spdx.org/licenses/BSD-2-Clause-Views.html',
+	]);
+	// GPLv3 is not an identifier at all, so it is reported as a suggestion.
+	expect(messages(await checkLicense('GPLv3'))).toEqual([
+		'License GPLv3 looks like the SPDX identifier GPL-3.0-only',
+	]);
+});
+
+test('license rule points at the SPDX page when no successor can be derived', async () => {
+	expect(messages(await checkLicense('wxWindows'))).toEqual([
+		'License wxWindows is a deprecated SPDX identifier',
+	]);
+	expect((await checkLicense('wxWindows')).at(0)?.hints).toEqual([
+		'see https://spdx.org/licenses/wxWindows.html for its replacement',
+	]);
+	expect(messages(await checkLicense('wxWindows Library Licence'))).toEqual([
+		'License wxWindows Library Licence looks like the deprecated SPDX identifier wxWindows',
+	]);
+});
+
+test('license rule checks non-default locales too', async () => {
+	expect(messages(await checkLicense('MIT License', { type: 'locale' }))).toEqual([
+		'License MIT License looks like the SPDX identifier MIT',
+	]);
+});
+
+test('license rule reports nothing when the SPDX list is unreachable', async () => {
+	expect(await checkLicense('MIT License', { response: new Error('offline') })).toEqual([]);
+	expect(
+		await checkLicense('MIT License', { response: new Response(undefined, { status: 503 }) }),
+	).toEqual([]);
+	expect(await checkLicense('MIT License', { response: Response.json({ licenses: [] }) })).toEqual(
+		[],
+	);
+});
+
+test('license rule does not fetch the list when no localization manifests are present', async () => {
+	const original = globalThis.fetch;
+	const requests: string[] = [];
+	globalThis.fetch = (async (url: string) => {
+		requests.push(url);
+		return Response.json({ licenses: LICENSES });
+	}) as typeof globalThis.fetch;
+	try {
+		expect(
+			await checkRule(licenseSpdxRule, { records: [record('installer'), record('version')] }),
+		).toEqual([]);
+	} finally {
+		globalThis.fetch = original;
+	}
+	expect(requests).toEqual([]);
+});

--- a/scripts/manifest-linter/rules/repository/license-spdx.test.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.test.ts
@@ -2,141 +2,84 @@ import { expect, test } from 'bun:test';
 
 import { licenseSpdxRule } from '@/scripts/manifest-linter/rules/repository/license-spdx';
 import { checkRule, manifest, messages, record } from '@/scripts/manifest-linter/rules/test-utils';
-import type { ReportedDiagnostic } from '@/scripts/manifest-linter/types';
 
 const LICENSES = [
-	{ licenseId: 'MIT', name: 'MIT License' },
-	{ licenseId: 'Apache-2.0', name: 'Apache License 2.0' },
-	{ licenseId: 'BSD-3-Clause', name: 'BSD 3-Clause "New" or "Revised" License' },
-	{ licenseId: 'OFL-1.1', name: 'SIL Open Font License 1.1' },
-	{ licenseId: 'GPL-3.0-only', name: 'GNU General Public License v3.0 only' },
-	{ licenseId: 'GPL-3.0-or-later', name: 'GNU General Public License v3.0 or later' },
-	{ licenseId: 'GPL-3.0', name: 'GNU General Public License v3.0', isDeprecatedLicenseId: true },
-	{
-		licenseId: 'GPL-3.0+',
-		name: 'GNU General Public License v3.0 or later',
-		isDeprecatedLicenseId: true,
-	},
-	{ licenseId: 'BSD-2-Clause-Views', name: 'BSD 2-Clause with views sentence' },
-	{
-		licenseId: 'BSD-2-Clause-FreeBSD',
-		name: 'BSD 2-Clause FreeBSD License',
-		isDeprecatedLicenseId: true,
-	},
-	{ licenseId: 'wxWindows', name: 'wxWindows Library License', isDeprecatedLicenseId: true },
+	{ licenseId: 'MIT', isDeprecatedLicenseId: false },
+	{ licenseId: 'Apache-2.0', isDeprecatedLicenseId: false },
+	{ licenseId: 'GPL-3.0-only', isDeprecatedLicenseId: false },
+	{ licenseId: 'Autoconf-exception-3.0', isDeprecatedLicenseId: false },
+	{ licenseId: 'GPL-3.0', isDeprecatedLicenseId: true },
 ];
 
-async function checkLicense(
-	license: string | undefined,
-	options: { type?: 'locale' | 'defaultLocale'; response?: Response | Error } = {},
-): Promise<ReportedDiagnostic[]> {
+async function checkLicense(license: string | undefined, response?: Response | Error) {
 	const original = globalThis.fetch;
+	const requests: string[] = [];
 	globalThis.fetch = (async (url: string) => {
-		expect(url).toBe('https://spdx.org/licenses/licenses.json');
-		if (options.response instanceof Error) throw options.response;
-		return options.response ?? Response.json({ licenseListVersion: '3.28.0', licenses: LICENSES });
+		requests.push(url);
+		if (response instanceof Error) throw response;
+		return response ?? Response.json({ licenses: LICENSES });
 	}) as typeof globalThis.fetch;
 	try {
-		const type = options.type ?? 'defaultLocale';
-		return await checkRule(licenseSpdxRule, {
-			records: [record(type, { manifest: { ...manifest(type), License: license } as never })],
+		const issues = await checkRule(licenseSpdxRule, {
+			records: [
+				record('defaultLocale', {
+					manifest: { ...manifest('defaultLocale'), License: license } as never,
+				}),
+			],
 		});
+		return { issues, requests };
 	} finally {
 		globalThis.fetch = original;
 	}
 }
 
-test('license rule accepts current identifiers and expressions over them', async () => {
-	expect(await checkLicense('MIT')).toEqual([]);
-	expect(await checkLicense('GPL-3.0-only')).toEqual([]);
-	expect(await checkLicense('OFL-1.1 OR MIT')).toEqual([]);
-	expect(await checkLicense('MIT AND Apache-2.0')).toEqual([]);
-	expect(await checkLicense('LicenseRef-Acme-Eula')).toEqual([]);
+test('license rule accepts published identifiers and expressions over them', async () => {
+	for (const license of [
+		'MIT',
+		'MIT OR Apache-2.0',
+		'GPL-3.0-only WITH Autoconf-exception-3.0',
+		'LicenseRef-Acme-Eula',
+		'  ',
+		undefined,
+	]) {
+		expect((await checkLicense(license)).issues).toEqual([]);
+	}
+	expect((await checkLicense('MIT')).requests).toEqual(['https://spdx.org/licenses/licenses.json']);
 });
 
-test('license rule stays silent for custom and unrecognized text', async () => {
-	expect(await checkLicense('Proprietary (Freeware)')).toEqual([]);
-	expect(await checkLicense('Nmap Public Source License')).toEqual([]);
-	expect(await checkLicense('Не указано')).toEqual([]);
-	expect(await checkLicense('Copyright (c) Acme Corporation')).toEqual([]);
-	expect(await checkLicense('  ')).toEqual([]);
-	expect(await checkLicense(undefined)).toEqual([]);
-	expect(await checkLicense('GPL-3.0-only WITH Autoconf-exception-3.0')).toEqual([]);
-	// An unknown operand inside an expression is more likely custom than a typo.
-	expect(await checkLicense('MIT OR Nmap Public Source License')).toEqual([]);
-});
-
-test('license rule suggests the identifier for a close variation', async () => {
-	const issues = await checkLicense('MIT License');
-	expect(messages(issues)).toEqual(['License MIT License looks like the SPDX identifier MIT']);
+test('license rule warns for values that are not published identifiers', async () => {
+	const { issues } = await checkLicense('Proprietary (Freeware)');
+	expect(messages(issues)).toEqual(['License Proprietary (Freeware) is not an SPDX identifier']);
 	expect(issues.at(0)?.level).toBe('warning');
 	expect(issues.at(0)?.search).toBe('License:');
 	expect(issues.at(0)?.hints).toEqual([
-		'use MIT (MIT License), see https://spdx.org/licenses/MIT.html',
+		'use an identifier from https://spdx.org/licenses/, or LicenseRef-<name> for a license SPDX does not list',
 	]);
 
-	expect(messages(await checkLicense('Apache 2.0'))).toEqual([
-		'License Apache 2.0 looks like the SPDX identifier Apache-2.0',
+	expect(messages((await checkLicense('GPLv3')).issues)).toEqual([
+		'License GPLv3 is not an SPDX identifier',
 	]);
-	expect(messages(await checkLicense('SIL Open Font License 1.1'))).toEqual([
-		'License SIL Open Font License 1.1 looks like the SPDX identifier OFL-1.1',
-	]);
-	expect(messages(await checkLicense('mit'))).toEqual([
-		'License mit looks like the SPDX identifier MIT',
-	]);
-	expect(messages(await checkLicense('BSD-3'))).toEqual([
-		'License BSD-3 looks like the SPDX identifier BSD-3-Clause',
+	// Only the unknown operand of an expression is reported.
+	expect(messages((await checkLicense('MIT OR Nonesuch')).issues)).toEqual([
+		'License Nonesuch is not an SPDX identifier',
 	]);
 });
 
-test('license rule replaces deprecated identifiers where SPDX defines a successor', async () => {
-	expect(messages(await checkLicense('GPL-3.0'))).toEqual([
-		'License GPL-3.0 is a deprecated SPDX identifier',
-	]);
-	expect((await checkLicense('GPL-3.0')).at(0)?.hints).toEqual([
-		'use GPL-3.0-only (GNU General Public License v3.0 only), see https://spdx.org/licenses/GPL-3.0-only.html',
-	]);
-	expect((await checkLicense('GPL-3.0+')).at(0)?.hints).toEqual([
-		'use GPL-3.0-or-later (GNU General Public License v3.0 or later), see https://spdx.org/licenses/GPL-3.0-or-later.html',
-	]);
-	expect((await checkLicense('BSD-2-Clause-FreeBSD')).at(0)?.hints).toEqual([
-		'use BSD-2-Clause-Views (BSD 2-Clause with views sentence), see https://spdx.org/licenses/BSD-2-Clause-Views.html',
-	]);
-	// GPLv3 is not an identifier at all, so it is reported as a suggestion.
-	expect(messages(await checkLicense('GPLv3'))).toEqual([
-		'License GPLv3 looks like the SPDX identifier GPL-3.0-only',
+test('license rule points a deprecated identifier at its SPDX page', async () => {
+	const { issues } = await checkLicense('GPL-3.0');
+	expect(messages(issues)).toEqual(['License GPL-3.0 is a deprecated SPDX identifier']);
+	expect(issues.at(0)?.hints).toEqual([
+		'see https://spdx.org/licenses/GPL-3.0.html for its replacement',
 	]);
 });
 
-test('license rule points at the SPDX page when no successor can be derived', async () => {
-	expect(messages(await checkLicense('wxWindows'))).toEqual([
-		'License wxWindows is a deprecated SPDX identifier',
-	]);
-	expect((await checkLicense('wxWindows')).at(0)?.hints).toEqual([
-		'see https://spdx.org/licenses/wxWindows.html for its replacement',
-	]);
-	expect(messages(await checkLicense('wxWindows Library Licence'))).toEqual([
-		'License wxWindows Library Licence looks like the deprecated SPDX identifier wxWindows',
-	]);
-});
-
-test('license rule checks non-default locales too', async () => {
-	expect(messages(await checkLicense('MIT License', { type: 'locale' }))).toEqual([
-		'License MIT License looks like the SPDX identifier MIT',
-	]);
-});
-
-test('license rule reports nothing when the SPDX list is unreachable', async () => {
-	expect(await checkLicense('MIT License', { response: new Error('offline') })).toEqual([]);
-	expect(
-		await checkLicense('MIT License', { response: new Response(undefined, { status: 503 }) }),
-	).toEqual([]);
-	expect(await checkLicense('MIT License', { response: Response.json({ licenses: [] }) })).toEqual(
+test('license rule reports nothing without a reachable list or a localization manifest', async () => {
+	expect((await checkLicense('GPLv3', new Error('offline'))).issues).toEqual([]);
+	expect((await checkLicense('GPLv3', new Response(undefined, { status: 503 }))).issues).toEqual(
 		[],
 	);
-});
+	expect((await checkLicense('GPLv3', Response.json({ licenses: [] }))).issues).toEqual([]);
 
-test('license rule does not fetch the list when no localization manifests are present', async () => {
 	const original = globalThis.fetch;
 	const requests: string[] = [];
 	globalThis.fetch = (async (url: string) => {

--- a/scripts/manifest-linter/rules/repository/license-spdx.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.ts
@@ -1,13 +1,11 @@
-import type { LocalizationManifest } from '@/scripts/manifest-linter/generated/manifest-types';
 import { defineRule } from '@/scripts/manifest-linter/rules/helpers';
-import type { ManifestRecord } from '@/scripts/manifest-linter/types';
 
 const LICENSE_LIST_URL = 'https://spdx.org/licenses/licenses.json';
 
 /**
- * What this repository spells a license SPDX does not publish. Most closed
- * source packages have no identifier to reach for, so they standardise on these
- * two rather than on a phrase per package.
+ * How this repository spells a license SPDX does not publish. Most closed source
+ * packages have no identifier to reach for, so they standardise on these two
+ * rather than on a phrase per package.
  */
 const HOUSE_IDENTIFIERS = new Set(['Proprietary', 'Freeware']);
 
@@ -48,29 +46,29 @@ function identifiers(value: string): string[] | undefined {
 	return expectOperand ? undefined : ids;
 }
 
+function accepted(id: string, licenses: Map<string, SpdxLicense>): boolean {
+	const license = licenses.get(id);
+	return HOUSE_IDENTIFIERS.has(id) || (license !== undefined && !license.isDeprecatedLicenseId);
+}
+
 export const licenseSpdxRule = defineRule({
 	id: 'repository/license-spdx',
 	async check({ records, report }) {
-		const licensed = records.filter(
-			(record): record is ManifestRecord & { manifest: LocalizationManifest } =>
-				record.manifest.ManifestType === 'locale' ||
-				record.manifest.ManifestType === 'defaultLocale',
+		const localized = records.some(
+			({ manifest }) =>
+				manifest.ManifestType === 'locale' || manifest.ManifestType === 'defaultLocale',
 		);
-		if (licensed.length === 0) return;
+		if (!localized) return;
 
 		const licenses = await fetchLicenses();
 		if (!licenses) return;
 
-		const accepted = (id: string) => {
-			const license = licenses.get(id);
-			return HOUSE_IDENTIFIERS.has(id) || (license !== undefined && !license.isDeprecatedLicenseId);
-		};
-
-		for (const { file, manifest } of licensed) {
+		for (const { file, manifest } of records) {
+			if (manifest.ManifestType !== 'locale' && manifest.ManifestType !== 'defaultLocale') continue;
 			const value = manifest.License?.trim();
 			if (!value) continue;
 
-			const unknown = identifiers(value)?.filter((id) => !accepted(id));
+			const unknown = identifiers(value)?.filter((id) => !accepted(id, licenses));
 			if (unknown && unknown.length === 0) continue;
 
 			for (const id of unknown?.length ? unknown : [value]) {
@@ -81,7 +79,7 @@ export const licenseSpdxRule = defineRule({
 					message: deprecated
 						? `License ${id} is a deprecated SPDX identifier`
 						: `License ${id} is not an SPDX identifier`,
-					search: 'License:',
+					search: 'License',
 					hints: [
 						deprecated
 							? `see https://spdx.org/licenses/${id}.html for its replacement`

--- a/scripts/manifest-linter/rules/repository/license-spdx.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.ts
@@ -4,6 +4,13 @@ import type { ManifestRecord } from '@/scripts/manifest-linter/types';
 
 const LICENSE_LIST_URL = 'https://spdx.org/licenses/licenses.json';
 
+/**
+ * What this repository spells a license SPDX does not publish. Most closed
+ * source packages have no identifier to reach for, so they standardise on these
+ * two rather than on a phrase per package.
+ */
+const HOUSE_IDENTIFIERS = new Set(['Proprietary', 'Freeware']);
+
 type SpdxLicense = { licenseId: string; isDeprecatedLicenseId?: boolean };
 
 // The published list is the only authority on which identifiers are current, so
@@ -54,19 +61,16 @@ export const licenseSpdxRule = defineRule({
 		const licenses = await fetchLicenses();
 		if (!licenses) return;
 
-		// LicenseRef-* is how SPDX spells a license that has no published identifier.
-		const published = (id: string) => {
+		const accepted = (id: string) => {
 			const license = licenses.get(id);
-			return (
-				id.startsWith('LicenseRef-') || (license !== undefined && !license.isDeprecatedLicenseId)
-			);
+			return HOUSE_IDENTIFIERS.has(id) || (license !== undefined && !license.isDeprecatedLicenseId);
 		};
 
 		for (const { file, manifest } of licensed) {
 			const value = manifest.License?.trim();
 			if (!value) continue;
 
-			const unknown = identifiers(value)?.filter((id) => !published(id));
+			const unknown = identifiers(value)?.filter((id) => !accepted(id));
 			if (unknown && unknown.length === 0) continue;
 
 			for (const id of unknown?.length ? unknown : [value]) {
@@ -81,7 +85,7 @@ export const licenseSpdxRule = defineRule({
 					hints: [
 						deprecated
 							? `see https://spdx.org/licenses/${id}.html for its replacement`
-							: 'use an identifier from https://spdx.org/licenses/, or LicenseRef-<name> for a license SPDX does not list',
+							: 'use an identifier from https://spdx.org/licenses/, or Proprietary or Freeware for a license SPDX does not list',
 					],
 				});
 			}

--- a/scripts/manifest-linter/rules/repository/license-spdx.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.ts
@@ -1,0 +1,211 @@
+import type { LocalizationManifest } from '@/scripts/manifest-linter/generated/manifest-types';
+import { defineRule } from '@/scripts/manifest-linter/rules/helpers';
+import type { ManifestRecord } from '@/scripts/manifest-linter/types';
+
+const LICENSE_LIST_URL = 'https://spdx.org/licenses/licenses.json';
+
+/**
+ * Deprecated identifiers whose replacement cannot be derived from the identifier
+ * itself. The GNU family is handled by {@link replacementFor} instead, and the
+ * `GPL-*-with-*-exception` identifiers are left without a suggestion because
+ * their replacements are `WITH` expressions over the separate exception list.
+ */
+const DEPRECATED_REPLACEMENTS: Record<string, string> = {
+	'BSD-2-Clause-FreeBSD': 'BSD-2-Clause-Views',
+	'BSD-2-Clause-NetBSD': 'BSD-2-Clause',
+	'StandardML-NJ': 'SMLNJ',
+	'bzip2-1.0.5': 'bzip2-1.0.6',
+};
+
+/** Shorthand that is common in manifests but normalizes to no SPDX name. */
+const SHORTHAND: [RegExp, string][] = [[/^bsd-?([234])(?:-?clause)?$/i, 'BSD-$1-Clause']];
+
+type SpdxLicense = {
+	licenseId: string;
+	name: string;
+	isDeprecatedLicenseId?: boolean;
+};
+
+type LicenseList = {
+	/** Every published identifier, keyed exactly as SPDX publishes it. */
+	byId: Map<string, SpdxLicense>;
+	/** Identifiers and full names keyed by {@link normalize}; ambiguous keys are dropped. */
+	byNormalized: Map<string, SpdxLicense | undefined>;
+};
+
+/**
+ * Reduces an identifier or a license name to a comparison key, so that `GPLv3`,
+ * `GPL-3.0` and `GNU General Public License version 3.0` all collide, while
+ * distinct licenses stay distinct. Ambiguous keys are discarded when the table
+ * is built, so a collision between two licenses suggests neither.
+ */
+function normalize(value: string): string {
+	const words = value
+		.toLowerCase()
+		.replaceAll('+', ' plus ')
+		.replace(/\b(?:version|licen[cs]e|the)\b/g, ' ')
+		.replace(/([a-z])v(\d)/g, '$1 $2')
+		.replace(/(^|[^a-z0-9])v(\d)/g, '$1$2')
+		.split(/[^a-z0-9.]+/)
+		.filter(Boolean);
+	return words
+		.map((word) =>
+			/^\d+(?:\.\d+)*$/.test(word) ? word.replace(/(?:\.0)+$/, '') : word.replaceAll('.', ''),
+		)
+		.join('');
+}
+
+function buildLicenseList(licenses: SpdxLicense[]): LicenseList {
+	const byId = new Map(licenses.map((license) => [license.licenseId, license]));
+	const byNormalized = new Map<string, SpdxLicense | undefined>();
+	const add = (key: string, license: SpdxLicense) => {
+		if (!key) return;
+		if (!byNormalized.has(key)) {
+			byNormalized.set(key, license);
+			return;
+		}
+		const existing = byNormalized.get(key);
+		if (!existing || existing.licenseId === license.licenseId) return;
+		// Prefer a current identifier over a deprecated one, otherwise suggest neither.
+		if (existing.isDeprecatedLicenseId && !license.isDeprecatedLicenseId) {
+			byNormalized.set(key, license);
+		} else if (!license.isDeprecatedLicenseId) byNormalized.set(key, undefined);
+	};
+	for (const license of licenses) add(normalize(license.licenseId), license);
+	for (const license of licenses) add(normalize(license.name), license);
+	return { byId, byNormalized };
+}
+
+// The published list is the only authority on which identifiers are current, so
+// it is fetched once per run. An unreachable list reports nothing rather than
+// failing the repository, matching the other network-backed rules.
+async function fetchLicenseList(): Promise<LicenseList | undefined> {
+	try {
+		const response = await fetch(LICENSE_LIST_URL, { signal: AbortSignal.timeout(10_000) });
+		if (!response.ok) return undefined;
+		const body = (await response.json()) as { licenses?: SpdxLicense[] };
+		if (!Array.isArray(body.licenses) || body.licenses.length === 0) return undefined;
+		return buildLicenseList(body.licenses);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Resolves a deprecated identifier to the current one where SPDX allows it. */
+function replacementFor(license: SpdxLicense, list: LicenseList): string | undefined {
+	const id = license.licenseId;
+	const explicit = DEPRECATED_REPLACEMENTS[id];
+	if (explicit) return list.byId.has(explicit) ? explicit : undefined;
+	const derived = id.endsWith('+') ? `${id.slice(0, -1)}-or-later` : `${id}-only`;
+	const target = list.byId.get(derived);
+	return target && !target.isDeprecatedLicenseId ? derived : undefined;
+}
+
+function describeLicense(id: string, list: LicenseList): string {
+	const name = list.byId.get(id)?.name;
+	return `${id}${name ? ` (${name})` : ''}, see https://spdx.org/licenses/${id}.html`;
+}
+
+/**
+ * Splits `A OR B` and `A AND B` into their operands. Expressions using `WITH`
+ * reference the separate exception list and are left alone, as is anything that
+ * is not a well-formed expression over identifier-shaped tokens.
+ */
+function operands(value: string): string[] | undefined {
+	if (!/^[\w.+\-()\s]+$/.test(value)) return undefined;
+	const tokens = value.split(/[\s()]+/).filter(Boolean);
+	if (tokens.length < 3 || tokens.includes('WITH')) return undefined;
+	const licenses: string[] = [];
+	for (const [index, token] of tokens.entries()) {
+		const isOperator = index % 2 === 1;
+		if (isOperator !== (token === 'AND' || token === 'OR')) return undefined;
+		if (!isOperator) licenses.push(token);
+	}
+	return tokens.length % 2 === 1 ? licenses : undefined;
+}
+
+function shorthandFor(value: string): string | undefined {
+	for (const [pattern, replacement] of SHORTHAND) {
+		if (pattern.test(value)) return value.replace(pattern, replacement);
+	}
+	return undefined;
+}
+
+type Suggestion = { message: string; hint: string };
+
+function review(value: string, list: LicenseList, inExpression: boolean): Suggestion | undefined {
+	// LicenseRef-* is how SPDX spells a license that has no published identifier.
+	if (value.startsWith('LicenseRef-')) return undefined;
+
+	const exact = list.byId.get(value);
+	if (exact && !exact.isDeprecatedLicenseId) return undefined;
+	if (exact) {
+		const replacement = replacementFor(exact, list);
+		return {
+			message: `License ${value} is a deprecated SPDX identifier`,
+			hint: replacement
+				? `use ${describeLicense(replacement, list)}`
+				: `see https://spdx.org/licenses/${value}.html for its replacement`,
+		};
+	}
+
+	// Only whole values are guessed at. Inside an expression an unknown operand is
+	// more likely a custom license than a typo, and rewriting one operand of an
+	// expression is not a suggestion the author can apply verbatim.
+	if (inExpression) return undefined;
+
+	const shorthand = shorthandFor(value);
+	const matched = shorthand ? list.byId.get(shorthand) : list.byNormalized.get(normalize(value));
+	if (!matched) return undefined;
+	if (!matched.isDeprecatedLicenseId) {
+		return {
+			message: `License ${value} looks like the SPDX identifier ${matched.licenseId}`,
+			hint: `use ${describeLicense(matched.licenseId, list)}`,
+		};
+	}
+
+	const replacement = replacementFor(matched, list);
+	if (replacement) {
+		return {
+			message: `License ${value} looks like the SPDX identifier ${replacement}`,
+			hint: `use ${describeLicense(replacement, list)}`,
+		};
+	}
+	return {
+		message: `License ${value} looks like the deprecated SPDX identifier ${matched.licenseId}`,
+		hint: `see https://spdx.org/licenses/${matched.licenseId}.html for its replacement`,
+	};
+}
+
+export const licenseSpdxRule = defineRule({
+	id: 'repository/license-spdx',
+	async check({ records, report }) {
+		const licensed = records.filter(
+			(record): record is ManifestRecord & { manifest: LocalizationManifest } =>
+				record.manifest.ManifestType === 'locale' ||
+				record.manifest.ManifestType === 'defaultLocale',
+		);
+		if (licensed.length === 0) return;
+
+		const list = await fetchLicenseList();
+		if (!list) return;
+
+		for (const { file, manifest } of licensed) {
+			const value = manifest.License?.trim();
+			if (!value || value.includes('\n')) continue;
+
+			const parts = operands(value);
+			for (const part of parts ?? [value]) {
+				const suggestion = review(part, list, parts !== undefined);
+				if (!suggestion) continue;
+				report({
+					file,
+					level: 'warning',
+					message: suggestion.message,
+					search: 'License:',
+					hints: [suggestion.hint],
+				});
+			}
+		}
+	},
+});

--- a/scripts/manifest-linter/rules/repository/license-spdx.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.ts
@@ -4,177 +4,41 @@ import type { ManifestRecord } from '@/scripts/manifest-linter/types';
 
 const LICENSE_LIST_URL = 'https://spdx.org/licenses/licenses.json';
 
-/**
- * Deprecated identifiers whose replacement cannot be derived from the identifier
- * itself. The GNU family is handled by {@link replacementFor} instead, and the
- * `GPL-*-with-*-exception` identifiers are left without a suggestion because
- * their replacements are `WITH` expressions over the separate exception list.
- */
-const DEPRECATED_REPLACEMENTS: Record<string, string> = {
-	'BSD-2-Clause-FreeBSD': 'BSD-2-Clause-Views',
-	'BSD-2-Clause-NetBSD': 'BSD-2-Clause',
-	'StandardML-NJ': 'SMLNJ',
-	'bzip2-1.0.5': 'bzip2-1.0.6',
-};
-
-/** Shorthand that is common in manifests but normalizes to no SPDX name. */
-const SHORTHAND: [RegExp, string][] = [[/^bsd-?([234])(?:-?clause)?$/i, 'BSD-$1-Clause']];
-
-type SpdxLicense = {
-	licenseId: string;
-	name: string;
-	isDeprecatedLicenseId?: boolean;
-};
-
-type LicenseList = {
-	/** Every published identifier, keyed exactly as SPDX publishes it. */
-	byId: Map<string, SpdxLicense>;
-	/** Identifiers and full names keyed by {@link normalize}; ambiguous keys are dropped. */
-	byNormalized: Map<string, SpdxLicense | undefined>;
-};
-
-/**
- * Reduces an identifier or a license name to a comparison key, so that `GPLv3`,
- * `GPL-3.0` and `GNU General Public License version 3.0` all collide, while
- * distinct licenses stay distinct. Ambiguous keys are discarded when the table
- * is built, so a collision between two licenses suggests neither.
- */
-function normalize(value: string): string {
-	const words = value
-		.toLowerCase()
-		.replaceAll('+', ' plus ')
-		.replace(/\b(?:version|licen[cs]e|the)\b/g, ' ')
-		.replace(/([a-z])v(\d)/g, '$1 $2')
-		.replace(/(^|[^a-z0-9])v(\d)/g, '$1$2')
-		.split(/[^a-z0-9.]+/)
-		.filter(Boolean);
-	return words
-		.map((word) =>
-			/^\d+(?:\.\d+)*$/.test(word) ? word.replace(/(?:\.0)+$/, '') : word.replaceAll('.', ''),
-		)
-		.join('');
-}
-
-function buildLicenseList(licenses: SpdxLicense[]): LicenseList {
-	const byId = new Map(licenses.map((license) => [license.licenseId, license]));
-	const byNormalized = new Map<string, SpdxLicense | undefined>();
-	const add = (key: string, license: SpdxLicense) => {
-		if (!key) return;
-		if (!byNormalized.has(key)) {
-			byNormalized.set(key, license);
-			return;
-		}
-		const existing = byNormalized.get(key);
-		if (!existing || existing.licenseId === license.licenseId) return;
-		// Prefer a current identifier over a deprecated one, otherwise suggest neither.
-		if (existing.isDeprecatedLicenseId && !license.isDeprecatedLicenseId) {
-			byNormalized.set(key, license);
-		} else if (!license.isDeprecatedLicenseId) byNormalized.set(key, undefined);
-	};
-	for (const license of licenses) add(normalize(license.licenseId), license);
-	for (const license of licenses) add(normalize(license.name), license);
-	return { byId, byNormalized };
-}
+type SpdxLicense = { licenseId: string; isDeprecatedLicenseId?: boolean };
 
 // The published list is the only authority on which identifiers are current, so
 // it is fetched once per run. An unreachable list reports nothing rather than
 // failing the repository, matching the other network-backed rules.
-async function fetchLicenseList(): Promise<LicenseList | undefined> {
+async function fetchLicenses(): Promise<Map<string, SpdxLicense> | undefined> {
 	try {
 		const response = await fetch(LICENSE_LIST_URL, { signal: AbortSignal.timeout(10_000) });
 		if (!response.ok) return undefined;
 		const body = (await response.json()) as { licenses?: SpdxLicense[] };
-		if (!Array.isArray(body.licenses) || body.licenses.length === 0) return undefined;
-		return buildLicenseList(body.licenses);
+		if (!body.licenses?.length) return undefined;
+		return new Map(body.licenses.map((license) => [license.licenseId, license]));
 	} catch {
 		return undefined;
 	}
 }
 
-/** Resolves a deprecated identifier to the current one where SPDX allows it. */
-function replacementFor(license: SpdxLicense, list: LicenseList): string | undefined {
-	const id = license.licenseId;
-	const explicit = DEPRECATED_REPLACEMENTS[id];
-	if (explicit) return list.byId.has(explicit) ? explicit : undefined;
-	const derived = id.endsWith('+') ? `${id.slice(0, -1)}-or-later` : `${id}-only`;
-	const target = list.byId.get(derived);
-	return target && !target.isDeprecatedLicenseId ? derived : undefined;
-}
-
-function describeLicense(id: string, list: LicenseList): string {
-	const name = list.byId.get(id)?.name;
-	return `${id}${name ? ` (${name})` : ''}, see https://spdx.org/licenses/${id}.html`;
-}
-
 /**
- * Splits `A OR B` and `A AND B` into their operands. Expressions using `WITH`
- * reference the separate exception list and are left alone, as is anything that
- * is not a well-formed expression over identifier-shaped tokens.
+ * Splits an SPDX expression into the identifiers it references, or returns
+ * undefined when the value is not a well-formed expression. The operand after a
+ * `WITH` names an exception rather than a license, so it is not returned.
  */
-function operands(value: string): string[] | undefined {
+function identifiers(value: string): string[] | undefined {
 	if (!/^[\w.+\-()\s]+$/.test(value)) return undefined;
-	const tokens = value.split(/[\s()]+/).filter(Boolean);
-	if (tokens.length < 3 || tokens.includes('WITH')) return undefined;
-	const licenses: string[] = [];
-	for (const [index, token] of tokens.entries()) {
-		const isOperator = index % 2 === 1;
-		if (isOperator !== (token === 'AND' || token === 'OR')) return undefined;
-		if (!isOperator) licenses.push(token);
+	const ids: string[] = [];
+	let expectOperand = true;
+	let afterWith = false;
+	for (const token of value.split(/[\s()]+/).filter(Boolean)) {
+		const isOperator = token === 'AND' || token === 'OR' || token === 'WITH';
+		if (isOperator === expectOperand) return undefined;
+		if (expectOperand && !afterWith) ids.push(token);
+		afterWith = token === 'WITH';
+		expectOperand = !expectOperand;
 	}
-	return tokens.length % 2 === 1 ? licenses : undefined;
-}
-
-function shorthandFor(value: string): string | undefined {
-	for (const [pattern, replacement] of SHORTHAND) {
-		if (pattern.test(value)) return value.replace(pattern, replacement);
-	}
-	return undefined;
-}
-
-type Suggestion = { message: string; hint: string };
-
-function review(value: string, list: LicenseList, inExpression: boolean): Suggestion | undefined {
-	// LicenseRef-* is how SPDX spells a license that has no published identifier.
-	if (value.startsWith('LicenseRef-')) return undefined;
-
-	const exact = list.byId.get(value);
-	if (exact && !exact.isDeprecatedLicenseId) return undefined;
-	if (exact) {
-		const replacement = replacementFor(exact, list);
-		return {
-			message: `License ${value} is a deprecated SPDX identifier`,
-			hint: replacement
-				? `use ${describeLicense(replacement, list)}`
-				: `see https://spdx.org/licenses/${value}.html for its replacement`,
-		};
-	}
-
-	// Only whole values are guessed at. Inside an expression an unknown operand is
-	// more likely a custom license than a typo, and rewriting one operand of an
-	// expression is not a suggestion the author can apply verbatim.
-	if (inExpression) return undefined;
-
-	const shorthand = shorthandFor(value);
-	const matched = shorthand ? list.byId.get(shorthand) : list.byNormalized.get(normalize(value));
-	if (!matched) return undefined;
-	if (!matched.isDeprecatedLicenseId) {
-		return {
-			message: `License ${value} looks like the SPDX identifier ${matched.licenseId}`,
-			hint: `use ${describeLicense(matched.licenseId, list)}`,
-		};
-	}
-
-	const replacement = replacementFor(matched, list);
-	if (replacement) {
-		return {
-			message: `License ${value} looks like the SPDX identifier ${replacement}`,
-			hint: `use ${describeLicense(replacement, list)}`,
-		};
-	}
-	return {
-		message: `License ${value} looks like the deprecated SPDX identifier ${matched.licenseId}`,
-		hint: `see https://spdx.org/licenses/${matched.licenseId}.html for its replacement`,
-	};
+	return expectOperand ? undefined : ids;
 }
 
 export const licenseSpdxRule = defineRule({
@@ -187,23 +51,38 @@ export const licenseSpdxRule = defineRule({
 		);
 		if (licensed.length === 0) return;
 
-		const list = await fetchLicenseList();
-		if (!list) return;
+		const licenses = await fetchLicenses();
+		if (!licenses) return;
+
+		// LicenseRef-* is how SPDX spells a license that has no published identifier.
+		const published = (id: string) => {
+			const license = licenses.get(id);
+			return (
+				id.startsWith('LicenseRef-') || (license !== undefined && !license.isDeprecatedLicenseId)
+			);
+		};
 
 		for (const { file, manifest } of licensed) {
 			const value = manifest.License?.trim();
-			if (!value || value.includes('\n')) continue;
+			if (!value) continue;
 
-			const parts = operands(value);
-			for (const part of parts ?? [value]) {
-				const suggestion = review(part, list, parts !== undefined);
-				if (!suggestion) continue;
+			const unknown = identifiers(value)?.filter((id) => !published(id));
+			if (unknown && unknown.length === 0) continue;
+
+			for (const id of unknown?.length ? unknown : [value]) {
+				const deprecated = licenses.get(id)?.isDeprecatedLicenseId ?? false;
 				report({
 					file,
 					level: 'warning',
-					message: suggestion.message,
+					message: deprecated
+						? `License ${id} is a deprecated SPDX identifier`
+						: `License ${id} is not an SPDX identifier`,
 					search: 'License:',
-					hints: [suggestion.hint],
+					hints: [
+						deprecated
+							? `see https://spdx.org/licenses/${id}.html for its replacement`
+							: 'use an identifier from https://spdx.org/licenses/, or LicenseRef-<name> for a license SPDX does not list',
+					],
 				});
 			}
 		}


### PR DESCRIPTION
Adds a `repository/license-spdx` rule that checks each localization manifest's `License` against the published [SPDX license list](https://spdx.org/licenses/licenses.json), and standardises the manifests that used neither an identifier nor one of the two house values.

> [!WARNING]
> Not ready to merge — see [Installation validation](#installation-validation) below. `All Checks Pass` is red because touching 75 manifests fans out ~100 real install jobs, 19 of which fail for reasons that predate this PR.

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#408103

Manifests

- [x] Have you checked that there aren't other open pull requests for the same manifest?
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-cli/tree/master/schemas/JSON/manifests/v1.12.0)?

75 manifests change, `License` only.

## The rule

A value passes when every operand of its SPDX expression is a published, current identifier, or one of `Proprietary` and `Freeware`. Most closed source packages have no identifier to reach for, so those two are the house spelling rather than a phrase per package.

| `License` value | Result |
| --- | --- |
| `MIT`, `MIT OR Apache-2.0`, `GPL-3.0-only WITH Autoconf-exception-3.0` | silent |
| `Proprietary`, `Freeware` | silent |
| `GPL-3.0`, `AGPL-3.0` | `is a deprecated SPDX identifier`, links to its SPDX page |
| `GPLv3`, `Proprietary (Freeware)`, `Nmap Public Source License` | `is not an SPDX identifier` |

Reported at `warning` level, so it surfaces as annotations rather than blocking a PR. The list is fetched once per run with a 10s timeout; an unreachable list reports nothing rather than failing the repository, matching `repository/upstream-versions`.

## The manifests

Values naming a published license became its identifier:

| Was | Now |
| --- | --- |
| `SIL Open Font License 1.1`, `Open Font License` | `OFL-1.1` |
| `Bitstream Vera License`, and DejaVu's three-line block | `Bitstream-Vera` |
| `IPA Font License V1.0`, `IPAフォントライセンスV1.0` | `IPA` |
| `Arphic Public License 1999` | `Arphic-1999` |
| `BSD-3` | `BSD-3-Clause` |
| `wxWindows Library Licence` | `LGPL-2.0-or-later WITH WxWindows-exception-3.1` |
| `Various` (Twemoji) | `CC-BY-4.0` |

The `-only` / `-or-later` suffix follows the upstream grant rather than a blanket rule. Ghostscript, Audiveris, Komac, Eden and XyGrib all state "either version 3 of the License, or (at your option) any later version" and became `-or-later`; RustDesk and EqualizerAPO state version 3 alone and became `-only`.

Everything else collapsed to `Proprietary` (16) or `Freeware` (34) — `Proprietary (Freeware)`, `Unclear (Freeware)`, `Presumed proprietary (Freeware)`, `Spread across multiple licenses (Freeware)`, the localised `Proprietær (Gratis)` and `Не указано`, `None stated`, `Microsoft Software License`/`Licence`, `Copyright (c) Microsoft Corporation`, `Nmap Public Source License`, `Npcap License`, `Input Font Software License Agreement`, and the C64 TrueType metadata paragraph.

Two of these are inferences rather than anything upstream states: `None stated` and `Не указано` (zapret2) became `Proprietary` on the reading that an unstated license reserves all rights, and DejaVu is really Bitstream-Vera plus Arev plus public-domain parts, so `Bitstream-Vera` is its primary license rather than the complete picture.

## Installation validation

`Validate / Detect` builds its matrix from changed manifest *directories*, so a `License`-only edit across 75 manifests fanned out 98 installation validation jobs that download and install the real packages. **79 passed, 19 failed.**

They are not caused by this diff. `validate.ps1` never reads `License` — it installs the package and throws on a non-zero exit code or a five minute timeout. The clearest evidence is #590, an automated version bump touching only `Microsoft.DotNet.Framework.Runtime.3`: it is failing the identical `Validate / Installation Validation (x86, …DotNet/Framework/Runtime/3…)` check right now, with no `License` change anywhere in it.

What this PR does is re-validate 75 packages that nothing had touched since they landed, so every package that cannot install cleanly on a GitHub runner surfaces at once. The full set:

| Package | Version | Arch |
| --- | --- | --- |
| `Nvidia.Driver.GeForceGameReady` | 391.35 | x86, x64 |
| `Nvidia.Driver.GeForceGameReady` | 591.86, 610.47, 610.62, 610.74 | x64 |
| `Nvidia.Driver.GeForceGameReady.10x0` | 582.53, 582.66 | x64 |
| `Samsung.NVMeDriver` | 3.3.0.2003 | x86 |
| `Insecure.Npcap` | 1.88 | x86 |
| `Insecure.Nmap` | 7.98, 7.99 | x86 |
| `EqualizerAPO` | 1.4.2 | x64 |
| `Microsoft.VCRedist.2012.arm32` | 11.0.61030.0 | arm |
| `Microsoft.VCRedist.2013.arm32` | 12.0.40660.0 | arm |
| `Microsoft.DotNet.Framework.Runtime.3` | 3.5.5101014 | x86 |
| `Microsoft.DeploymentToolkit` | 6.3.8450.1000 | x86 |
| `ArtifexSoftware.GhostScript` | 10.07.1 | x64 |
| `opengribs.XyGrib` | 1.2.6.1 | x86 |

Most are kernel-mode or driver installs that a hosted runner cannot complete — GeForce drivers, the Samsung NVMe driver, Npcap and Nmap (which bundles it), and EqualizerAPO's audio APO. The rest look like the five minute install timeout: Ghostscript's job ran 13 minutes wall clock and Nmap's 9.

Two useful contrasts, both pointing away from the diff: `Microsoft.DeploymentToolkit` passed on x64 and failed on x86, and every other package in the change set — including all twelve fonts, VS Code on three arches, RustDesk on four, Komac, and both zapret2 versions — installed cleanly.

## Verification

- `bun test scripts` — 72 pass, covering expressions, `WITH`, the house values, deprecated identifiers, an unreachable list, and repositories with no localization manifests.
- `Lint Project` green on this commit. It runs the linter against the live SPDX list and reports `Found 2 manifest warning(s)`, both from `repository/upstream-versions` — no license warnings remain anywhere in the tree.
- CRLF and mixed line endings preserved; the diff is one line per manifest, except DejaVu where a block scalar collapses to four.