### PR TITLE
fix(deps): update anthelion digest to 55dbf99

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,7 +4,7 @@
   "workspaces": {
     "": {
       "dependencies": {
-        "anthelion": "github:UnownPlain/anthelion-external#fc5452e0bdd0885b60b3e6eafe332f1c3567bc2e",
+        "anthelion": "github:UnownPlain/anthelion-external#55dbf99d99b0ec4910e955846d3ab16f9b9c81c6",
       },
       "devDependencies": {
         "@parcel/codeframe": "2.16.4",
@@ -20,13 +20,13 @@
     },
   },
   "packages": {
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.22", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-KdXJLa6O25fltJC/Lh8gnB1VaYMdX2mEKIalkohuItS+Ig523XxwK9e/Uuc66AvtrLIf7G51cDg3rDpP9mrxwQ=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.28", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q=="],
 
-    "@ai-sdk/groq": ["@ai-sdk/groq@4.0.11", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-/TL59OiozAQutjm1gr8pdYo8BfnLQIMIxqhjGgvRvtOEy8SI+hJ/WO+0tt3RcmoPaD8GwaqMslXOglNUJdGUcg=="],
+    "@ai-sdk/groq": ["@ai-sdk/groq@4.0.13", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bEUGDm3v3X/LvrpMioPg8NhaFBmwt+MjFa0cFdQVOJOT6LBLlGEYwr70g8B2/ttjZj4fW2qIhM/m8DDoYpXdrg=="],
 
     "@ai-sdk/provider": ["@ai-sdk/provider@4.0.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-e0CpNWJUY7OxAFAnCZkw+ri9QOHWwTs1tXP42782KFGCU07qt8NiXCrCVowyCB5dP2r5/Uls+g2oPd8kOJn9dw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.10", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-uPyec0+85dwxZYXtb8qe8gCjhjDfxP4LCDo/uRQS/iG+FIgYbHPRhr/ys281udG90bTaE18+5cxWraYaf8oHCw=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.12", "", { "dependencies": { "@ai-sdk/provider": "4.0.3", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-bbhlOgHeYwrIGheLkM6fhS8hVger8uFPmcOLg+kxc9EFh7y30XYorWhthlYAgpadO3SJhFZrIcEknN7qEqEVvA=="],
 
     "@octokit/app": ["@octokit/app@16.1.2", "", { "dependencies": { "@octokit/auth-app": "^8.1.2", "@octokit/auth-unauthenticated": "^7.0.3", "@octokit/core": "^7.0.6", "@octokit/oauth-app": "^8.0.3", "@octokit/plugin-paginate-rest": "^14.0.0", "@octokit/types": "^16.0.0", "@octokit/webhooks": "^14.0.0" } }, "sha512-8j7sEpUYVj18dxvh0KWj6W/l6uAiVRBl1JBDVRqH1VHKAO/G5eRVl4yEoYACjakWers1DjUkcCHyJNQK47JqyQ=="],
 
@@ -192,29 +192,29 @@
 
     "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
 
-    "@unownplain/anthelion-komac": ["@unownplain/anthelion-komac@0.0.51", "", { "optionalDependencies": { "@unownplain/anthelion-komac-darwin-arm64": "0.0.51", "@unownplain/anthelion-komac-darwin-x64": "0.0.51", "@unownplain/anthelion-komac-linux-arm64-gnu": "0.0.51", "@unownplain/anthelion-komac-linux-arm64-musl": "0.0.51", "@unownplain/anthelion-komac-linux-x64-gnu": "0.0.51", "@unownplain/anthelion-komac-linux-x64-musl": "0.0.51", "@unownplain/anthelion-komac-win32-arm64-msvc": "0.0.51", "@unownplain/anthelion-komac-win32-x64-msvc": "0.0.51" } }, "sha512-OH9+XaH1asDmyHOh8PrauRsTmb/XjGcVeN4g0XB/z+z2guemieRWnxsJIVqDYL9e+Y9KbBc9QmC6qK1CKcXejA=="],
+    "@unownplain/anthelion-komac": ["@unownplain/anthelion-komac@0.0.52", "", { "optionalDependencies": { "@unownplain/anthelion-komac-darwin-arm64": "0.0.52", "@unownplain/anthelion-komac-darwin-x64": "0.0.52", "@unownplain/anthelion-komac-linux-arm64-gnu": "0.0.52", "@unownplain/anthelion-komac-linux-arm64-musl": "0.0.52", "@unownplain/anthelion-komac-linux-x64-gnu": "0.0.52", "@unownplain/anthelion-komac-linux-x64-musl": "0.0.52", "@unownplain/anthelion-komac-win32-arm64-msvc": "0.0.52", "@unownplain/anthelion-komac-win32-x64-msvc": "0.0.52" } }, "sha512-z48tz/PcFYnY0/iBm1qAPkL/QIl7J/UhqG8uCl7UBupvzvHgUx6ATjBrvETlfgMwL0PW9CpZuU1wvs3X72Syrw=="],
 
-    "@unownplain/anthelion-komac-darwin-arm64": ["@unownplain/anthelion-komac-darwin-arm64@0.0.51", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XPmUU7a4kAswzJM9f+EpqMpv9NQ+49Y44VZ+t3FjC9QfOil7EM78M/ypBpiuB47jZHmnINyPb6nFRMy/hCSLhg=="],
+    "@unownplain/anthelion-komac-darwin-arm64": ["@unownplain/anthelion-komac-darwin-arm64@0.0.52", "", { "os": "darwin", "cpu": "arm64" }, "sha512-3/vVYH3P7TIX3OHjNdemM2u6d45INgmILE5JQEyr2KvP/48xJ1pi/XAiUZuNoz/ZmSJvvy6usEbwjVIuiiCPzQ=="],
 
-    "@unownplain/anthelion-komac-darwin-x64": ["@unownplain/anthelion-komac-darwin-x64@0.0.51", "", { "os": "darwin", "cpu": "x64" }, "sha512-raJOZSMal1bGynk/fnSriSANxHj9Z91CXA1qshL9cgyIFDcpagSOKsaPxeT+gJecSC2Q/yyPRBrVeRo6gU2DUA=="],
+    "@unownplain/anthelion-komac-darwin-x64": ["@unownplain/anthelion-komac-darwin-x64@0.0.52", "", { "os": "darwin", "cpu": "x64" }, "sha512-/n/kyJtApBsV0Gd6nlNrfm9zLJGOayhVMPKrwUYP58spAk9k095x/sm1NUT/DWPNiKnEQdox9o9cO8o3lybB6g=="],
 
-    "@unownplain/anthelion-komac-linux-arm64-gnu": ["@unownplain/anthelion-komac-linux-arm64-gnu@0.0.51", "", { "os": "linux", "cpu": "arm64" }, "sha512-CJ6nFzg2vEYO3bLqC2ONOzv8g/IXttub7MkArAnZ7t8215W2x74KKV0ZxwKcrSxI3yLcgyw5ckwP5pBIgfBM8Q=="],
+    "@unownplain/anthelion-komac-linux-arm64-gnu": ["@unownplain/anthelion-komac-linux-arm64-gnu@0.0.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-wmxN19Ks4QRX408VHWMmV9+kUyXsx53iEGbzyY/mcb8pRyLoHyNjPzl6tDXJlVo5B8IFGbUfd5SHF64We7r1Rw=="],
 
-    "@unownplain/anthelion-komac-linux-arm64-musl": ["@unownplain/anthelion-komac-linux-arm64-musl@0.0.51", "", { "os": "linux", "cpu": "arm64" }, "sha512-q0FuscgSlHJf61L93iyx2Z+Mu79McvmVqhXaMf8MymtZCCmP+W3DEQux8+ansZsu8dng3MySTiPV4uH0yi4q0w=="],
+    "@unownplain/anthelion-komac-linux-arm64-musl": ["@unownplain/anthelion-komac-linux-arm64-musl@0.0.52", "", { "os": "linux", "cpu": "arm64" }, "sha512-VWrG70E6VhinoxPhnEJMMxp730bdg+rr5EFVuGY2jU6BYM4vAD1w/oSY8n+zGxzRCaG5Hlp3n7eKehKJDUCZwg=="],
 
-    "@unownplain/anthelion-komac-linux-x64-gnu": ["@unownplain/anthelion-komac-linux-x64-gnu@0.0.51", "", { "os": "linux", "cpu": "x64" }, "sha512-vqdVFncygx/Nd5/Iu72Iv9A/rXIha6f6WuT0/d7THZwCtVNDKLNutc5SsRCbr3hgDLOOI8T35nWuwNjkA0KIsA=="],
+    "@unownplain/anthelion-komac-linux-x64-gnu": ["@unownplain/anthelion-komac-linux-x64-gnu@0.0.52", "", { "os": "linux", "cpu": "x64" }, "sha512-V80y1FK3VbKRP0j5xzAjqJNVOEQXlbklp6gnGM3TcxHs9DwZjwEuYeNIkWjXVtpnfsvczLbF2QmyVatxPXc6TQ=="],
 
-    "@unownplain/anthelion-komac-linux-x64-musl": ["@unownplain/anthelion-komac-linux-x64-musl@0.0.51", "", { "os": "linux", "cpu": "x64" }, "sha512-kNhdC94bSzeWH8RR+fzW9aCylu3EZul6aUeRQI7jM2A6s1CgJCBWjY/1Tak0T6M2+JxZV7vaAdaDseIMsx3MuQ=="],
+    "@unownplain/anthelion-komac-linux-x64-musl": ["@unownplain/anthelion-komac-linux-x64-musl@0.0.52", "", { "os": "linux", "cpu": "x64" }, "sha512-pDbzf5pePu3reCaeJwxA9s9i/f9r1r7+7MTdeqi//WexCOCERk8JrxP1iQccV1sSoZMyaJtnv98Kw/cRkkHF4A=="],
 
-    "@unownplain/anthelion-komac-win32-arm64-msvc": ["@unownplain/anthelion-komac-win32-arm64-msvc@0.0.51", "", { "os": "win32", "cpu": "arm64" }, "sha512-rbWOlfRqbM6EaIE0QL31g0zwNN85QZw+t5G2vW0wB+exsYO3XMwoxq1WYDngj6ttkFUPf+ZX4Nyy7aZYKl7q6A=="],
+    "@unownplain/anthelion-komac-win32-arm64-msvc": ["@unownplain/anthelion-komac-win32-arm64-msvc@0.0.52", "", { "os": "win32", "cpu": "arm64" }, "sha512-4M60ArrQDxQElZLsiFM7XCLKAfhm/d2nwXwUXDyE/BlBthp1qfq1V19W1NIaX355xysMejmTQcKejuz5rDGV/A=="],
 
-    "@unownplain/anthelion-komac-win32-x64-msvc": ["@unownplain/anthelion-komac-win32-x64-msvc@0.0.51", "", { "os": "win32", "cpu": "x64" }, "sha512-5uAlqxpJmGvx0+71pdpQyD10CidyLHLobytZSZGGfHk/uwOFi/caweOC8lthOxKJI6wKQPUMQCVqjsLa4Xr/BQ=="],
+    "@unownplain/anthelion-komac-win32-x64-msvc": ["@unownplain/anthelion-komac-win32-x64-msvc@0.0.52", "", { "os": "win32", "cpu": "x64" }, "sha512-+aVKpmo4jLHLJNn4iBbJsF5QU1ZVUKSxVktJrPJILajjo/Kd4HyUg0lxqW8e2TZT0C6QM7Z8KYMVtGumRvyDuQ=="],
 
     "@vercel/oidc": ["@vercel/oidc@3.2.0", "", {}, "sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug=="],
 
     "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
 
-    "ai": ["ai@7.0.30", "", { "dependencies": { "@ai-sdk/gateway": "4.0.22", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.10" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-tm0gTAHSWBdDfW4P2mj+LlglGCUQTSA9ktyS2PsPgVhxNO9gYWTSnRAehiJ3h1lYsJBp1Zgbz3RH2lezJXagiw=="],
+    "ai": ["ai@7.0.37", "", { "dependencies": { "@ai-sdk/gateway": "4.0.28", "@ai-sdk/provider": "4.0.3", "@ai-sdk/provider-utils": "5.0.12" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-stF+SEQJgKY3Qfe3FwNzqUrehHviOp2l7LemoI8YMOa0Zk5PxKsRNgUk3cHXz0RAue9RRyCAis2fz6LSCP6EKw=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -224,7 +224,7 @@
 
     "ansis": ["ansis@4.3.1", "", {}, "sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA=="],
 
-    "anthelion": ["anthelion@github:UnownPlain/anthelion-external#fc5452e", { "dependencies": { "@ai-sdk/groq": "4.0.11", "@rcompat/fs": "0.35.1", "@unownplain/anthelion-komac": "0.0.51", "ai": "7.0.30", "ansis": "4.3.1", "es-toolkit": "1.49.0", "ky": "2.0.2", "octokit": "5.0.5", "temporal-polyfill": "1.0.1", "yaml": "2.9.0", "zod": "4.4.3" }, "bin": { "anthelion": "./dist/bin/main.js", "anthelion-test": "./dist/bin/test.js" } }, "UnownPlain-anthelion-external-fc5452e", "sha512-wQv12DUdWuzzaJf1TqsvB+XTMH64o/WchxGn+g0fr8wb7EITlxfp6xzEPJJG+UxwkjuiBWavBYa/sdnN09rnKA=="],
+    "anthelion": ["anthelion@github:UnownPlain/anthelion-external#55dbf99", { "dependencies": { "@ai-sdk/groq": "4.0.13", "@rcompat/fs": "0.35.1", "@unownplain/anthelion-komac": "0.0.52", "ai": "7.0.37", "ansis": "4.3.1", "es-toolkit": "1.49.0", "ky": "2.0.2", "octokit": "5.0.5", "temporal-polyfill": "1.0.1", "zod": "4.4.3" }, "bin": { "anthelion": "./dist/bin/main.js", "anthelion-test": "./dist/bin/test.js" } }, "UnownPlain-anthelion-external-55dbf99", "sha512-prchtQoCs3qwOU2nQP32sZTuvixb6EJ+MZCtrAx8VMv7/LKbZUXiE/3wHfeK3BCC5u4ZsYYKH7gEk5w4UK4s4g=="],
 
     "before-after-hook": ["before-after-hook@4.0.0", "", {}, "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ=="],
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
 		"manifests:fix": "bun scripts/manifest-linter --fix"
 	},
 	"dependencies": {
-		"anthelion": "github:UnownPlain/anthelion-external#fc5452e0bdd0885b60b3e6eafe332f1c3567bc2e"
+		"anthelion": "github:UnownPlain/anthelion-external#55dbf99d99b0ec4910e955846d3ab16f9b9c81c6"
 	},
 	"devDependencies": {
 		"@parcel/codeframe": "2.16.4",

--- a/scripts/font-shard.ts
+++ b/scripts/font-shard.ts
@@ -66,8 +66,8 @@ export async function branchFontShard({
 	).arrayBuffer();
 
 	return {
-		version: () => fontVersion(new Uint8Array(font)),
-		urls: urls(sha),
+		version: fontVersion(new Uint8Array(font)),
+		urls: () => urls(sha),
 		state: sha,
 	};
 }
@@ -97,8 +97,8 @@ export async function archiveFontShard({
 		createHash('sha256').update(archive).digest('hex');
 
 	return {
-		version: () => fontVersion(readZipEntry(archive, (name) => path.test(name))),
-		urls: [url],
+		version: fontVersion(readZipEntry(archive, (name) => path.test(name))),
+		urls: () => [url],
 		state,
 	};
 }

--- a/scripts/mde-analyzer.ts
+++ b/scripts/mde-analyzer.ts
@@ -32,8 +32,8 @@ export async function analyzerShard(shortLink: string) {
 	// Record where the aka.ms shortlink lands rather than the shortlink itself.
 	// The analyzer is a script package, so one architecture covers it.
 	return {
-		version: () => analyzerVersion(script),
-		urls: [`${response.url}|x64`],
+		version: analyzerVersion(script),
+		urls: () => [`${response.url}|x64`],
 		state,
 		replace: true,
 	};

--- a/scripts/mde-analyzer.ts
+++ b/scripts/mde-analyzer.ts
@@ -33,7 +33,7 @@ export async function analyzerShard(shortLink: string) {
 	// The analyzer is a script package, so one architecture covers it.
 	return {
 		version: analyzerVersion(script),
-		urls: () => [`${response.url}|x64`],
+		urls: () => [{ url: response.url, architecture: 'x64' }],
 		state,
 		replace: true,
 	};

--- a/shards/json/Auslogics.DiskDefragUltimate.json
+++ b/shards/json/Auslogics.DiskDefragUltimate.json
@@ -3,7 +3,10 @@
 	"strategy": "static",
 	"version": "productVersion",
 	"urls": [
-		"https://downloads.auslogics.com/en/disk-defrag-ultimate/auslogics-disk-defrag-ultimate-setup.exe|x86"
+		{
+			"url": "https://downloads.auslogics.com/en/disk-defrag-ultimate/auslogics-disk-defrag-ultimate-setup.exe",
+			"architecture": "x86"
+		}
 	],
 	"state": {
 		"source": "response-header",

--- a/shards/json/CnCNet.RedAlert2YurisRevenge.json
+++ b/shards/json/CnCNet.RedAlert2YurisRevenge.json
@@ -2,7 +2,9 @@
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
 	"strategy": "static",
 	"version": "productVersion",
-	"urls": ["https://downloads.cncnet.org/CnCNet5_YR_Installer.exe|x86"],
+	"urls": [
+		{ "url": "https://downloads.cncnet.org/CnCNet5_YR_Installer.exe", "architecture": "x86" }
+	],
 	"state": {
 		"source": "response-header",
 		"url": "https://downloads.cncnet.org/CnCNet5_YR_Installer.exe",

--- a/shards/json/Composer.WindowsSetup.json
+++ b/shards/json/Composer.WindowsSetup.json
@@ -2,5 +2,5 @@
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
 	"strategy": "github-release",
 	"github": { "owner": "composer", "repo": "windows-setup" },
-	"urls": ["https://getcomposer.org/Composer-Setup.exe|x86"]
+	"urls": [{ "url": "https://getcomposer.org/Composer-Setup.exe", "architecture": "x86" }]
 }

--- a/shards/json/Famatech.AdvancedPortScanner.json
+++ b/shards/json/Famatech.AdvancedPortScanner.json
@@ -6,6 +6,9 @@
 		"regex": "Advanced_Port_Scanner_(\\d+(?:\\.\\d+)+)\\.exe"
 	},
 	"urls": [
-		"https://download.advanced-port-scanner.com/download/files/Advanced_Port_Scanner_{version}.exe|x86"
+		{
+			"url": "https://download.advanced-port-scanner.com/download/files/Advanced_Port_Scanner_{version}.exe",
+			"architecture": "x86"
+		}
 	]
 }

--- a/shards/json/Fortinet.FortiClientVPN.json
+++ b/shards/json/Fortinet.FortiClientVPN.json
@@ -3,8 +3,8 @@
 	"strategy": "static",
 	"version": "productVersion",
 	"urls": [
-		"https://links.fortinet.com/forticlient/win/vpnagent|x86",
-		"https://links.fortinet.com/forticlient/winarm/vpnagent|arm64"
+		{ "url": "https://links.fortinet.com/forticlient/win/vpnagent", "architecture": "x86" },
+		{ "url": "https://links.fortinet.com/forticlient/winarm/vpnagent", "architecture": "arm64" }
 	],
 	"state": {
 		"source": "response-header",

--- a/shards/json/InterstellarResearch.Daqarta.json
+++ b/shards/json/InterstellarResearch.Daqarta.json
@@ -5,6 +5,6 @@
 		"url": "https://www.daqarta.com/",
 		"regex": "Daqarta v(\\d+(?:\\.\\d+)+)"
 	},
-	"urls": ["https://www.daqarta.com/DHsetup.exe|x86"],
+	"urls": [{ "url": "https://www.daqarta.com/DHsetup.exe", "architecture": "x86" }],
 	"replace": true
 }

--- a/shards/json/Microsoft.DotNet.DesktopRuntime.10.x64.json
+++ b/shards/json/Microsoft.DotNet.DesktopRuntime.10.x64.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x64.exe|arm64"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x64.exe",
+			"architecture": "arm64"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.DesktopRuntime.10.x86.json
+++ b/shards/json/Microsoft.DotNet.DesktopRuntime.10.x86.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x86.exe|neutral"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x86.exe",
+			"architecture": "neutral"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.DesktopRuntime.5.x86.json
+++ b/shards/json/Microsoft.DotNet.DesktopRuntime.5.x86.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x86.exe|neutral"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x86.exe",
+			"architecture": "neutral"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.DesktopRuntime.8.x64.json
+++ b/shards/json/Microsoft.DotNet.DesktopRuntime.8.x64.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x64.exe|arm64"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x64.exe",
+			"architecture": "arm64"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.DesktopRuntime.8.x86.json
+++ b/shards/json/Microsoft.DotNet.DesktopRuntime.8.x86.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x86.exe|neutral"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x86.exe",
+			"architecture": "neutral"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.DesktopRuntime.9.x64.json
+++ b/shards/json/Microsoft.DotNet.DesktopRuntime.9.x64.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x64.exe|arm64"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x64.exe",
+			"architecture": "arm64"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.DesktopRuntime.9.x86.json
+++ b/shards/json/Microsoft.DotNet.DesktopRuntime.9.x86.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x86.exe|neutral"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/WindowsDesktop/{version}/windowsdesktop-runtime-{version}-win-x86.exe",
+			"architecture": "neutral"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.Runtime.10.x64.json
+++ b/shards/json/Microsoft.DotNet.Runtime.10.x64.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x64.exe|arm64"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x64.exe",
+			"architecture": "arm64"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.Runtime.10.x86.json
+++ b/shards/json/Microsoft.DotNet.Runtime.10.x86.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x86.exe|neutral"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x86.exe",
+			"architecture": "neutral"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.Runtime.8.x86.json
+++ b/shards/json/Microsoft.DotNet.Runtime.8.x86.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x86.exe|neutral"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x86.exe",
+			"architecture": "neutral"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.Runtime.9.x64.json
+++ b/shards/json/Microsoft.DotNet.Runtime.9.x64.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x64.exe|arm64"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x64.exe",
+			"architecture": "arm64"
+		}
 	]
 }

--- a/shards/json/Microsoft.DotNet.Runtime.9.x86.json
+++ b/shards/json/Microsoft.DotNet.Runtime.9.x86.json
@@ -6,6 +6,9 @@
 		"path": "latest-runtime"
 	},
 	"urls": [
-		"https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x86.exe|neutral"
+		{
+			"url": "https://builds.dotnet.microsoft.com/dotnet/Runtime/{version}/dotnet-runtime-{version}-win-x86.exe",
+			"architecture": "neutral"
+		}
 	]
 }

--- a/shards/json/Microsoft.Intune.ManagementExtension.json
+++ b/shards/json/Microsoft.Intune.ManagementExtension.json
@@ -2,7 +2,12 @@
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
 	"strategy": "static",
 	"version": "displayVersion",
-	"urls": ["https://imeswdc-afd-primary.manage.microsoft.com/IntuneWindowsAgent.msi|x86"],
+	"urls": [
+		{
+			"url": "https://imeswdc-afd-primary.manage.microsoft.com/IntuneWindowsAgent.msi",
+			"architecture": "x86"
+		}
+	],
 	"state": {
 		"source": "response-header",
 		"url": "https://imeswdc-afd-primary.manage.microsoft.com/IntuneWindowsAgent.msi",

--- a/shards/json/Microsoft.vcpkg.json
+++ b/shards/json/Microsoft.vcpkg.json
@@ -3,7 +3,10 @@
 	"strategy": "github-release",
 	"github": { "owner": "microsoft", "repo": "vcpkg-tool" },
 	"urls": [
-		"https://github.com/microsoft/vcpkg-tool/releases/download/{version}/vcpkg.exe|x64",
+		{
+			"url": "https://github.com/microsoft/vcpkg-tool/releases/download/{version}/vcpkg.exe",
+			"architecture": "x64"
+		},
 		"https://github.com/microsoft/vcpkg-tool/releases/download/{version}/vcpkg-arm64.exe"
 	]
 }

--- a/shards/json/ModMii.ModMii.json
+++ b/shards/json/ModMii.ModMii.json
@@ -2,6 +2,11 @@
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
 	"strategy": "github-release",
 	"github": { "owner": "modmii", "repo": "modmii.github.io" },
-	"urls": ["https://github.com/modmii/modmii.github.io/releases/download/{version}/ModMii.zip|x64"],
+	"urls": [
+		{
+			"url": "https://github.com/modmii/modmii.github.io/releases/download/{version}/ModMii.zip",
+			"architecture": "x64"
+		}
+	],
 	"installerMatches": ["ModMii.exe", "ModMiiSkin.exe"]
 }

--- a/shards/json/Mozilla.MozillaBuild.json
+++ b/shards/json/Mozilla.MozillaBuild.json
@@ -6,6 +6,9 @@
 		"regex": "MozillaBuildSetup-(\\d+(?:\\.\\d+)+)\\.exe"
 	},
 	"urls": [
-		"https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-{version}.exe|x64"
+		{
+			"url": "https://ftp.mozilla.org/pub/mozilla/libraries/win32/MozillaBuildSetup-{version}.exe",
+			"architecture": "x64"
+		}
 	]
 }

--- a/shards/json/NirSoft.NirCmd.json
+++ b/shards/json/NirSoft.NirCmd.json
@@ -6,7 +6,7 @@
 		"regex": "<a name=\"verhistory\"><\/a>[\\s\\S]+?<tr><td>[^<]+<td>(\\d+(?:\\.\\d+)+)<td>"
 	},
 	"urls": [
-		"https://www.nirsoft.net/utils/nircmd.zip|x86",
+		{ "url": "https://www.nirsoft.net/utils/nircmd.zip", "architecture": "x86" },
 		"https://www.nirsoft.net/utils/nircmd-x64.zip"
 	],
 	"replace": true

--- a/shards/json/SeriousBit.NetBalancer.json
+++ b/shards/json/SeriousBit.NetBalancer.json
@@ -2,7 +2,9 @@
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
 	"strategy": "static",
 	"version": "productVersion",
-	"urls": ["https://netbalancer.com/downloads/NetBalancerSetup.exe|x64"],
+	"urls": [
+		{ "url": "https://netbalancer.com/downloads/NetBalancerSetup.exe", "architecture": "x64" }
+	],
 	"state": {
 		"source": "response-header",
 		"url": "https://netbalancer.com/downloads/NetBalancerSetup.exe",

--- a/shards/json/SwisslogForWindows.Swisslog.json
+++ b/shards/json/SwisslogForWindows.Swisslog.json
@@ -7,6 +7,9 @@
 	},
 	"version": "{version}.{captures.minor}",
 	"urls": [
-		"https://www.swisslogforwindows.com/Download/SwisslogSetupv{captures.version}{captures.minor}.exe|x86"
+		{
+			"url": "https://www.swisslogforwindows.com/Download/SwisslogSetupv{captures.version}{captures.minor}.exe",
+			"architecture": "x86"
+		}
 	]
 }

--- a/shards/json/laoo.Felix.json
+++ b/shards/json/laoo.Felix.json
@@ -3,7 +3,13 @@
 	"strategy": "github-release",
 	"github": { "owner": "laoo", "repo": "Felix" },
 	"urls": [
-		"https://github.com/laoo/Felix/releases/download/v{version}/Felix.exe|x64",
-		"https://github.com/laoo/Felix/releases/download/v{version}/Felix32.exe|x86"
+		{
+			"url": "https://github.com/laoo/Felix/releases/download/v{version}/Felix.exe",
+			"architecture": "x64"
+		},
+		{
+			"url": "https://github.com/laoo/Felix/releases/download/v{version}/Felix32.exe",
+			"architecture": "x86"
+		}
 	]
 }

