### PR TITLE
ci: auto-merge update PRs

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -11,6 +11,10 @@ concurrency:
 
 permissions: {}
 
+defaults:
+  run:
+    shell: bash -euo pipefail {0}
+
 jobs:
   update-packages:
     name: Update Packages
@@ -39,6 +43,13 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
+      - name: List Existing Pull Requests
+        run: gh pr list --state open --app "${GH_APP_SLUG}" --limit 100 --json number --jq '.[].number' | sort > "${RUNNER_TEMP}/prs-before"
+        env:
+          GH_APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+
       - name: Update Packages
         run: bun start
         env:
@@ -46,3 +57,20 @@ jobs:
           KOMAC_GITHUB_OWNER: ${{ github.repository_owner }}
           KOMAC_GITHUB_REPO: ${{ github.event.repository.name }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      # Auto-merge must be enabled with the app token, not GITHUB_TOKEN: the merge is
+      # attributed to whoever enabled it, and a GITHUB_TOKEN push to main wouldn't
+      # trigger the publish workflow.
+      - name: Enable Auto-merge
+        run: |
+          gh pr list --state open --app "${GH_APP_SLUG}" --limit 100 --json number --jq '.[].number' | sort > "${RUNNER_TEMP}/prs-after"
+          failed=0
+          while read -r pr; do
+            echo "Enabling auto-merge on #${pr}"
+            gh pr merge --squash --auto "${pr}" || failed=1
+          done < <(comm -13 "${RUNNER_TEMP}/prs-before" "${RUNNER_TEMP}/prs-after")
+          exit "${failed}"
+        env:
+          GH_APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_REPO: ${{ github.repository }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Enables auto-merge on the PRs anthelion opens, so shard-driven package updates merge themselves once **All Checks Pass** reports green.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - n/a — workflow only

Manifests

No manifests are changed by this PR, so the manifest checklist does not apply.

## How it works

Two steps around the existing `bun start`, in the same job, reusing the app token that's already minted there:

1. **List Existing Pull Requests** — snapshot the app's open PR numbers before the run.
2. **Enable Auto-merge** — snapshot again afterwards; `comm -13` gives the PRs this run opened, and each gets `gh pr merge --squash --auto`.

Scoping to the diff rather than "every open bot PR" means a PR you're deliberately sitting on doesn't get armed retroactively by the next hourly run.

## Why the app token

Auto-merge merges on behalf of whoever enabled it. Enabling with the default `GITHUB_TOKEN` would attribute the merge to `github-actions[bot]`, and a `GITHUB_TOKEN` push to `main` doesn't trigger workflows — `publish.yml` would stop firing and the source index would silently stop rebuilding. The app token has no such restriction, and the step already has `pull-requests: write` on it.

## Preconditions, all already in place

| Requirement | State |
| --- | --- |
| `Allow auto-merge` on the repo | enabled |
| A required check for auto-merge to wait on | `default` ruleset requires `All Checks Pass` on `main` |
| Bot PRs trigger CI | head branches are in this repo, not a fork, and are pushed with an app token |

That second row matters: GitHub rejects `enablePullRequestAutoMerge` on a PR that is already mergeable. The ruleset keeps new PRs blocked until CI reports, so there's something to wait on.

## Behaviour

- `--squash` matches existing history and the repo's `squash_merge_commit_title: COMMIT_OR_PR_TITLE`.
- A PR that fails to arm logs and sets a failure flag, but the remaining PRs are still processed; the step exits non-zero at the end so a failure is visible rather than leaving a PR silently unmerged forever.
- Workflow-level `defaults.run.shell: bash -euo pipefail {0}` added, matching `ci.yml` and `test.yml` — without `pipefail` a failing `gh pr list` would be masked by the `| sort`.

## Testing

YAML parses and the loop body passes `bash -n`. `actionlint`/`zizmor` aren't installed in this environment, so the Lint Actions job is the first real lint. The step itself can't be exercised until it runs on the schedule against real anthelion output — the first hourly run after merge is the real test, and `gh pr list --app` is the piece most worth watching in that run's log.


---
_Generated by [Claude Code](https://claude.ai/code/session_01N5hJEWai7rtqWCC13GmYLi)_