### PR TITLE
ryanoasis.D2Coding: move to ryanoasis.D2Koding

### DIFF
--- a/fonts/r/ryanoasis/D2Koding/3.4.0/ryanoasis.D2Koding.installer.yaml
+++ b/fonts/r/ryanoasis/D2Koding/3.4.0/ryanoasis.D2Koding.installer.yaml
@@ -1,7 +1,7 @@
 # Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
-PackageIdentifier: ryanoasis.D2Coding
+PackageIdentifier: ryanoasis.D2Koding
 PackageVersion: 3.4.0
 InstallerType: zip
 NestedInstallerType: font

--- a/fonts/r/ryanoasis/D2Koding/3.4.0/ryanoasis.D2Koding.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/D2Koding/3.4.0/ryanoasis.D2Koding.locale.en-US.yaml
@@ -1,14 +1,14 @@
 # Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
-PackageIdentifier: ryanoasis.D2Coding
+PackageIdentifier: ryanoasis.D2Koding
 PackageVersion: 3.4.0
 PackageLocale: en-US
 Publisher: ryanoasis
 PublisherUrl: https://www.nerdfonts.com/
 PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
 Author: Ryan L McIntyre
-PackageName: D2Coding Nerd Font
+PackageName: D2Koding Nerd Font (D2Coding)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
@@ -16,7 +16,7 @@ Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A fixed-width font optimized for coding and character distinction.
 Description: D2 Coding is a fixed-width font optimized for coding, readability, and distinction between similar Latin, Hangul, numeric, and symbol characters.
-Moniker: d2coding-nerd-font
+Moniker: d2koding-nerd-font
 Tags:
 - font
 - font-awesome

--- a/fonts/r/ryanoasis/D2Koding/3.4.0/ryanoasis.D2Koding.yaml
+++ b/fonts/r/ryanoasis/D2Koding/3.4.0/ryanoasis.D2Koding.yaml
@@ -1,7 +1,7 @@
 # Created with komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
-PackageIdentifier: ryanoasis.D2Coding
+PackageIdentifier: ryanoasis.D2Koding
 PackageVersion: 3.4.0
 DefaultLocale: en-US
 ManifestType: version

--- a/fonts/r/ryanoasis/D2Koding/3.5.0/ryanoasis.D2Koding.installer.yaml
+++ b/fonts/r/ryanoasis/D2Koding/3.5.0/ryanoasis.D2Koding.installer.yaml
@@ -1,7 +1,7 @@
 # Created by Anthelion using komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
 
-PackageIdentifier: ryanoasis.D2Coding
+PackageIdentifier: ryanoasis.D2Koding
 PackageVersion: 3.5.0
 InstallerType: zip
 NestedInstallerType: font

--- a/fonts/r/ryanoasis/D2Koding/3.5.0/ryanoasis.D2Koding.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/D2Koding/3.5.0/ryanoasis.D2Koding.locale.en-US.yaml
@@ -1,14 +1,14 @@
 # Created by Anthelion using komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
 
-PackageIdentifier: ryanoasis.D2Coding
+PackageIdentifier: ryanoasis.D2Koding
 PackageVersion: 3.5.0
 PackageLocale: en-US
 Publisher: ryanoasis
 PublisherUrl: https://www.nerdfonts.com/
 PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
 Author: Ryan L McIntyre
-PackageName: D2Coding Nerd Font
+PackageName: D2Koding Nerd Font (D2Coding)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
@@ -16,7 +16,7 @@ Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A fixed-width font optimized for coding and character distinction.
 Description: D2 Coding is a fixed-width font optimized for coding, readability, and distinction between similar Latin, Hangul, numeric, and symbol characters.
-Moniker: d2coding-nerd-font
+Moniker: d2koding-nerd-font
 Tags:
 - font
 - font-awesome

--- a/fonts/r/ryanoasis/D2Koding/3.5.0/ryanoasis.D2Koding.yaml
+++ b/fonts/r/ryanoasis/D2Koding/3.5.0/ryanoasis.D2Koding.yaml
@@ -1,7 +1,7 @@
 # Created by Anthelion using komac v2.16.0
 # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
 
-PackageIdentifier: ryanoasis.D2Coding
+PackageIdentifier: ryanoasis.D2Koding
 PackageVersion: 3.5.0
 DefaultLocale: en-US
 ManifestType: version


### PR DESCRIPTION
Renamed upstream to comply with OFL-1.1-RFN

https://github.com/ryanoasis/nerd-fonts/releases/tag/v3.5.0