### PR TITLE
New package: GameJolt.GameJolt version 1.39.4

### DIFF
--- a/manifests/g/GameJolt/GameJolt/1.39.4/GameJolt.GameJolt.installer.yaml
+++ b/manifests/g/GameJolt/GameJolt/1.39.4/GameJolt.GameJolt.installer.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: GameJolt.GameJolt
+PackageVersion: 1.39.4
+InstallerType: inno
+Installers:
+- Architecture: x86
+  InstallerUrl: https://winget.tplant.com.au/download/g/GameJolt/GameJolt/1.39.4/gamejoltclientsetup.exe
+  InstallerSha256: C411AB8F5242D7FB3A53B7ACCBA26A80159E7016F027CE9DE3D8ADC38FF5A496
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/g/GameJolt/GameJolt/1.39.4/GameJolt.GameJolt.locale.en.yaml
+++ b/manifests/g/GameJolt/GameJolt/1.39.4/GameJolt.GameJolt.locale.en.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: GameJolt.GameJolt
+PackageVersion: 1.39.4
+PackageLocale: en
+Publisher: Game Jolt Inc.
+PackageName: Game Jolt Desktop App
+PackageUrl: https://gamejolt.com/app
+License: Freeware
+ShortDescription: The client launcher of the videogame storefront Game Jolt.
+Moniker: gamejolt
+Tags:
+- game-jolt-client
+- gamejoltclient
+- game-jolt-launcher
+- gamejoltlauncher
+- game-jolt-desktop-app
+- gamejoltdesktopapp
+- game-launcher
+- gamelauncher
+- game-client
+- gameclient
+- games-storefront
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/g/GameJolt/GameJolt/1.39.4/GameJolt.GameJolt.yaml
+++ b/manifests/g/GameJolt/GameJolt/1.39.4/GameJolt.GameJolt.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: GameJolt.GameJolt
+PackageVersion: 1.39.4
+DefaultLocale: en
+ManifestType: version
+ManifestVersion: 1.28.0

--- a/shards/json/GameJolt.GameJolt.json.disabled
+++ b/shards/json/GameJolt.GameJolt.json.disabled
@@ -1,0 +1,1 @@
+selfhosted, download.gamejolt.net only serves signed URLs that expire after 24h


### PR DESCRIPTION
Re-adds `GameJolt.GameJolt` 1.39.4, removed in #652, pointing the installer at the repository's self-hosted download.

cc @DandelionSprout 