### PR TITLE
chore(linter): use anthelion-komac's YAML parser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -15,7 +15,6 @@
         "oxfmt": "0.60.0",
         "oxlint": "1.75.0",
         "oxlint-tsgolint": "7.0.2001",
-        "yaml": "2.9.0",
       },
     },
   },
@@ -289,8 +288,6 @@
     "universal-github-app-jwt": ["universal-github-app-jwt@2.2.2", "", {}, "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="],
 
     "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
-
-    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 		"json-schema-to-dts": "2.0.1",
 		"oxfmt": "0.60.0",
 		"oxlint": "1.75.0",
-		"oxlint-tsgolint": "7.0.2001",
-		"yaml": "2.9.0"
+		"oxlint-tsgolint": "7.0.2001"
 	}
 }

--- a/scripts/manifest-linter/README.md
+++ b/scripts/manifest-linter/README.md
@@ -7,10 +7,6 @@ The linter has three layers:
 - `cli.ts` and `reporter.ts` handle command-line arguments and terminal output.
 - `generate-manifest-types.ts` builds the generated TypeScript declarations and schema validators.
 
-Valid manifests use Bun's native YAML parser. Inputs with duplicate keys or complex
-mapping syntax fall back to the full YAML parser, which preserves strict parsing and
-detailed error ranges without imposing its cost on the normal path.
-
 When `GITHUB_ACTIONS=true`, the reporter emits GitHub error and warning annotations in
 addition to its normal terminal code frames.
 

--- a/scripts/manifest-linter/linter.ts
+++ b/scripts/manifest-linter/linter.ts
@@ -67,13 +67,12 @@ async function loadFileModes(entries: RepositoryEntry[]): Promise<void> {
 	);
 }
 
-async function parseSources(
+function parseSources(
 	sources: ManifestSource[],
 	parseNonUtf8: boolean,
 	report: (diagnostic: ReportedDiagnostic) => void,
-): Promise<ManifestRecord[]> {
+): ManifestRecord[] {
 	const records: Array<ManifestRecord | undefined> = Array.from({ length: sources.length });
-	const pending: Promise<void>[] = [];
 	for (const [index, source] of sources.entries()) {
 		// In check mode, stop after the encoding error. Fix mode can safely validate
 		// the decoded text and combine encoding and content fixes in one pass.
@@ -81,15 +80,8 @@ async function parseSources(
 			continue;
 		}
 		const result = parseManifest(source.file, source.raw, report);
-		if (result instanceof Promise) {
-			pending.push(
-				result.then((manifest) => {
-					if (manifest) records[index] = { ...source, manifest };
-				}),
-			);
-		} else if (result) records[index] = { ...source, manifest: result };
+		if (result) records[index] = { ...source, manifest: result };
 	}
-	await Promise.all(pending);
 	return records.filter((record) => record !== undefined);
 }
 
@@ -138,7 +130,7 @@ export async function lintManifests(options: LintOptions = {}): Promise<LintResu
 			level: diagnostic.level ?? 'error',
 		});
 	};