--- a/shards/script/Adobe.SourceCodePro.Font.ts
+++ b/shards/script/Adobe.SourceCodePro.Font.ts
@@ -11,6 +11,6 @@ export default defineShard(async () => {
 
 	return {
 		version: firstMatch(release.rawTag, /^(\d+(?:\.\d+)+)R/, 'No version found in release tag'),
-		urls,
+		urls: () => urls,
 	};
 });

--- a/shards/script/Insecure.Nmap.ts
+++ b/shards/script/Insecure.Nmap.ts
@@ -14,6 +14,6 @@ export default defineShard(async () => {
 
 	return {
 		version,
-		urls: () => [`https://nmap.org/dist/nmap-${version}-setup.exe|x86`],
+		urls: () => [{ url: `https://nmap.org/dist/nmap-${version}-setup.exe`, architecture: 'x86' }],
 	};
 });

--- a/shards/script/Insecure.Nmap.ts
+++ b/shards/script/Insecure.Nmap.ts
@@ -14,6 +14,6 @@ export default defineShard(async () => {
 
 	return {
 		version,
-		urls: [`https://nmap.org/dist/nmap-${version}-setup.exe|x86`],
+		urls: () => [`https://nmap.org/dist/nmap-${version}-setup.exe|x86`],
 	};
 });

