### PR TITLE
ci: resolve zizmor code scanning findings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,7 @@ jobs:
     needs: merge
     runs-on: windows-2025
     permissions:
-      id-token: write
+      id-token: write # Required for azure/login to request an OIDC token.
     defaults:
       run:
         shell: pwsh
@@ -125,8 +125,11 @@ jobs:
 
       - name: Publish source
         working-directory: index
-        run: rclone sync cache r2:winget-extras/cache --checksum --fast-list ${{ github.ref != 'refs/heads/main' && '--dry-run' || '' }}
+        run: |
+          $extraArgs = if ($env:DRY_RUN -eq 'true') { @('--dry-run') } else { @() }
+          rclone sync cache r2:winget-extras/cache --checksum --fast-list $extraArgs
         env:
+          DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           RCLONE_CONFIG_R2_TYPE: s3

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -94,6 +94,11 @@ jobs:
       fail-fast: false
       matrix:
         installer: ${{ fromJSON(needs.detect.outputs.installers) }}
+    # Keyed by matrix entry as well as ref, so a new run cancels only the stale
+    # run of the same installer rather than the sibling matrix jobs.
+    concurrency:
+      group: validate-install-${{ github.event.pull_request.number || github.ref }}-${{ matrix.installer.path }}-${{ matrix.installer.arch }}-${{ matrix.installer.scope }}-${{ matrix.installer.type }}
+      cancel-in-progress: true
     defaults:
       run:
         shell: pwsh


### PR DESCRIPTION
Clears the three open code scanning alerts on `main`, all from the `zizmor` category (`zizmor . --pedantic`). `actionlint` was already clean.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - N/A — CI/workflow change only, no upstream winget-pkgs counterpart.

Manifests

N/A — this PR touches no manifests, only `.github/workflows/`.

## Changes

**`template-injection` — `publish.yml:128` (low)**

The rclone dry-run flag was built by expanding `github.ref` straight into the `run:` block:

```yaml
run: rclone sync cache r2:winget-extras/cache --checksum --fast-list ${{ github.ref != 'refs/heads/main' && '--dry-run' || '' }}
```

Now passed through a `DRY_RUN` env var and assembled in PowerShell, so no template expansion reaches the shell.

One subtlety worth flagging for review: the array must be expanded as `$extraArgs`, **not** splatted as `@extraArgs`. For native commands the splat form expands the string character by character — I verified this under pwsh 7.4:

```
@extraArgs → ['--fast-list', '-', '-', 'd', 'r', 'y', '-', 'r', 'u', 'n']
$extraArgs → ['--fast-list', '--dry-run']
```

**`undocumented-permissions` — `publish.yml:57` (low)**

Added an explanatory comment for `id-token: write` (needed by `azure/login` to request an OIDC token), matching the existing style in `ci.yml`/`lint-actions.yml`.

**`concurrency-limits` — `validate.yml` (low)**

The Installation Validation job had no concurrency limit. Added a job-level group following the pattern already used by the `detect` job. The group is keyed by matrix entry as well as ref, since a ref-only group with `cancel-in-progress: true` would make sibling matrix jobs cancel each other.

## Verification

Ran both scanners locally at the pinned versions from `mise.toml` (zizmor 1.28.0, actionlint 1.7.12), with the same flags and ignores as `lint-actions.yml`:

```
zizmor:     No findings to report. Good job! (1 ignored, 2 suppressed)
actionlint: clean (exit 0)
```

The `1 ignored, 2 suppressed` counts are unchanged from before this PR.

Also verified the rebuilt rclone argument list matches the original semantics exactly in both branches:

```
DRY_RUN=true  → sync cache r2:winget-extras/cache --checksum --fast-list --dry-run
DRY_RUN=false → sync cache r2:winget-extras/cache --checksum --fast-list
```

**Caveat:** zizmor's *online* audits (`impostor-commit`, `known-vulnerable-actions`, etc.) could not run in my environment — they need GitHub API access to third-party action repos, which this session isn't scoped for. If any open alerts came from those audits, they aren't covered here. The three findings above are everything the offline audits report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vq8EgsKAyQJhPbgkfsQasT

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vq8EgsKAyQJhPbgkfsQasT)_