-	const records = await parseSources(manifestSources, options.fix ?? false, report);
+	const records = parseSources(manifestSources, options.fix ?? false, report);
 
 	for (const rule of options.rules ?? defaultRules) {
 		activeRuleId = rule.id;

--- a/scripts/manifest-linter/parser.test.ts
+++ b/scripts/manifest-linter/parser.test.ts
@@ -11,20 +11,20 @@ ManifestType: version
 ManifestVersion: 1.28.0
 `;
 
-async function parse(raw: string): Promise<{
-	manifest: Awaited<ReturnType<typeof parseManifest>>;
+function parse(raw: string): {
+	manifest: ReturnType<typeof parseManifest>;
 	diagnostics: ReportedDiagnostic[];
-}> {
+} {
 	const diagnostics: ReportedDiagnostic[] = [];
-	const manifest = await parseManifest('manifest.yaml', raw, (diagnostic) => {
+	const manifest = parseManifest('manifest.yaml', raw, (diagnostic) => {
 		diagnostics.push(diagnostic);
 	});
 	return { manifest, diagnostics };
 }
 
 describe('manifest parser', () => {
-	test('parses and validates a manifest on the native fast path', async () => {
-		const result = await parse(VALID_VERSION_MANIFEST);
+	test('parses and validates a manifest with Anthelion Komac', () => {
+		const result = parse(VALID_VERSION_MANIFEST);
 		expect(result.diagnostics).toEqual([]);
 		expect(result.manifest).toMatchObject({
 			PackageIdentifier: 'Example.Package',
@@ -33,8 +33,8 @@ describe('manifest parser', () => {
 		});
 	});
 
-	test('retains detailed source ranges for invalid YAML', async () => {
-		const result = await parse(
+	test('retains detailed source ranges for invalid YAML', () => {
+		const result = parse(
 			VALID_VERSION_MANIFEST.replace(
 				'PackageVersion:',
 				'PackageIdentifier: Duplicate\nPackageVersion:',
@@ -42,12 +42,23 @@ describe('manifest parser', () => {
 		);
 		expect(result.manifest).toBeUndefined();
 		expect(result.diagnostics).toHaveLength(1);
-		expect(result.diagnostics[0]?.message).toStartWith('invalid YAML: Map keys must be unique');
+		expect(result.diagnostics[0]?.message).toBe(
+			'invalid YAML: duplicate mapping key: PackageIdentifier, set DuplicateKeyPolicy in Options if acceptable',
+		);
+		expect(result.diagnostics[0]?.message).not.toContain('\n');
 		expect(result.diagnostics[0]?.location?.start.line).toBeGreaterThan(1);
 	});
 
-	test('continues to report schema errors after native parsing', async () => {
-		const result = await parse(`${VALID_VERSION_MANIFEST}Unexpected: true\n`);
+	test('reports syntax errors without embedding a second code frame', () => {
+		const result = parse(`${VALID_VERSION_MANIFEST}invalid\n`);
+		expect(result.manifest).toBeUndefined();
+		expect(result.diagnostics).toHaveLength(1);
+		expect(result.diagnostics[0]?.message).toBe("invalid YAML: simple key expected ':'");
+		expect(result.diagnostics[0]?.message).not.toContain('<input>');
+	});
+
+	test('continues to report schema errors after parsing', () => {
+		const result = parse(`${VALID_VERSION_MANIFEST}Unexpected: true\n`);
 		expect(result.manifest).toBeUndefined();
 		expect(result.diagnostics).toContainEqual({
 			file: 'manifest.yaml',

--- a/scripts/manifest-linter/parser.ts
+++ b/scripts/manifest-linter/parser.ts
@@ -1,75 +1,22 @@
+import { parseYaml } from '@unownplain/anthelion-komac';
+
 import type { WingetManifest } from '@/scripts/manifest-linter/generated/manifest-types';
 import { formatSchemaError, getSchemaValidator } from '@/scripts/manifest-linter/schema';
 import type { ReportedDiagnostic } from '@/scripts/manifest-linter/types';
 
 type ParseResult = WingetManifest | undefined;
-type MappingFrame = { indent: number; keys: Set<string> };
 
-const SIMPLE_KEY = /^([A-Za-z][A-Za-z0-9]*):(?:\s|$)/;
-const BLOCK_SCALAR = /^[|>](?:[+-]?\d?|\d?[+-]?)(?:\s|$)/;
-const QUOTED_KEY = /^(?:"(?:[^"\\]|\\.)*"|'(?:[^']|'')*')\s*:/;
+type YamlParseError = Error & {
+	location?: {
+		start: { line: number; column: number };
+		end: { line: number; column: number };
+	};
+};
 
-/**
- * Bun's native parser intentionally accepts duplicate mapping keys. Detect the
- * simple block mappings used by manifests, and route complex mapping syntax to
- * the full parser. Repeated keys in separate sequence items remain independent.
- */
-function requiresDetailedParser(raw: string): boolean {
-	const frames: MappingFrame[] = [];
-	let blockScalarIndent: number | undefined;
-
-	for (const line of raw.split(/\r?\n/)) {
-		if (!line.trim() || line.trimStart().startsWith('#')) continue;
-		const indent = line.length - line.trimStart().length;
-		if (blockScalarIndent !== undefined) {
-			if (indent > blockScalarIndent) continue;
-			blockScalarIndent = undefined;
-		}
-
-		let mappingIndent = indent;
-		let candidate = line.slice(indent);
-		const sequenceItem = candidate.startsWith('- ');
-		if (sequenceItem) {
-			mappingIndent += 2;
-			candidate = candidate.slice(2);
-		}
-
-		// Quoted/explicit keys and flow mappings are uncommon in manifests. Let the
-		// detailed parser handle them so the fast path never changes their semantics.
-		if (
-			candidate.startsWith('? ') ||
-			QUOTED_KEY.test(candidate) ||
-			candidate.startsWith('{') ||
-			/:\s*\{/.test(candidate)
-		) {
-			return true;
-		}
-
-		while (
-			frames.length &&
-			(frames.at(-1)!.indent > mappingIndent ||
-				(sequenceItem && frames.at(-1)!.indent === mappingIndent))
-		) {
-			frames.pop();
-		}
-
-		const match = SIMPLE_KEY.exec(candidate);
-		if (!match) continue;
-		let frame = frames.at(-1);
-		if (!frame || frame.indent !== mappingIndent) {
-			frame = { indent: mappingIndent, keys: new Set() };
-			frames.push(frame);
-		}
-
-		const key = match[1]!;
-		if (frame.keys.has(key)) return true;
-		frame.keys.add(key);
-		if (BLOCK_SCALAR.test(candidate.slice(match[0].length).trimStart())) {
-			blockScalarIndent = mappingIndent;
-		}
-	}
-
-	return false;
+function formatYamlParseError(error: unknown): string {
+	if (!(error instanceof Error)) return String(error);
+	const firstLine = error.message.split(/\r?\n/, 1)[0] ?? error.message;
+	return /^error: line \d+ column \d+: (.*)$/.exec(firstLine)?.[1] ?? firstLine;
 }
 
 function validateManifest(
@@ -99,48 +46,22 @@ function validateManifest(
 	return parsed as WingetManifest;
 }
 
-async function parseWithDetailedErrors(
-	file: string,
-	raw: string,
-	report: (diagnostic: ReportedDiagnostic) => void,
-): Promise<ParseResult> {
-	try {
-		const { LineCounter, parseDocument } = await import('yaml');
-		const lineCounter = new LineCounter();
-		const document = parseDocument(raw, { lineCounter, prettyErrors: false });
-		for (const error of document.errors) {
-			const start = lineCounter.linePos(error.pos[0]);
-			const end = lineCounter.linePos(Math.max(error.pos[1] - 1, error.pos[0]));
-			report({
-				file,
-				message: `invalid YAML: ${error.message}`,
-				location: {
-					start: { line: start.line, column: start.col },
-					end: { line: end.line, column: end.col },
-				},
-			});
-		}
-		if (document.errors.length) return;
-		return validateManifest(file, document.toJS(), report);
-	} catch (error) {
-		report({
-			file,
-			message: `invalid YAML: ${error instanceof Error ? error.message : String(error)}`,
-		});
-	}
-}
-
 export function parseManifest(
 	file: string,
 	raw: string,
 	report: (diagnostic: ReportedDiagnostic) => void,
-): ParseResult | Promise<ParseResult> {
-	if (requiresDetailedParser(raw)) return parseWithDetailedErrors(file, raw, report);
+): ParseResult {
+	let parsed: unknown;
 	try {
-		return validateManifest(file, Bun.YAML.parse(raw), report);
-	} catch {
-		// Keep valid manifests on Bun's native parser. Load the full parser only
-		// when needed so invalid YAML still gets an exact source range.
-		return parseWithDetailedErrors(file, raw, report);
+		parsed = parseYaml(raw);
+	} catch (error) {
+		const yamlError = error as YamlParseError;
+		report({
+			file,
+			message: `invalid YAML: ${formatYamlParseError(error)}`,
+			location: yamlError.location,
+		});
+		return;
 	}
+	return validateManifest(file, parsed, report);
 }

--- a/scripts/manifest-linter/rules/repository/manifest-set.test.ts
+++ b/scripts/manifest-linter/rules/repository/manifest-set.test.ts
@@ -50,6 +50,17 @@ describe('manifest set rule', () => {
 		);
 	});
 
+	test('does not report missing members when a source failed to parse', async () => {
+		const version = record('version');
+		const installer = record('installer');
+		const defaultLocale = record('defaultLocale');
+		const issues = await checkRule(manifestSetRule, {
+			records: [version, defaultLocale],
+			sources: [version, installer, defaultLocale],
+		});
+		expect(issues).toEqual([]);
+	});
+
 	test('validates locale uniqueness and the declared default locale', async () => {
 		const version = manifest('version');
 		if (version.ManifestType === 'version') version.DefaultLocale = 'fr-FR';

--- a/scripts/manifest-linter/rules/repository/manifest-set.ts
+++ b/scripts/manifest-linter/rules/repository/manifest-set.ts
@@ -19,10 +19,14 @@ function groupByDirectory(records: ManifestRecord[]): ManifestRecord[][] {
 
 export const manifestSetRule = defineRule({
 	id: 'repository/manifest-set',
-	check({ records, report }) {
+	check({ records, sources, report }) {
+		const parsedFiles = new Set(records.map((record) => record.file));
+		const invalidDirectories = new Set(
+			sources.filter((source) => !parsedFiles.has(source.file)).map((source) => source.directory),
+		);
 		for (const members of groupByDirectory(records)) {
 			const firstMember = members.at(0);
-			if (!firstMember) continue;
+			if (!firstMember || invalidDirectories.has(firstMember.directory)) continue;
 			const versionManifests = members.filter(
 				(member) => member.manifest.ManifestType === 'version',
 			);


### PR DESCRIPTION
Replaces Bun.YAML and yaml with anthelion-komac's YAML parser so we don't need 2 different parsers. Anthelion komac's implementation is just a pretty much just a wrapper around the https://github.com/bourumir-wyngs/serde-saphyr and https://github.com/bourumir-wyngs/granit-parser libraries already used to generate and parse manifests so YAML conformance should be identical serde-saphyr.