--- a/shards/script/Insecure.Npcap.ts
+++ b/shards/script/Insecure.Npcap.ts
@@ -14,6 +14,6 @@ export default defineShard(async () => {
 
 	return {
 		version,
-		urls: () => [`https://npcap.com/dist/npcap-${version}.exe|x86`],
+		urls: () => [{ url: `https://npcap.com/dist/npcap-${version}.exe`, architecture: 'x86' }],
 	};
 });

--- a/shards/script/Insecure.Npcap.ts
+++ b/shards/script/Insecure.Npcap.ts
@@ -14,6 +14,6 @@ export default defineShard(async () => {
 
 	return {
 		version,
-		urls: [`https://npcap.com/dist/npcap-${version}.exe|x86`],
+		urls: () => [`https://npcap.com/dist/npcap-${version}.exe|x86`],
 	};
 });

--- a/shards/script/MOJI.IPAFont.Font.ts
+++ b/shards/script/MOJI.IPAFont.Font.ts
@@ -11,6 +11,6 @@ export default defineShard(async () => {
 
 	return {
 		version: `${release.slice(0, 3)}.${release.slice(3)}`,
-		urls: [`https://moji.or.jp/wp-content/ipafont/IPAfont/IPAfont${release}.zip`],
+		urls: () => [`https://moji.or.jp/wp-content/ipafont/IPAfont/IPAfont${release}.zip`],
 	};
 });

