### PR TITLE
ci: retry PSGallery module installs in validation

### DIFF
--- a/.github/workflows/install-module.ps1
+++ b/.github/workflows/install-module.ps1
@@ -1,0 +1,30 @@
+param(
+    [Parameter(Mandatory)][string]$Name,
+    [int]$Attempts = 5
+)
+
+# PSGallery's search API intermittently returns no results, which surfaces as
+# "No match was found for the specified search criteria and module name '<name>'"
+# and fails the whole job. Retry with backoff instead.
+for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
+    if (Get-Module -ListAvailable -Name $Name) { return }
+
+    try {
+        Install-Module $Name -Force -ErrorAction Stop
+        # Install-Package can report the failure as a non-terminating error, so
+        # confirm the module actually landed rather than trusting the exit path.
+        if (Get-Module -ListAvailable -Name $Name) { return }
+        throw "Install-Module reported success but '$Name' is not available"
+    }
+    catch {
+        if ($attempt -eq $Attempts) { throw }
+        Write-Host "::warning::Failed to install '$Name' (attempt $attempt/$Attempts): $($_.Exception.Message)"
+
+        # An unregistered PSGallery produces the same error as a transient search
+        # failure, so restore the default repositories before retrying.
+        if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+            Register-PSRepository -Default -ErrorAction SilentlyContinue
+        }
+        Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
+    }
+}

--- a/.github/workflows/install-module.ps1
+++ b/.github/workflows/install-module.ps1
@@ -3,28 +3,20 @@ param(
     [int]$Attempts = 5
 )
 
-# PSGallery's search API intermittently returns no results, which surfaces as
-# "No match was found for the specified search criteria and module name '<name>'"
-# and fails the whole job. Retry with backoff instead.
+# PSGallery intermittently can't find modules, from either a transient search
+# failure or a dropped repository registration. Both report "No match was found".
 for ($attempt = 1; $attempt -le $Attempts; $attempt++) {
     if (Get-Module -ListAvailable -Name $Name) { return }
-
     try {
         Install-Module $Name -Force -ErrorAction Stop
-        # Install-Package can report the failure as a non-terminating error, so
-        # confirm the module actually landed rather than trusting the exit path.
-        if (Get-Module -ListAvailable -Name $Name) { return }
-        throw "Install-Module reported success but '$Name' is not available"
     }
     catch {
         if ($attempt -eq $Attempts) { throw }
         Write-Host "::warning::Failed to install '$Name' (attempt $attempt/$Attempts): $($_.Exception.Message)"
-
-        # An unregistered PSGallery produces the same error as a transient search
-        # failure, so restore the default repositories before retrying.
         if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
             Register-PSRepository -Default -ErrorAction SilentlyContinue
         }
         Start-Sleep -Seconds ([Math]::Pow(2, $attempt))
     }
 }
+if (-not (Get-Module -ListAvailable -Name $Name)) { throw "Failed to install '$Name'" }

--- a/.github/workflows/validate.ps1
+++ b/.github/workflows/validate.ps1
@@ -14,7 +14,7 @@ function New-Screenshot([string]$Path) {
     $bmp.Save($Path); $gfx.Dispose(); $bmp.Dispose()
 }
 
