### PR TITLE
chore: enable automerge in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -3,6 +3,10 @@
 	"extends": ["github>pl4nty/.github"],
 	"packageRules": [
 		{
+			"matchUpdateTypes": ["patch", "minor", "digest"],
+			"automerge": true
+		},
+		{
 			"matchManagers": "github-actions",
 			"minimumReleaseAge": "7 days"
 		},

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   automerge:
     name: Auto-merge
-    if: contains(fromJSON('["winget-extras-bot[bot]", "renovate[bot]"]'), github.event.pull_request.user.login) && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.user.login == 'winget-extras-bot[bot]' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-slim
     timeout-minutes: 1
     steps:


### PR DESCRIPTION
Renovate has native support for automerge so we don't need to configure a workflow for it.