--- a/shards/script/Microsoft.DotNet.Framework.Runtime.3.ts
+++ b/shards/script/Microsoft.DotNet.Framework.Runtime.3.ts
@@ -39,7 +39,7 @@ export default defineShard(async () => {
 
 	return {
 		version: `3.5.${latest.kb}`,
-		urls: [
+		urls: () => [
 			firstMatch(dialog, /'(https:\/\/[^']+\.exe)'/i, 'No download URL in the catalog dialog'),
 		],
 		replace: true,

--- a/shards/script/Microsoft.GlobalSecureAccessClient.ts
+++ b/shards/script/Microsoft.GlobalSecureAccessClient.ts
@@ -25,6 +25,9 @@ export default defineShard(async () => {
 			/GlobalSecureAccessInstaller_(\d+(?:\.\d+)+)\.exe$/i,
 			'No version in the resolved installer name',
 		),
-		urls: () => [`${x86}|x86`, `${arm64}|arm64`],
+		urls: () => [
+			{ url: x86, architecture: 'x86' },
+			{ url: arm64, architecture: 'arm64' },
+		],
 	};
 });

--- a/shards/script/Microsoft.GlobalSecureAccessClient.ts
+++ b/shards/script/Microsoft.GlobalSecureAccessClient.ts
@@ -25,6 +25,6 @@ export default defineShard(async () => {
 			/GlobalSecureAccessInstaller_(\d+(?:\.\d+)+)\.exe$/i,
 			'No version in the resolved installer name',
 		),
-		urls: [`${x86}|x86`, `${arm64}|arm64`],
+		urls: () => [`${x86}|x86`, `${arm64}|arm64`],
 	};
 });