-Install-Module powershell-yaml -Force
+& "$PSScriptRoot\install-module.ps1" -Name powershell-yaml
 
 $artifacts = "$env:RUNNER_TEMP\artifacts"
 New-Item $artifacts -ItemType Directory -Force | Out-Null

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -151,8 +151,6 @@ jobs:
           INSTALLER_TYPE: ${{ matrix.installer.type }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # An early Validate failure leaves the working directory uncreated, so the
-      # step would fail too and bury the real error.
       - name: Print logs
         if: always() && steps.validate.outputs.artifact_name
         working-directory: ${{ runner.temp }}\artifacts

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -151,8 +151,8 @@ jobs:
           INSTALLER_TYPE: ${{ matrix.installer.type }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      # Skipped when Validate fails before naming the artifact, since the logs
-      # can't exist yet and the working directory wouldn't either.
+      # An early Validate failure leaves the working directory uncreated, so the
+      # step would fail too and bury the real error.
       - name: Print logs
         if: always() && steps.validate.outputs.artifact_name
         working-directory: ${{ runner.temp }}\artifacts

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,7 +54,7 @@ jobs:
           VERSION: ${{ inputs.version || (github.event_name == 'schedule' && '5.2509.1065.1000' || '') }}
           CHANGED: ${{ steps.changed.outputs.all_changed_files }}
         run: |
-          Install-Module powershell-yaml -Force
+          ./.github/workflows/install-module.ps1 -Name powershell-yaml
           $packages = @(if ($env:PACKAGE_ID) {
             $relativePath = "$($env:PACKAGE_ID.Substring(0,1).ToLower())/$($env:PACKAGE_ID -replace '\.', '/')/$($env:VERSION)"
             if (Test-Path "fonts/$relativePath") { "fonts/$relativePath" } else { "manifests/$relativePath" }
@@ -108,6 +108,7 @@ jobs:
           persist-credentials: false
           sparse-checkout: |
             .github/workflows/validate.ps1
+            .github/workflows/install-module.ps1
             .github/workflows/analyses.json
             ${{ matrix.installer.path }}
 
@@ -150,11 +151,13 @@ jobs:
           INSTALLER_TYPE: ${{ matrix.installer.type }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      # Skipped when Validate fails before naming the artifact, since the logs
+      # can't exist yet and the working directory wouldn't either.
       - name: Print logs
-        if: always()
+        if: always() && steps.validate.outputs.artifact_name
         working-directory: ${{ runner.temp }}\artifacts
         run: |
-          Get-ChildItem "$env:STEPS_VALIDATE_OUTPUTS_ARTIFACT_NAME-*.log", "$env:STEPS_VALIDATE_OUTPUTS_ARTIFACT_NAME-installer.log" -Recurse -File | select -Unique | ForEach-Object {
+          Get-ChildItem "$env:STEPS_VALIDATE_OUTPUTS_ARTIFACT_NAME-*.log", "$env:STEPS_VALIDATE_OUTPUTS_ARTIFACT_NAME-installer.log" -Recurse -File -ErrorAction SilentlyContinue | select -Unique | ForEach-Object {
             Write-Host "::group::$($_.Name)"
             Get-Content $_
             Write-Host "::endgroup::"


### PR DESCRIPTION
## Problem

Validation intermittently fails at the very first line of `validate.ps1`:

```
Install-Package: No match was found for the specified search criteria and module name 'powershell-yaml'.
Try Get-PSRepository to see all available registered module repositories.
##[error]Process completed with exit code 1.
```

Seen in [run 30772777917](https://github.com/pl4nty/winget-extras/actions/runs/30772777917/job/91563424470?pr=709) (`ryanoasis.Hurmit` 3.5.0). The job dies before installing anything, so the failure says nothing about the manifest under test.

Two things produce that identical message: a transient PSGallery search-API failure, and PSGallery not being registered on the runner. Neither was retried.

A second, cosmetic failure followed: `Print logs` has `working-directory: ${{ runner.temp }}\artifacts`, but `validate.ps1` creates that directory *after* the module install. When the install failed, the directory didn't exist, so the step failed too with `The directory name is invalid` — burying the real error behind a second red X.

## Changes

- **New `.github/workflows/install-module.ps1`** — installs a PSGallery module with up to 5 attempts and exponential backoff. It short-circuits if the module is already present, verifies the module actually landed rather than trusting `Install-Module`'s exit path (the underlying `Install-Package` failure is non-terminating), and re-registers the default repositories between attempts to cover the unregistered-PSGallery case.
- **`validate.ps1`** — calls the helper instead of `Install-Module powershell-yaml -Force`.
- **`validate.yml`** — same swap in the `detect` job's matrix builder, which had the identical unguarded call; adds the helper to the validate job's `sparse-checkout`.
- **`validate.yml`** — `Print logs` is now skipped when `Validate` fails before setting an artifact name, so a failing install surfaces one error instead of two.

## Verification

Ran against PowerShell 7.5.4 locally:

- **Reproduced the CI error** with a non-existent module: the helper emits a warning per attempt, backs off, and rethrows the original message on the last attempt.
- **Unregistered PSGallery**, then ran the helper — attempt 1 failed with exactly the CI message, the helper re-registered the repository, and attempt 2 installed successfully.
- **Happy path** — installs `powershell-yaml` 0.4.12; a second call short-circuits in 3 ms; `ConvertFrom-Yaml` then parses an installer manifest correctly, so `validate.ps1` and the `detect` job behave as before.
- Both `.ps1` files parse cleanly via `[Parser]::ParseFile`, and `validate.yml` parses as valid YAML with the new `if:` on the correct step.

## Notes on the PR template

The repo's PR template covers manifest submissions (`winget validate --manifest`, schema conformance, duplicate manifest PRs). This PR changes CI workflows only and touches no manifests, so those items don't apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BBDsT8eoyNPDHP1uFHLsVd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BBDsT8eoyNPDHP1uFHLsVd)_