### PR TITLE
fix: use github.com installer URL in Google.OpenSans shard

### DIFF
--- a/shards/script/Google.OpenSans.Font.ts
+++ b/shards/script/Google.OpenSans.Font.ts
@@ -8,7 +8,7 @@ export default defineShard(() =>
 		repo: 'opensans',
 		path: 'fonts/variable/OpenSans%5Bwdth%2Cwght%5D.ttf',
 		urls: (sha) => [
-			`https://raw.githubusercontent.com/googlefonts/opensans/${sha}/fonts/variable/OpenSans%5Bwdth%2Cwght%5D.ttf`,
+			`https://github.com/googlefonts/opensans/raw/${sha}/fonts/variable/OpenSans%5Bwdth%2Cwght%5D.ttf`,
 		],
 	}),
 );


### PR DESCRIPTION
`shards/script/Google.OpenSans.Font.ts` was the only shard emitting an installer URL on `raw.githubusercontent.com`, a host `installer/github-host` warns about, and it disagreed with the published manifest for `Google.OpenSans` 3.003, which uses `https://github.com/googlefonts/opensans/raw/<sha>/...`.

That was a workaround for [UnownPlain/anthelion#471](https://github.com/UnownPlain/anthelion/issues/471): Anthelion percent-decoded installer URLs before downloading, and `github.com` 404s on the decoded `OpenSans[wdth,wght].ttf` path while `raw.githubusercontent.com` serves it. The issue was fixed by [UnownPlain/anthelion#474](https://github.com/UnownPlain/anthelion/pull/474), so the encoded URL now survives to the download and the shard can use `github.com` like every other one.

Note: the fix landed in `anthelion-external` build `55dbf99` (a build of `UnownPlain/anthelion@666b96c`, which includes #474). This repo is still pinned to `fc5452e` from 22 Jul, which predates it — the pin is Renovate-managed and I couldn't regenerate `bun.lock` here, so this change takes effect once that bump lands.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - N/A — no winget-pkgs issue; this tracks an upstream Anthelion fix.

Manifests

- [ ] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

No manifests change in this PR — it only touches the shard that generates future ones. `bun manifests:check` passes (1349 files).

---
_Generated by [Claude Code](https://claude.ai/code/session_01TcENXW8eUXC3HnWJLcLYpF)_