--- a/shards/script/Microsoft.WindowsAdvancedSettings.ts
+++ b/shards/script/Microsoft.WindowsAdvancedSettings.ts
@@ -16,6 +16,6 @@ export default defineShard(async () => {
 			/_(\d+(?:\.\d+){2})\.\d+\.msixbundle$/,
 			'No version found in asset name',
 		),
-		urls,
+		urls: () => urls,
 	};
 });

--- a/shards/script/antijingoist.OpenDyslexic.Font.ts
+++ b/shards/script/antijingoist.OpenDyslexic.Font.ts
@@ -15,5 +15,5 @@ export default defineShard(async () => {
 	const urls = release.urls().filter((url) => /\/opendyslexic-[^/]+\.zip$/.test(url));
 	if (urls.length !== 1) throw new Error('Expected exactly one font archive asset');
 
-	return { version: release.version, urls };
+	return { version: release.version, urls: () => urls };
 });

--- a/shards/script/opengribs.XyGrib.ts
+++ b/shards/script/opengribs.XyGrib.ts
@@ -11,5 +11,5 @@ export default defineShard(async () => {
 		.filter((url) => /\/XyGrib_Win_Offline_Installer_[^/]+\.exe$/.test(url));
 	if (urls.length !== 1) throw new Error('Expected exactly one Windows offline installer asset');
 
-	return { version: release.version, urls };
+	return { version: release.version, urls: () => urls };
 });

--- a/shards/script/rbanffy.3270.Font.ts
+++ b/shards/script/rbanffy.3270.Font.ts
@@ -8,5 +8,5 @@ export default defineShard(async () => {
 	const urls = release.urls().filter((url) => /\/3270_fonts_[^/]+\.zip$/.test(url));
 	if (urls.length !== 1) throw new Error('Expected exactly one fonts asset');
 
-	return { version: release.version, urls };
+	return { version: release.version, urls: () => urls };
 });

--- a/shards/script/rubjo.VictorMono.Font.ts
+++ b/shards/script/rubjo.VictorMono.Font.ts
@@ -13,8 +13,8 @@ export default defineShard(async () => {
 	).json<{ version: string }>();
 
 	return {
-		version: () => version,
-		urls: [`https://github.com/rubjo/victor-mono/raw/${sha}/public/VictorMonoAll.zip`],
+		version,
+		urls: () => [`https://github.com/rubjo/victor-mono/raw/${sha}/public/VictorMonoAll.zip`],
 		state: sha,
 	};
 });


### PR DESCRIPTION
Fixes the CI failure on #624 (`fix(deps): update anthelion digest to 55dbf99`). This branch carries that Renovate commit plus the shard changes the new digest needs, so it can be merged in its place.

Two breaking changes come with `55dbf99`.

**1. Script shard result schema** ([`dist/script-shard.d.ts`](https://github.com/UnownPlain/anthelion-external/compare/fc5452e0bdd0885b60b3e6eafe332f1c3567bc2e..55dbf99d99b0ec4910e955846d3ab16f9b9c81c6))

- `urls` is now always a zero-argument function anthelion calls lazily (`z.function({ input: [], output: z.unknown() })`), where it used to accept an array *or* a function.
- `version` no longer accepts a callback — it is a string or a `{ source }` object, and the old "lazy version + required `state`" variant is gone.
- `defineShard` now takes an async shard and rejects excess properties.

All 38 script shards failed `bun lint --deny-warnings` on the new digest, and each would also have failed to parse at runtime: against the new schema, an array `urls` reports `expected function, received array` and a callback `version` reports `Invalid input`.

Wrapped every `urls` array in `() => …`, and evaluated the deferred versions eagerly in `branchFontShard`, `archiveFontShard` (`scripts/font-shard.ts`), `analyzerShard` (`scripts/mde-analyzer.ts`) and `rubjo.VictorMono.Font.ts`. All four already downloaded their bytes before returning, so only the name-table / `$ScriptVer` parsing moves earlier; the `state` short-circuit that skips unchanged packages is unaffected.

**2. `url|architecture` suffixes are gone**

The digest pulls in `@unownplain/anthelion-komac` 0.0.52, which replaces the old `urls: Array<string>` (documented in 0.0.51 as *may include "|architecture" suffix*) with `InstallerSource`, whose `url` is documented as a URL *"without an encoded architecture suffix"*. A suffixed URL is now percent-encoded and fails to download — the first CI run on this branch caught it on `Insecure.Nmap`, `Insecure.Npcap` and `Microsoft.GlobalSecureAccessClient`:

```
[ANALYSIS_FAILED] Failed to download installer https://nmap.org/dist/nmap-7.99-setup.exe%7Cx86
```

Switched every suffixed URL to the `{ url, architecture }` form the shard schema already accepts — 3 script shards, `scripts/mde-analyzer.ts`, and the 26 JSON shards using the suffix. The JSON shards are not covered by the Test job unless they change, so they would have broken silently in the scheduled update runs. Placeholder resolution and `resolveDataBackedUrls` both handle the object form, so `{version}`-templated URLs are unaffected.

`bun lint --deny-warnings`, `bun fmt --check`, `bun manifests:check` and `bun test:manifests` all pass locally against `55dbf99`.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - N/A — this is a dependency migration in this repo's shard code.

Manifests

- [ ] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

No manifests change in this PR — it only touches the shards that generate future ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)