### PR TITLE
feat(linter): add copyright format linter rule

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,14 +33,18 @@ jobs:
         with:
           persist-credentials: false
 
+      # Only an installer manifest decides what gets installed, so a change to
+      # locale text or a version manifest cannot alter the result of a run. The
+      # filter keeps those out of the matrix, which also holds a repository-wide
+      # metadata change under the 256 job limit a matrix expands to.
       - name: Get changed manifests
         id: changed
         if: github.event_name == 'pull_request'
         uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: |
-            manifests/**/*.yaml
-            fonts/**/*.yaml
+            manifests/**/*.installer.yaml
+            fonts/**/*.installer.yaml
           dir_names: true
           json: true
           escape_json: false

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,10 +33,6 @@ jobs:
         with:
           persist-credentials: false
 
-      # Only an installer manifest decides what gets installed, so a change to
-      # locale text or a version manifest cannot alter the result of a run. The
-      # filter keeps those out of the matrix, which also holds a repository-wide
-      # metadata change under the 256 job limit a matrix expands to.
       - name: Get changed manifests
         id: changed
         if: github.event_name == 'pull_request'

--- a/fonts/0/0xType/0xProto/2.500/0xType.0xProto.locale.en-US.yaml
+++ b/fonts/0/0xType/0xProto/2.500/0xType.0xProto.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: 0xProto
 PackageUrl: https://github.com/0xType/0xProto
 License: OFL-1.1
 LicenseUrl: https://github.com/0xType/0xProto/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2024, 0xType Project Authors (https://github.com/0xType)
+Copyright: © 2024 0xType Project Authors (https://github.com/0xType)
 CopyrightUrl: https://github.com/0xType/0xProto/blob/HEAD/LICENSE
 ShortDescription: A programming font focused on source code legibility
 Description: |-

--- a/fonts/0/0xType/0xProto/2.500/0xType.0xProto.locale.en-US.yaml
+++ b/fonts/0/0xType/0xProto/2.500/0xType.0xProto.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: 0xProto
 PackageUrl: https://github.com/0xType/0xProto
 License: OFL-1.1
 LicenseUrl: https://github.com/0xType/0xProto/blob/HEAD/LICENSE
-Copyright: © 2024 0xType Project Authors (https://github.com/0xType)
+Copyright: © 2024 0xType Project Authors (https://github.com/0xType).
 CopyrightUrl: https://github.com/0xType/0xProto/blob/HEAD/LICENSE
 ShortDescription: A programming font focused on source code legibility
 Description: |-

--- a/fonts/0/0xType/0xProto/2.502/0xType.0xProto.locale.en-US.yaml
+++ b/fonts/0/0xType/0xProto/2.502/0xType.0xProto.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: 0xProto
 PackageUrl: https://github.com/0xType/0xProto
 License: OFL-1.1
 LicenseUrl: https://github.com/0xType/0xProto/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2024, 0xType Project Authors (https://github.com/0xType)
+Copyright: © 2024 0xType Project Authors (https://github.com/0xType)
 CopyrightUrl: https://github.com/0xType/0xProto/blob/HEAD/LICENSE
 ShortDescription: A programming font focused on source code legibility
 Description: |-

--- a/fonts/0/0xType/0xProto/2.502/0xType.0xProto.locale.en-US.yaml
+++ b/fonts/0/0xType/0xProto/2.502/0xType.0xProto.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: 0xProto
 PackageUrl: https://github.com/0xType/0xProto
 License: OFL-1.1
 LicenseUrl: https://github.com/0xType/0xProto/blob/HEAD/LICENSE
-Copyright: © 2024 0xType Project Authors (https://github.com/0xType)
+Copyright: © 2024 0xType Project Authors (https://github.com/0xType).
 CopyrightUrl: https://github.com/0xType/0xProto/blob/HEAD/LICENSE
 ShortDescription: A programming font focused on source code legibility
 Description: |-

--- a/fonts/a/Adobe/SourceCodePro/2.042/Adobe.SourceCodePro.locale.en-US.yaml
+++ b/fonts/a/Adobe/SourceCodePro/2.042/Adobe.SourceCodePro.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: Source Code Pro
 PackageUrl: https://github.com/adobe-fonts/source-code-pro
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/adobe-fonts/source-code-pro/blob/HEAD/LICENSE.md
-Copyright: © 2023 Adobe (http://www.adobe.com/)
+Copyright: © 2023 Adobe (http://www.adobe.com/).
 CopyrightUrl: https://github.com/adobe-fonts/source-code-pro/blob/HEAD/LICENSE.md
 ShortDescription: Monospaced font family for user interface and coding environments.
 Moniker: source-code-pro

--- a/fonts/a/AndreBerg/MesloLG/1.21.1/AndreBerg.MesloLG.locale.en-US.yaml
+++ b/fonts/a/AndreBerg/MesloLG/1.21.1/AndreBerg.MesloLG.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Meslo LG
 PackageUrl: https://github.com/andreberg/Meslo-Font
 License: Apache-2.0
 LicenseUrl: https://github.com/andreberg/Meslo-Font/blob/HEAD/README.textile#license
-Copyright: Copyright 2009, 2010, 2013 André Berg
+Copyright: © 2009, 2010, 2013 André Berg
 CopyrightUrl: https://github.com/andreberg/Meslo-Font/blob/HEAD/README.textile#license
 ShortDescription: Meslo LG is a customized version of Apple's Menlo-Regular font (which is a customized Bitstream Vera Sans Mono).
 Moniker: meslo-lg

--- a/fonts/a/AndreBerg/MesloLG/1.21.1/AndreBerg.MesloLG.locale.en-US.yaml
+++ b/fonts/a/AndreBerg/MesloLG/1.21.1/AndreBerg.MesloLG.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Meslo LG
 PackageUrl: https://github.com/andreberg/Meslo-Font
 License: Apache-2.0
 LicenseUrl: https://github.com/andreberg/Meslo-Font/blob/HEAD/README.textile#license
-Copyright: © 2009, 2010, 2013 André Berg
+Copyright: © 2009, 2010, 2013 André Berg.
 CopyrightUrl: https://github.com/andreberg/Meslo-Font/blob/HEAD/README.textile#license
 ShortDescription: Meslo LG is a customized version of Apple's Menlo-Regular font (which is a customized Bitstream Vera Sans Mono).
 Moniker: meslo-lg

--- a/fonts/a/AndreBerg/MesloLG/DZ/1.21.1/AndreBerg.MesloLG.DZ.locale.en-US.yaml
+++ b/fonts/a/AndreBerg/MesloLG/DZ/1.21.1/AndreBerg.MesloLG.DZ.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Meslo LG DZ
 PackageUrl: https://github.com/andreberg/Meslo-Font
 License: Apache-2.0
 LicenseUrl: https://github.com/andreberg/Meslo-Font/blob/HEAD/README.textile#license
-Copyright: Copyright 2009, 2010, 2013 André Berg
+Copyright: © 2009, 2010, 2013 André Berg
 CopyrightUrl: https://github.com/andreberg/Meslo-Font/blob/HEAD/README.textile#license
 ShortDescription: Meslo LG is a customized version of Apple's Menlo-Regular font (which is a customized Bitstream Vera Sans Mono).
 Moniker: meslo-lg-dz

--- a/fonts/a/AndreBerg/MesloLG/DZ/1.21.1/AndreBerg.MesloLG.DZ.locale.en-US.yaml
+++ b/fonts/a/AndreBerg/MesloLG/DZ/1.21.1/AndreBerg.MesloLG.DZ.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Meslo LG DZ
 PackageUrl: https://github.com/andreberg/Meslo-Font
 License: Apache-2.0
 LicenseUrl: https://github.com/andreberg/Meslo-Font/blob/HEAD/README.textile#license
-Copyright: © 2009, 2010, 2013 André Berg
+Copyright: © 2009, 2010, 2013 André Berg.
 CopyrightUrl: https://github.com/andreberg/Meslo-Font/blob/HEAD/README.textile#license
 ShortDescription: Meslo LG is a customized version of Apple's Menlo-Regular font (which is a customized Bitstream Vera Sans Mono).
 Moniker: meslo-lg-dz

--- a/fonts/a/ArrowType/Recursive/1.085/ArrowType.Recursive.locale.en-US.yaml
+++ b/fonts/a/ArrowType/Recursive/1.085/ArrowType.Recursive.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Recursive
 PackageUrl: https://recursive.design/
 License: OFL-1.1
 LicenseUrl: https://github.com/arrowtype/recursive/blob/HEAD/OFL.txt
-Copyright: © 2020 The Recursive Project Authors (https://github.com/arrowtype/recursive)
+Copyright: © 2020 The Recursive Project Authors (https://github.com/arrowtype/recursive).
 CopyrightUrl: https://github.com/arrowtype/recursive/blob/HEAD/OFL.txt
 ShortDescription: A variable type family for code and user interfaces.
 Description: Recursive Sans and Mono is a variable type family with multiple mono styles, inspired by casual script signpainting.

--- a/fonts/a/ArrowType/Recursive/1.085/ArrowType.Recursive.locale.en-US.yaml
+++ b/fonts/a/ArrowType/Recursive/1.085/ArrowType.Recursive.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Recursive
 PackageUrl: https://recursive.design/
 License: OFL-1.1
 LicenseUrl: https://github.com/arrowtype/recursive/blob/HEAD/OFL.txt
-Copyright: Copyright 2020 The Recursive Project Authors (https://github.com/arrowtype/recursive)
+Copyright: © 2020 The Recursive Project Authors (https://github.com/arrowtype/recursive)
 CopyrightUrl: https://github.com/arrowtype/recursive/blob/HEAD/OFL.txt
 ShortDescription: A variable type family for code and user interfaces.
 Description: Recursive Sans and Mono is a variable type family with multiple mono styles, inspired by casual script signpainting.

--- a/fonts/a/antijingoist/OpenDyslexic/0.91.12/antijingoist.OpenDyslexic.locale.en-US.yaml
+++ b/fonts/a/antijingoist/OpenDyslexic/0.91.12/antijingoist.OpenDyslexic.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: OpenDyslexic
 PackageUrl: https://opendyslexic.org/
 License: OFL-1.1-RFN
 LicenseUrl: https://forge.hackers.town/antijingoist/opendyslexic/src/branch/HEAD/OFL.txt
-Copyright: Copyright (c) 2019-07-29, Abbie Gonzalez (https://abbiecod.es|support@abbiecod.es), with Reserved Font Name OpenDyslexic.
+Copyright: © 2019-07-29 Abbie Gonzalez (https://abbiecod.es|support@abbiecod.es), with Reserved Font Name OpenDyslexic.
 CopyrightUrl: https://forge.hackers.town/antijingoist/opendyslexic/src/branch/HEAD/OFL.txt
 ShortDescription: OpenDyslexic is a typeface designed against some common symptoms of dyslexia.
 Description: |-

--- a/fonts/a/atelierAnchor/SmileySans/OTF/2.0.1/atelierAnchor.SmileySans.OTF.locale.en-US.yaml
+++ b/fonts/a/atelierAnchor/SmileySans/OTF/2.0.1/atelierAnchor.SmileySans.OTF.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Smiley Sans (OTF)
 PackageUrl: https://atelier-anchor.com/typefaces/smiley-sans
 License: OFL-1.1
 LicenseUrl: https://github.com/atelier-anchor/smiley-sans/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2022--2024, atelierAnchor <https://atelier-anchor.com>, with Reserved Font Name <Smiley> and <得意黑>.
+Copyright: © 2022--2024 atelierAnchor <https://atelier-anchor.com>, with Reserved Font Name <Smiley> and <得意黑>.
 ShortDescription: A condensed and oblique Chinese typeface seeking a visual balance between the humanist and the geometric.
 Description: Smiley Sans is a Chinese sans-serif typeface seeking a visual balance between the humanist and the geometric. The overall character shape is narrow and slightly slanted, with details incorporating special forms inspired by hand-drawn display lettering. The font supports commonly used Simplified Chinese characters (covering GB/T 2312-1980 character set and the "General Standard Chinese Characters" list), Latin, Cyrillic, and Greek letters, Japanese kana, Arabic numerals, and various punctuation marks.
 Moniker: smiley-sans-otf

--- a/fonts/a/atelierAnchor/SmileySans/TTF/2.0.1/atelierAnchor.SmileySans.TTF.locale.en-US.yaml
+++ b/fonts/a/atelierAnchor/SmileySans/TTF/2.0.1/atelierAnchor.SmileySans.TTF.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Smiley Sans (TTF)
 PackageUrl: https://atelier-anchor.com/typefaces/smiley-sans
 License: OFL-1.1
 LicenseUrl: https://github.com/atelier-anchor/smiley-sans/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2022--2024, atelierAnchor <https://atelier-anchor.com>, with Reserved Font Name <Smiley> and <得意黑>.
+Copyright: © 2022--2024 atelierAnchor <https://atelier-anchor.com>, with Reserved Font Name <Smiley> and <得意黑>.
 ShortDescription: A condensed and oblique Chinese typeface seeking a visual balance between the humanist and the geometric.
 Description: Smiley Sans is a Chinese sans-serif typeface seeking a visual balance between the humanist and the geometric. The overall character shape is narrow and slightly slanted, with details incorporating special forms inspired by hand-drawn display lettering. The font supports commonly used Simplified Chinese characters (covering GB/T 2312-1980 character set and the "General Standard Chinese Characters" list), Latin, Cyrillic, and Greek letters, Japanese kana, Arabic numerals, and various punctuation marks.
 Moniker: smiley-sans-ttf

--- a/fonts/b/Bitstream/Vera/1.10/Bitstream.Vera.locale.en-US.yaml
+++ b/fonts/b/Bitstream/Vera/1.10/Bitstream.Vera.locale.en-US.yaml
@@ -9,7 +9,7 @@ Author: Bitstream Inc.
 PackageName: Bitstream Vera
 PackageUrl: https://web.archive.org/web/20210314185159/https://www.gnome.org/fonts/
 License: Bitstream-Vera
-Copyright: Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
+Copyright: © 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
 ShortDescription: A digital typeface superfamily with generous open-source licensing
 Description: Bitstream Vera is a comprehensive digital typeface superfamily designed by Jim Lyles at Bitstream Inc., featuring serif, sans-serif, and monospace font families. Released in 2003 with liberal open-source licensing terms, it provides full TrueType hinting instructions for improved rendering on low-resolution displays. The monospace variant is particularly well-suited for technical work, clearly distinguishing similar characters like lowercase "l" from "1" and "0" from "O". Bitstream Vera Sans is also the default font for the Python Matplotlib library.
 Moniker: bitstream-vera

--- a/fonts/b/BrailleInstitute/AtkinsonHyperlegible/2020-0514/BrailleInstitute.AtkinsonHyperlegible.locale.en-US.yaml
+++ b/fonts/b/BrailleInstitute/AtkinsonHyperlegible/2020-0514/BrailleInstitute.AtkinsonHyperlegible.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: Atkinson Hyperlegible
 PackageUrl: https://www.brailleinstitute.org/freefont/
 License: OFL-1.1
 LicenseUrl: https://www.brailleinstitute.org/freefont/
-Copyright: Copyright 2020 Braille Institute of America, Inc.
+Copyright: © 2020 Braille Institute of America, Inc.
 ShortDescription: Typeface designed to improve legibility for readers with low vision.
 Description: Atkinson Hyperlegible prioritizes character distinction for readers with low vision through unambiguous letterforms, distinct similar characters, open counters, and differentiated spurs and tails.
 Moniker: atkinson-hyperlegible

--- a/fonts/b/be5invis/Iosevka/33.3.1/be5invis.Iosevka.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/33.3.1/be5invis.Iosevka.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/b/be5invis/Iosevka/33.3.1/be5invis.Iosevka.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/33.3.1/be5invis.Iosevka.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/b/be5invis/Iosevka/34.7.0/be5invis.Iosevka.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/34.7.0/be5invis.Iosevka.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/b/be5invis/Iosevka/34.7.0/be5invis.Iosevka.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/34.7.0/be5invis.Iosevka.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/b/be5invis/Iosevka/34.8.0/be5invis.Iosevka.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/34.8.0/be5invis.Iosevka.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/b/be5invis/Iosevka/34.8.0/be5invis.Iosevka.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/34.8.0/be5invis.Iosevka.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/b/be5invis/Iosevka/Aile/34.7.0/be5invis.Iosevka.Aile.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Aile/34.7.0/be5invis.Iosevka.Aile.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Aile
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Aile is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Aile/34.7.0/be5invis.Iosevka.Aile.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Aile/34.7.0/be5invis.Iosevka.Aile.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Aile
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Aile is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Aile/34.8.0/be5invis.Iosevka.Aile.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Aile/34.8.0/be5invis.Iosevka.Aile.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Aile
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Aile is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Aile/34.8.0/be5invis.Iosevka.Aile.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Aile/34.8.0/be5invis.Iosevka.Aile.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Aile
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Aile is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Curly/34.7.0/be5invis.Iosevka.Curly.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Curly/34.7.0/be5invis.Iosevka.Curly.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Curly
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Curly is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Curly/34.7.0/be5invis.Iosevka.Curly.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Curly/34.7.0/be5invis.Iosevka.Curly.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Curly
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Curly is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Curly/34.8.0/be5invis.Iosevka.Curly.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Curly/34.8.0/be5invis.Iosevka.Curly.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Curly
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Curly is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Curly/34.8.0/be5invis.Iosevka.Curly.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Curly/34.8.0/be5invis.Iosevka.Curly.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Curly
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Curly is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Curly/Slab/34.7.0/be5invis.Iosevka.Curly.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Curly/Slab/34.7.0/be5invis.Iosevka.Curly.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Curly Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Curly Slab is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Curly/Slab/34.7.0/be5invis.Iosevka.Curly.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Curly/Slab/34.7.0/be5invis.Iosevka.Curly.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Curly Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Curly Slab is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Curly/Slab/34.8.0/be5invis.Iosevka.Curly.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Curly/Slab/34.8.0/be5invis.Iosevka.Curly.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Curly Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Curly Slab is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Curly/Slab/34.8.0/be5invis.Iosevka.Curly.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Curly/Slab/34.8.0/be5invis.Iosevka.Curly.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Curly Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Curly Slab is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Etoile/34.7.0/be5invis.Iosevka.Etoile.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Etoile/34.7.0/be5invis.Iosevka.Etoile.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Etoile
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Etoile is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Etoile/34.7.0/be5invis.Iosevka.Etoile.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Etoile/34.7.0/be5invis.Iosevka.Etoile.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Etoile
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Etoile is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Etoile/34.8.0/be5invis.Iosevka.Etoile.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Etoile/34.8.0/be5invis.Iosevka.Etoile.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Etoile
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Etoile is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Etoile/34.8.0/be5invis.Iosevka.Etoile.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Etoile/34.8.0/be5invis.Iosevka.Etoile.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Etoile
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Etoile is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS03/34.7.0/be5invis.Iosevka.SS03.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS03/34.7.0/be5invis.Iosevka.SS03.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS03
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS03 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS03/34.7.0/be5invis.Iosevka.SS03.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS03/34.7.0/be5invis.Iosevka.SS03.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS03
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS03 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS03/34.8.0/be5invis.Iosevka.SS03.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS03/34.8.0/be5invis.Iosevka.SS03.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS03
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS03 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS03/34.8.0/be5invis.Iosevka.SS03.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS03/34.8.0/be5invis.Iosevka.SS03.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS03
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS03 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS04/34.7.0/be5invis.Iosevka.SS04.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS04/34.7.0/be5invis.Iosevka.SS04.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS04
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS04 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS04/34.7.0/be5invis.Iosevka.SS04.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS04/34.7.0/be5invis.Iosevka.SS04.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS04
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS04 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS04/34.8.0/be5invis.Iosevka.SS04.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS04/34.8.0/be5invis.Iosevka.SS04.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS04
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS04 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS04/34.8.0/be5invis.Iosevka.SS04.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS04/34.8.0/be5invis.Iosevka.SS04.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS04
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS04 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS05/34.7.0/be5invis.Iosevka.SS05.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS05/34.7.0/be5invis.Iosevka.SS05.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS05
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS05 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS05/34.7.0/be5invis.Iosevka.SS05.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS05/34.7.0/be5invis.Iosevka.SS05.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS05
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS05 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS05/34.8.0/be5invis.Iosevka.SS05.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS05/34.8.0/be5invis.Iosevka.SS05.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS05
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS05 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS05/34.8.0/be5invis.Iosevka.SS05.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS05/34.8.0/be5invis.Iosevka.SS05.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS05
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS05 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS07/34.7.0/be5invis.Iosevka.SS07.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS07/34.7.0/be5invis.Iosevka.SS07.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS07
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS07 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS07/34.7.0/be5invis.Iosevka.SS07.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS07/34.7.0/be5invis.Iosevka.SS07.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS07
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS07 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS07/34.8.0/be5invis.Iosevka.SS07.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS07/34.8.0/be5invis.Iosevka.SS07.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS07
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS07 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS07/34.8.0/be5invis.Iosevka.SS07.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS07/34.8.0/be5invis.Iosevka.SS07.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS07
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS07 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS08/34.7.0/be5invis.Iosevka.SS08.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS08/34.7.0/be5invis.Iosevka.SS08.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS08
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS08 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS08/34.7.0/be5invis.Iosevka.SS08.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS08/34.7.0/be5invis.Iosevka.SS08.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS08
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS08 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS08/34.8.0/be5invis.Iosevka.SS08.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS08/34.8.0/be5invis.Iosevka.SS08.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS08
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS08 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS08/34.8.0/be5invis.Iosevka.SS08.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS08/34.8.0/be5invis.Iosevka.SS08.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS08
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS08 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS09/34.7.0/be5invis.Iosevka.SS09.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS09/34.7.0/be5invis.Iosevka.SS09.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS09
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS09 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS09/34.7.0/be5invis.Iosevka.SS09.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS09/34.7.0/be5invis.Iosevka.SS09.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS09
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS09 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS09/34.8.0/be5invis.Iosevka.SS09.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS09/34.8.0/be5invis.Iosevka.SS09.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS09
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS09 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS09/34.8.0/be5invis.Iosevka.SS09.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS09/34.8.0/be5invis.Iosevka.SS09.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS09
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS09 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS12/34.7.0/be5invis.Iosevka.SS12.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS12/34.7.0/be5invis.Iosevka.SS12.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS12
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS12 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS12/34.7.0/be5invis.Iosevka.SS12.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS12/34.7.0/be5invis.Iosevka.SS12.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS12
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS12 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS12/34.8.0/be5invis.Iosevka.SS12.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS12/34.8.0/be5invis.Iosevka.SS12.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS12
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS12 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS12/34.8.0/be5invis.Iosevka.SS12.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS12/34.8.0/be5invis.Iosevka.SS12.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS12
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS12 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS14/34.7.0/be5invis.Iosevka.SS14.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS14/34.7.0/be5invis.Iosevka.SS14.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS14
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS14 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS14/34.7.0/be5invis.Iosevka.SS14.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS14/34.7.0/be5invis.Iosevka.SS14.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS14
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS14 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS14/34.8.0/be5invis.Iosevka.SS14.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS14/34.8.0/be5invis.Iosevka.SS14.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS14
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS14 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS14/34.8.0/be5invis.Iosevka.SS14.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS14/34.8.0/be5invis.Iosevka.SS14.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS14
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS14 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS15/34.7.0/be5invis.Iosevka.SS15.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS15/34.7.0/be5invis.Iosevka.SS15.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS15
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS15 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS15/34.7.0/be5invis.Iosevka.SS15.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS15/34.7.0/be5invis.Iosevka.SS15.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS15
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS15 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS15/34.8.0/be5invis.Iosevka.SS15.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS15/34.8.0/be5invis.Iosevka.SS15.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS15
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS15 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS15/34.8.0/be5invis.Iosevka.SS15.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS15/34.8.0/be5invis.Iosevka.SS15.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS15
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS15 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS16/34.7.0/be5invis.Iosevka.SS16.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS16/34.7.0/be5invis.Iosevka.SS16.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS16
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS16 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS16/34.7.0/be5invis.Iosevka.SS16.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS16/34.7.0/be5invis.Iosevka.SS16.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS16
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS16 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS16/34.8.0/be5invis.Iosevka.SS16.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS16/34.8.0/be5invis.Iosevka.SS16.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS16
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS16 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/SS16/34.8.0/be5invis.Iosevka.SS16.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/SS16/34.8.0/be5invis.Iosevka.SS16.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka SS16
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka SS16 is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Slab/34.7.0/be5invis.Iosevka.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Slab/34.7.0/be5invis.Iosevka.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Slab is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Slab/34.7.0/be5invis.Iosevka.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Slab/34.7.0/be5invis.Iosevka.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Slab is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Slab/34.8.0/be5invis.Iosevka.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Slab/34.8.0/be5invis.Iosevka.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Slab is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Slab/34.8.0/be5invis.Iosevka.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Slab/34.8.0/be5invis.Iosevka.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka Slab is a variant of Iosevka, a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono. Its family is divided into sub-families for different uses and stylistic choices.

--- a/fonts/b/be5invis/Iosevka/Term/Slab/34.4.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Term/Slab/34.4.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: A slab-serif terminal variant of Iosevka.
 Description: Iosevka Term Slab is a slab-serif terminal variant of Iosevka designed for code and terminal use.

--- a/fonts/b/be5invis/Iosevka/Term/Slab/34.4.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Term/Slab/34.4.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: A slab-serif terminal variant of Iosevka.
 Description: Iosevka Term Slab is a slab-serif terminal variant of Iosevka designed for code and terminal use.

--- a/fonts/b/be5invis/Iosevka/Term/Slab/34.7.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Term/Slab/34.7.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: A slab-serif terminal variant of Iosevka.
 Description: Iosevka Term Slab is a slab-serif terminal variant of Iosevka designed for code and terminal use.

--- a/fonts/b/be5invis/Iosevka/Term/Slab/34.7.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Term/Slab/34.7.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: A slab-serif terminal variant of Iosevka.
 Description: Iosevka Term Slab is a slab-serif terminal variant of Iosevka designed for code and terminal use.

--- a/fonts/b/be5invis/Iosevka/Term/Slab/34.8.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Term/Slab/34.8.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: Copyright (c) 2015-2026, Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: A slab-serif terminal variant of Iosevka.
 Description: Iosevka Term Slab is a slab-serif terminal variant of Iosevka designed for code and terminal use.

--- a/fonts/b/be5invis/Iosevka/Term/Slab/34.8.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
+++ b/fonts/b/be5invis/Iosevka/Term/Slab/34.8.0/be5invis.Iosevka.Term.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Slab
 PackageUrl: https://typeof.net/Iosevka/
 License: OFL-1.1
 LicenseUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
-Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net)
+Copyright: © 2015-2026 Renzhi Li (aka. Belleve Invis, belleve@typeof.net).
 CopyrightUrl: https://github.com/be5invis/Iosevka/blob/HEAD/LICENSE.md
 ShortDescription: A slab-serif terminal variant of Iosevka.
 Description: Iosevka Term Slab is a slab-serif terminal variant of Iosevka designed for code and terminal use.

--- a/fonts/b/belluzj/FantasqueSansMono/1.8.0/belluzj.FantasqueSansMono.locale.en-US.yaml
+++ b/fonts/b/belluzj/FantasqueSansMono/1.8.0/belluzj.FantasqueSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fantasque Sans Mono
 PackageUrl: https://belluzj.github.io/projects/design/fantasquesansmono-font
 License: OFL-1.1
 LicenseUrl: https://github.com/belluzj/fantasque-sans/blob/HEAD/LICENSE.txt
-Copyright: Copyright (c) 2013-2017, Jany Belluz (jany.belluz@hotmail.fr)
+Copyright: © 2013-2017 Jany Belluz (jany.belluz@hotmail.fr)
 CopyrightUrl: https://github.com/belluzj/fantasque-sans/blob/HEAD/LICENSE.txt
 ShortDescription: A programming font with handwriting-like fuzziness
 Description: A programming font designed with functionality in mind, featuring wibbly-wobbly handwriting-like fuzziness that makes it unassumingly cool. Includes bold and italic variants with the same metrics, extensive glyph coverage including Latin letters, accented glyphs, Greek letters, and arrows. Inspirational sources include Inconsolata, Monaco, and Consolas.

--- a/fonts/b/belluzj/FantasqueSansMono/1.8.0/belluzj.FantasqueSansMono.locale.en-US.yaml
+++ b/fonts/b/belluzj/FantasqueSansMono/1.8.0/belluzj.FantasqueSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fantasque Sans Mono
 PackageUrl: https://belluzj.github.io/projects/design/fantasquesansmono-font
 License: OFL-1.1
 LicenseUrl: https://github.com/belluzj/fantasque-sans/blob/HEAD/LICENSE.txt
-Copyright: © 2013-2017 Jany Belluz (jany.belluz@hotmail.fr)
+Copyright: © 2013-2017 Jany Belluz (jany.belluz@hotmail.fr).
 CopyrightUrl: https://github.com/belluzj/fantasque-sans/blob/HEAD/LICENSE.txt
 ShortDescription: A programming font with handwriting-like fuzziness
 Description: A programming font designed with functionality in mind, featuring wibbly-wobbly handwriting-like fuzziness that makes it unassumingly cool. Includes bold and italic variants with the same metrics, extensive glyph coverage including Latin letters, accented glyphs, Greek letters, and arrows. Inspirational sources include Inconsolata, Monaco, and Consolas.

--- a/fonts/b/blobject/Agave/37/blobject.Agave.locale.en-US.yaml
+++ b/fonts/b/blobject/Agave/37/blobject.Agave.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Agave
 PackageUrl: https://b.agaric.net/page/agave
 License: MIT
 LicenseUrl: https://github.com/blobject/agave/blob/HEAD/LICENSE
-Copyright: © 2013-2021 type agaric <agaric@protonmail.com>
+Copyright: © 2013-2021 type agaric <agaric@protonmail.com>.
 CopyrightUrl: https://github.com/blobject/agave/blob/HEAD/LICENSE
 ShortDescription: A small, monospaced, outline font that is geometrically regular and simple
 Description: Agave is a fixed-width outline typeface designed for programming and terminal use. It features a simple, geometrically regular design based on the power of two and golden ratio principles. The font supports over 2,400 glyphs including ASCII, Latin extended, Greek, Cyrillic, IPA, mathematical symbols, arrows, box-drawing characters, Braille, and Powerline symbols.

--- a/fonts/b/blobject/Agave/37/blobject.Agave.locale.en-US.yaml
+++ b/fonts/b/blobject/Agave/37/blobject.Agave.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Agave
 PackageUrl: https://b.agaric.net/page/agave
 License: MIT
 LicenseUrl: https://github.com/blobject/agave/blob/HEAD/LICENSE
-Copyright: (c) 2013-2021, type agaric <agaric@protonmail.com>
+Copyright: © 2013-2021 type agaric <agaric@protonmail.com>
 CopyrightUrl: https://github.com/blobject/agave/blob/HEAD/LICENSE
 ShortDescription: A small, monospaced, outline font that is geometrically regular and simple
 Description: Agave is a fixed-width outline typeface designed for programming and terminal use. It features a simple, geometrically regular design based on the power of two and golden ratio principles. The font supports over 2,400 glyphs including ASCII, Latin extended, Greek, Cyrillic, IPA, mathematical symbols, arrows, box-drawing characters, Braille, and Powerline symbols.

--- a/fonts/b/blobject/Agave/38/blobject.Agave.locale.en-US.yaml
+++ b/fonts/b/blobject/Agave/38/blobject.Agave.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Agave
 PackageUrl: https://b.agaric.net/page/agave
 License: MIT
 LicenseUrl: https://github.com/blobject/agave/blob/HEAD/LICENSE
-Copyright: © 2013-2021 type agaric <agaric@protonmail.com>
+Copyright: © 2013-2021 type agaric <agaric@protonmail.com>.
 CopyrightUrl: https://github.com/blobject/agave/blob/HEAD/LICENSE
 ShortDescription: A small, monospaced, outline font that is geometrically regular and simple
 Description: Agave is a fixed-width outline typeface designed for programming and terminal use. It features a simple, geometrically regular design based on the power of two and golden ratio principles. The font supports over 2,400 glyphs including ASCII, Latin extended, Greek, Cyrillic, IPA, mathematical symbols, arrows, box-drawing characters, Braille, and Powerline symbols.

--- a/fonts/b/blobject/Agave/38/blobject.Agave.locale.en-US.yaml
+++ b/fonts/b/blobject/Agave/38/blobject.Agave.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Agave
 PackageUrl: https://b.agaric.net/page/agave
 License: MIT
 LicenseUrl: https://github.com/blobject/agave/blob/HEAD/LICENSE
-Copyright: (c) 2013-2021, type agaric <agaric@protonmail.com>
+Copyright: © 2013-2021 type agaric <agaric@protonmail.com>
 CopyrightUrl: https://github.com/blobject/agave/blob/HEAD/LICENSE
 ShortDescription: A small, monospaced, outline font that is geometrically regular and simple
 Description: Agave is a fixed-width outline typeface designed for programming and terminal use. It features a simple, geometrically regular design based on the power of two and golden ratio principles. The font supports over 2,400 glyphs including ASCII, Latin extended, Greek, Cyrillic, IPA, mathematical symbols, arrows, box-drawing characters, Braille, and Powerline symbols.

--- a/fonts/c/Canonical/UbuntuFont/0.83/Canonical.UbuntuFont.locale.en-US.yaml
+++ b/fonts/c/Canonical/UbuntuFont/0.83/Canonical.UbuntuFont.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: Ubuntu Font Family
 PackageUrl: https://design.ubuntu.com/font
 License: Ubuntu-font-1.0
 LicenseUrl: https://www.ubuntu.com/legal/terms-and-policies/font-licence
-Copyright: Copyright (c), The Ubuntu Font Family Project Authors (https://launchpad.net/ubuntu-font-family)
+Copyright: © The Ubuntu Font Family Project Authors (https://launchpad.net/ubuntu-font-family)
 CopyrightUrl: https://www.ubuntu.com/legal/terms-and-policies/font-licence
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/c/Canonical/UbuntuFont/0.83/Canonical.UbuntuFont.locale.en-US.yaml
+++ b/fonts/c/Canonical/UbuntuFont/0.83/Canonical.UbuntuFont.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: Ubuntu Font Family
 PackageUrl: https://design.ubuntu.com/font
 License: Ubuntu-font-1.0
 LicenseUrl: https://www.ubuntu.com/legal/terms-and-policies/font-licence
-Copyright: © The Ubuntu Font Family Project Authors (https://launchpad.net/ubuntu-font-family)
+Copyright: © The Ubuntu Font Family Project Authors (https://launchpad.net/ubuntu-font-family).
 CopyrightUrl: https://www.ubuntu.com/legal/terms-and-policies/font-licence
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/c/Canonical/UbuntuFont/Mono/0.83/Canonical.UbuntuFont.Mono.locale.en-US.yaml
+++ b/fonts/c/Canonical/UbuntuFont/Mono/0.83/Canonical.UbuntuFont.Mono.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: Ubuntu Font Family (Mono)
 PackageUrl: https://design.ubuntu.com/font
 License: Ubuntu-font-1.0
 LicenseUrl: https://www.ubuntu.com/legal/terms-and-policies/font-licence
-Copyright: Copyright (c), The Ubuntu Font Family Project Authors (https://launchpad.net/ubuntu-font-family)
+Copyright: © The Ubuntu Font Family Project Authors (https://launchpad.net/ubuntu-font-family)
 CopyrightUrl: https://www.ubuntu.com/legal/terms-and-policies/font-licence
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/c/Canonical/UbuntuFont/Mono/0.83/Canonical.UbuntuFont.Mono.locale.en-US.yaml
+++ b/fonts/c/Canonical/UbuntuFont/Mono/0.83/Canonical.UbuntuFont.Mono.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: Ubuntu Font Family (Mono)
 PackageUrl: https://design.ubuntu.com/font
 License: Ubuntu-font-1.0
 LicenseUrl: https://www.ubuntu.com/legal/terms-and-policies/font-licence
-Copyright: © The Ubuntu Font Family Project Authors (https://launchpad.net/ubuntu-font-family)
+Copyright: © The Ubuntu Font Family Project Authors (https://launchpad.net/ubuntu-font-family).
 CopyrightUrl: https://www.ubuntu.com/legal/terms-and-policies/font-licence
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/c/cormullion/JuliaMono/0.63.2/cormullion.JuliaMono.locale.en-US.yaml
+++ b/fonts/c/cormullion/JuliaMono/0.63.2/cormullion.JuliaMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: JuliaMono
 PackageUrl: https://juliamono.netlify.app/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/cormullion/juliamono/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2020 - 2023, cormullion with Reserved Font Name JuliaMono.
+Copyright: © 2020 - 2023 cormullion with Reserved Font Name JuliaMono.
 ShortDescription: Monospaced typeface for scientific and technical programming with broad Unicode support.
 Description: JuliaMono is designed for programming and text-editing environments that require specialist and technical Unicode characters. Its design aims to remain readable, simple, and consistent across a broad glyph repertoire.
 Moniker: juliamono

--- a/fonts/d/DJR/Input/1.1/DJR.Input.locale.en-US.yaml
+++ b/fonts/d/DJR/Input/1.1/DJR.Input.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: Input
 PackageUrl: https://input.djr.com/
 License: Proprietary
 LicenseUrl: https://input.djr.com/license/
-Copyright: Copyright 2014 DJR and The Font Bureau, Inc.
+Copyright: © 2014 DJR and The Font Bureau, Inc.
 ShortDescription: Flexible system of monospaced and proportional fonts designed specifically for code.
 Description: Input is a system of Mono, Sans, and Serif fonts designed specifically for code by David Jonathan Ross. It provides a broad range of widths, weights, and styles for richer code formatting.
 Moniker: input

--- a/fonts/e/EigilNikolajsen/CommitMono/1.143/EigilNikolajsen.CommitMono.locale.en-US.yaml
+++ b/fonts/e/EigilNikolajsen/CommitMono/1.143/EigilNikolajsen.CommitMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Commit Mono
 PackageUrl: https://commitmono.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/eigilnikolajsen/commit-mono/blob/HEAD/LICENSE-FONT
-Copyright: © 2023 Eigil Nikolajsen (eigi0088@gmail.com)
+Copyright: © 2023 Eigil Nikolajsen (eigi0088@gmail.com).
 CopyrightUrl: https://github.com/eigilnikolajsen/commit-mono/blob/HEAD/LICENSE-FONT
 ShortDescription: Commit Mono is an anonymous and neutral programming typeface.
 Description: Commit Mono is an anonymous and neutral coding font focused on creating a better reading experience for developers. The typeface is designed for use in code editors and terminals, with careful attention to legibility and character distinction. It features multiple weights and customizable design variations to suit different coding preferences.

--- a/fonts/e/EigilNikolajsen/CommitMono/1.143/EigilNikolajsen.CommitMono.locale.en-US.yaml
+++ b/fonts/e/EigilNikolajsen/CommitMono/1.143/EigilNikolajsen.CommitMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Commit Mono
 PackageUrl: https://commitmono.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/eigilnikolajsen/commit-mono/blob/HEAD/LICENSE-FONT
-Copyright: Copyright (c) 2023 Eigil Nikolajsen (eigi0088@gmail.com)
+Copyright: © 2023 Eigil Nikolajsen (eigi0088@gmail.com)
 CopyrightUrl: https://github.com/eigilnikolajsen/commit-mono/blob/HEAD/LICENSE-FONT
 ShortDescription: Commit Mono is an anonymous and neutral programming typeface.
 Description: Commit Mono is an anonymous and neutral coding font focused on creating a better reading experience for developers. The typeface is designed for use in code editors and terminals, with careful attention to legibility and character distinction. It features multiple weights and customizable design variations to suit different coding preferences.

--- a/fonts/e/EugeneChing/ConsolasPowerline/5.22/EugeneChing.ConsolasPowerline.locale.en-US.yaml
+++ b/fonts/e/EugeneChing/ConsolasPowerline/5.22/EugeneChing.ConsolasPowerline.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Consolas for Powerline
 PackageUrl: https://github.com/eugeii/consolas-powerline-vim
 License: BSD-2-Clause
 LicenseUrl: https://github.com/eugeii/consolas-powerline-vim/blob/HEAD/LICENSE
-Copyright: © 2012 Eugene Ching
+Copyright: © 2012 Eugene Ching.
 ShortDescription: Consolas font patched for Vim Powerline in four styles.
 Description: Consolas for Powerline adds Powerline symbols to Consolas for use in Vim status lines and terminal prompts. It includes regular, bold, italic, and bold-italic styles.
 Moniker: consolas-for-powerline

--- a/fonts/e/EugeneChing/ConsolasPowerline/5.22/EugeneChing.ConsolasPowerline.locale.en-US.yaml
+++ b/fonts/e/EugeneChing/ConsolasPowerline/5.22/EugeneChing.ConsolasPowerline.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Consolas for Powerline
 PackageUrl: https://github.com/eugeii/consolas-powerline-vim
 License: BSD-2-Clause
 LicenseUrl: https://github.com/eugeii/consolas-powerline-vim/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2012, Eugene Ching
+Copyright: © 2012 Eugene Ching
 ShortDescription: Consolas font patched for Vim Powerline in four styles.
 Description: Consolas for Powerline adds Powerline symbols to Consolas for use in Vim status lines and terminal prompts. It includes regular, bold, italic, and bold-italic styles.
 Moniker: consolas-for-powerline

--- a/fonts/e/EvilMartians/MartianMono/1.1.0/EvilMartians.MartianMono.locale.en-US.yaml
+++ b/fonts/e/EvilMartians/MartianMono/1.1.0/EvilMartians.MartianMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Martian Mono
 PackageUrl: https://github.com/evilmartians/mono
 License: OFL-1.1
 LicenseUrl: https://github.com/evilmartians/mono/blob/HEAD/OFL.txt
-Copyright: Copyright 2021 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+Copyright: © 2021 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
 CopyrightUrl: https://github.com/evilmartians/mono/blob/HEAD/OFL.txt
 ShortDescription: A monospaced typeface based on Martian Grotesk.
 Description: Martian Mono is a monospaced version of Martian Grotesk designed for code and interface use.

--- a/fonts/e/EvilMartians/MartianMono/1.1.0/EvilMartians.MartianMono.locale.en-US.yaml
+++ b/fonts/e/EvilMartians/MartianMono/1.1.0/EvilMartians.MartianMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Martian Mono
 PackageUrl: https://github.com/evilmartians/mono
 License: OFL-1.1
 LicenseUrl: https://github.com/evilmartians/mono/blob/HEAD/OFL.txt
-Copyright: © 2021 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+Copyright: © 2021 The Martian Mono Project Authors (https://github.com/evilmartians/mono).
 CopyrightUrl: https://github.com/evilmartians/mono/blob/HEAD/OFL.txt
 ShortDescription: A monospaced typeface based on Martian Grotesk.
 Description: Martian Mono is a monospaced version of Martian Grotesk designed for code and interface use.

--- a/fonts/g/GitHub/Monaspace/1.301/GitHub.Monaspace.locale.en-US.yaml
+++ b/fonts/g/GitHub/Monaspace/1.301/GitHub.Monaspace.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monaspace
 PackageUrl: https://monaspace.githubnext.com/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
-Copyright: © 2023 GitHub https://github.com/githubnext/monaspace
+Copyright: © 2023 GitHub https://github.com/githubnext/monaspace.
 CopyrightUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
 ShortDescription: An innovative superfamily of fonts for code.
 Description: The Monaspace type system is a monospaced type superfamily with some modern tricks up its sleeve. It consists of five variable axis typefaces. Each one has a distinct voice, but they are all metrics-compatible with one another, allowing you to mix and match them for a more expressive typographical palette.

--- a/fonts/g/GitHub/Monaspace/1.301/GitHub.Monaspace.locale.en-US.yaml
+++ b/fonts/g/GitHub/Monaspace/1.301/GitHub.Monaspace.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monaspace
 PackageUrl: https://monaspace.githubnext.com/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2023, GitHub https://github.com/githubnext/monaspace
+Copyright: © 2023 GitHub https://github.com/githubnext/monaspace
 CopyrightUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
 ShortDescription: An innovative superfamily of fonts for code.
 Description: The Monaspace type system is a monospaced type superfamily with some modern tricks up its sleeve. It consists of five variable axis typefaces. Each one has a distinct voice, but they are all metrics-compatible with one another, allowing you to mix and match them for a more expressive typographical palette.

--- a/fonts/g/GitHub/Monaspace/1.400/GitHub.Monaspace.locale.en-US.yaml
+++ b/fonts/g/GitHub/Monaspace/1.400/GitHub.Monaspace.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monaspace
 PackageUrl: https://monaspace.githubnext.com/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
-Copyright: © 2023 GitHub https://github.com/githubnext/monaspace
+Copyright: © 2023 GitHub https://github.com/githubnext/monaspace.
 CopyrightUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
 ShortDescription: An innovative superfamily of fonts for code.
 Description: The Monaspace type system is a monospaced type superfamily with some modern tricks up its sleeve. It consists of five variable axis typefaces. Each one has a distinct voice, but they are all metrics-compatible with one another, allowing you to mix and match them for a more expressive typographical palette.

--- a/fonts/g/GitHub/Monaspace/1.400/GitHub.Monaspace.locale.en-US.yaml
+++ b/fonts/g/GitHub/Monaspace/1.400/GitHub.Monaspace.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monaspace
 PackageUrl: https://monaspace.githubnext.com/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2023, GitHub https://github.com/githubnext/monaspace
+Copyright: © 2023 GitHub https://github.com/githubnext/monaspace
 CopyrightUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
 ShortDescription: An innovative superfamily of fonts for code.
 Description: The Monaspace type system is a monospaced type superfamily with some modern tricks up its sleeve. It consists of five variable axis typefaces. Each one has a distinct voice, but they are all metrics-compatible with one another, allowing you to mix and match them for a more expressive typographical palette.

--- a/fonts/g/GitHub/Monaspace/NerdFont/1.400/GitHub.Monaspace.NerdFont.locale.en-US.yaml
+++ b/fonts/g/GitHub/Monaspace/NerdFont/1.400/GitHub.Monaspace.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monaspace Nerd Font
 PackageUrl: https://monaspace.githubnext.com/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2023, GitHub https://github.com/githubnext/monaspace
+Copyright: © 2023 GitHub https://github.com/githubnext/monaspace
 CopyrightUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
 ShortDescription: An innovative superfamily of fonts for code.
 Description: The Monaspace type system is a monospaced type superfamily with some modern tricks up its sleeve. It consists of five variable axis typefaces. Each one has a distinct voice, but they are all metrics-compatible with one another, allowing you to mix and match them for a more expressive typographical palette.

--- a/fonts/g/GitHub/Monaspace/NerdFont/1.400/GitHub.Monaspace.NerdFont.locale.en-US.yaml
+++ b/fonts/g/GitHub/Monaspace/NerdFont/1.400/GitHub.Monaspace.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monaspace Nerd Font
 PackageUrl: https://monaspace.githubnext.com/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
-Copyright: © 2023 GitHub https://github.com/githubnext/monaspace
+Copyright: © 2023 GitHub https://github.com/githubnext/monaspace.
 CopyrightUrl: https://github.com/githubnext/monaspace/blob/HEAD/LICENSE
 ShortDescription: An innovative superfamily of fonts for code.
 Description: The Monaspace type system is a monospaced type superfamily with some modern tricks up its sleeve. It consists of five variable axis typefaces. Each one has a distinct voice, but they are all metrics-compatible with one another, allowing you to mix and match them for a more expressive typographical palette.

--- a/fonts/g/Google/AtkinsonHyperlegible/Mono/2.001/Google.AtkinsonHyperlegible.Mono.locale.en-US.yaml
+++ b/fonts/g/Google/AtkinsonHyperlegible/Mono/2.001/Google.AtkinsonHyperlegible.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Atkinson Hyperlegible Mono
 PackageUrl: https://github.com/googlefonts/atkinson-hyperlegible-next-mono
 License: OFL-1.1
 LicenseUrl: https://github.com/googlefonts/atkinson-hyperlegible-next-mono/blob/HEAD/OFL.txt
-Copyright: Copyright 2020-2024 The Atkinson Hyperlegible Mono Project Authors.
+Copyright: © 2020-2024 The Atkinson Hyperlegible Mono Project Authors.
 ShortDescription: Monospaced hyperlegible typeface for quickly scanning tables and coding environments.
 Description: Atkinson Hyperlegible Mono is the monospaced member of the Braille Institute’s typeface family for low-vision readers. Its equally wide characters support quick scanning in tables and coding environments across seven weights and italic styles.
 Moniker: atkinson-hyperlegible-mono

--- a/fonts/g/Google/AtkinsonHyperlegible/Next/2.001/Google.AtkinsonHyperlegible.Next.locale.en-US.yaml
+++ b/fonts/g/Google/AtkinsonHyperlegible/Next/2.001/Google.AtkinsonHyperlegible.Next.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Atkinson Hyperlegible Next
 PackageUrl: https://github.com/googlefonts/atkinson-hyperlegible-next
 License: OFL-1.1
 LicenseUrl: https://github.com/googlefonts/atkinson-hyperlegible-next/blob/HEAD/OFL.txt
-Copyright: Copyright 2020-2024 The Atkinson Hyperlegible Next Project Authors.
+Copyright: © 2020-2024 The Atkinson Hyperlegible Next Project Authors.
 ShortDescription: Enhanced hyperlegible typeface with seven weights and support for more than 150 languages.
 Description: Atkinson Hyperlegible Next expands the Braille Institute’s typeface for low-vision readers with seven weights from ExtraLight through ExtraBold, upright and italic styles, and support for more than 150 languages.
 Moniker: atkinson-hyperlegible-next

--- a/fonts/g/Google/Fira/SansExtraCondensed/4.203/Google.Fira.SansExtraCondensed.locale.en-US.yaml
+++ b/fonts/g/Google/Fira/SansExtraCondensed/4.203/Google.Fira.SansExtraCondensed.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Sans Extra Condensed
 PackageUrl: https://fonts.google.com/specimen/Fira+Sans+Extra+Condensed
 License: OFL-1.1
 LicenseUrl: https://github.com/google/fonts/blob/HEAD/ofl/firasansextracondensed/OFL.txt
-Copyright: Copyright (c) 2012-2015, The Mozilla Foundation and Telefonica S.A.
+Copyright: © 2012-2015 The Mozilla Foundation and Telefonica S.A.
 ShortDescription: Narrowest-width member of Mozilla's humanist Fira Sans typeface family.
 Description: Fira Sans Extra Condensed is the narrowest-width member of the humanist Fira Sans family designed by Carrois Apostrophe for Mozilla and Firefox OS, with nine weights and matching italics.
 Moniker: fira-sans-extra-condensed

--- a/fonts/g/Google/Noto/Sans/2.015/Google.Noto.Sans.locale.en-US.yaml
+++ b/fonts/g/Google/Noto/Sans/2.015/Google.Noto.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Noto Sans
 PackageUrl: https://notofonts.github.io/
 License: OFL-1.1
 LicenseUrl: https://github.com/notofonts/latin-greek-cyrillic/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Noto Project Authors (https://github.com/notofonts/latin-greek-cyrillic)
+Copyright: © 2022 The Noto Project Authors (https://github.com/notofonts/latin-greek-cyrillic)
 CopyrightUrl: https://github.com/notofonts/latin-greek-cyrillic/blob/HEAD/OFL.txt
 ShortDescription: A global sans-serif font for writing in the Latin, Cyrillic, and Greek scripts
 Description: Noto is a global font collection designed to support writing in all modern and ancient languages. Noto Sans is an unmodulated sans-serif design for texts in the Latin, Cyrillic, and Greek scripts, suitable as a complementary choice for other script-specific Noto Sans fonts. It features italic styles, multiple weights and widths, and comprehensive Unicode support with 3,741 glyphs.

--- a/fonts/g/Google/Noto/Sans/2.015/Google.Noto.Sans.locale.en-US.yaml
+++ b/fonts/g/Google/Noto/Sans/2.015/Google.Noto.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Noto Sans
 PackageUrl: https://notofonts.github.io/
 License: OFL-1.1
 LicenseUrl: https://github.com/notofonts/latin-greek-cyrillic/blob/HEAD/OFL.txt
-Copyright: © 2022 The Noto Project Authors (https://github.com/notofonts/latin-greek-cyrillic)
+Copyright: © 2022 The Noto Project Authors (https://github.com/notofonts/latin-greek-cyrillic).
 CopyrightUrl: https://github.com/notofonts/latin-greek-cyrillic/blob/HEAD/OFL.txt
 ShortDescription: A global sans-serif font for writing in the Latin, Cyrillic, and Greek scripts
 Description: Noto is a global font collection designed to support writing in all modern and ancient languages. Noto Sans is an unmodulated sans-serif design for texts in the Latin, Cyrillic, and Greek scripts, suitable as a complementary choice for other script-specific Noto Sans fonts. It features italic styles, multiple weights and widths, and comprehensive Unicode support with 3,741 glyphs.

--- a/fonts/g/Google/SansCode/6.001/Google.SansCode.locale.en-US.yaml
+++ b/fonts/g/Google/SansCode/6.001/Google.SansCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Google Sans Code
 PackageUrl: https://github.com/googlefonts/googlesans-code
 License: OFL-1.1
 LicenseUrl: https://github.com/googlefonts/googlesans-code/blob/HEAD/OFL.txt
-Copyright: © 2025 The Google Sans Code Project Authors (github.com/googlefonts/googlesans-code)
+Copyright: © 2025 The Google Sans Code Project Authors (github.com/googlefonts/googlesans-code).
 CopyrightUrl: https://github.com/googlefonts/googlesans-code/blob/HEAD/OFL.txt
 ShortDescription: A fixed-width font designed for code and programming
 Description: Google Sans Code is a fixed-width font family designed to bring clarity, readability, and Google's distinctive brand character to code. Developed for products like Gemini and Android Studio, each character remains distinct even at small sizes. Features enhanced legibility for code editors and terminals, supports Extended Latin scripts, offers a wide weight range from 300 to 800, and includes OpenType features like stylistic sets and localized forms.

--- a/fonts/g/Google/SansCode/6.001/Google.SansCode.locale.en-US.yaml
+++ b/fonts/g/Google/SansCode/6.001/Google.SansCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Google Sans Code
 PackageUrl: https://github.com/googlefonts/googlesans-code
 License: OFL-1.1
 LicenseUrl: https://github.com/googlefonts/googlesans-code/blob/HEAD/OFL.txt
-Copyright: Copyright 2025 The Google Sans Code Project Authors (github.com/googlefonts/googlesans-code)
+Copyright: © 2025 The Google Sans Code Project Authors (github.com/googlefonts/googlesans-code)
 CopyrightUrl: https://github.com/googlefonts/googlesans-code/blob/HEAD/OFL.txt
 ShortDescription: A fixed-width font designed for code and programming
 Description: Google Sans Code is a fixed-width font family designed to bring clarity, readability, and Google's distinctive brand character to code. Developed for products like Gemini and Android Studio, each character remains distinct even at small sizes. Features enhanced legibility for code editors and terminals, supports Extended Latin scripts, offers a wide weight range from 300 to 800, and includes OpenType features like stylistic sets and localized forms.

--- a/fonts/g/Google/SansCode/7.001/Google.SansCode.locale.en-US.yaml
+++ b/fonts/g/Google/SansCode/7.001/Google.SansCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Google Sans Code
 PackageUrl: https://github.com/googlefonts/googlesans-code
 License: OFL-1.1
 LicenseUrl: https://github.com/googlefonts/googlesans-code/blob/HEAD/OFL.txt
-Copyright: © 2025 The Google Sans Code Project Authors (github.com/googlefonts/googlesans-code)
+Copyright: © 2025 The Google Sans Code Project Authors (github.com/googlefonts/googlesans-code).
 CopyrightUrl: https://github.com/googlefonts/googlesans-code/blob/HEAD/OFL.txt
 ShortDescription: A fixed-width font designed for code and programming
 Description: Google Sans Code is a fixed-width font family designed to bring clarity, readability, and Google's distinctive brand character to code. Developed for products like Gemini and Android Studio, each character remains distinct even at small sizes. Features enhanced legibility for code editors and terminals, supports Extended Latin scripts, offers a wide weight range from 300 to 800, and includes OpenType features like stylistic sets and localized forms.

--- a/fonts/g/Google/SansCode/7.001/Google.SansCode.locale.en-US.yaml
+++ b/fonts/g/Google/SansCode/7.001/Google.SansCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Google Sans Code
 PackageUrl: https://github.com/googlefonts/googlesans-code
 License: OFL-1.1
 LicenseUrl: https://github.com/googlefonts/googlesans-code/blob/HEAD/OFL.txt
-Copyright: Copyright 2025 The Google Sans Code Project Authors (github.com/googlefonts/googlesans-code)
+Copyright: © 2025 The Google Sans Code Project Authors (github.com/googlefonts/googlesans-code)
 CopyrightUrl: https://github.com/googlefonts/googlesans-code/blob/HEAD/OFL.txt
 ShortDescription: A fixed-width font designed for code and programming
 Description: Google Sans Code is a fixed-width font family designed to bring clarity, readability, and Google's distinctive brand character to code. Developed for products like Gemini and Android Studio, each character remains distinct even at small sizes. Features enhanced legibility for code editors and terminals, supports Extended Latin scripts, offers a wide weight range from 300 to 800, and includes OpenType features like stylistic sets and localized forms.

--- a/fonts/g/Google/SpaceMono/1.003/Google.SpaceMono.locale.en-US.yaml
+++ b/fonts/g/Google/SpaceMono/1.003/Google.SpaceMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Space Mono
 PackageUrl: https://github.com/googlefonts/spacemono
 License: OFL-1.1
 LicenseUrl: https://github.com/googlefonts/spacemono/blob/HEAD/OFL.txt
-Copyright: Copyright 2016 The Space Mono Project Authors (https://github.com/googlefonts/spacemono)
+Copyright: © 2016 The Space Mono Project Authors (https://github.com/googlefonts/spacemono)
 CopyrightUrl: https://github.com/googlefonts/spacemono/blob/HEAD/OFL.txt
 ShortDescription: An original monospace display typeface
 Description: Space Mono is an original monospace display typeface family designed by Colophon Foundry for Google Design. Developed explicitly for headline and display typography, the letterforms infuse a geometric slab core with novel over-rationalized forms. It supports an Extended Latin glyph set, enabling typesetting for English and other Western European languages.

--- a/fonts/g/Google/SpaceMono/1.003/Google.SpaceMono.locale.en-US.yaml
+++ b/fonts/g/Google/SpaceMono/1.003/Google.SpaceMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Space Mono
 PackageUrl: https://github.com/googlefonts/spacemono
 License: OFL-1.1
 LicenseUrl: https://github.com/googlefonts/spacemono/blob/HEAD/OFL.txt
-Copyright: © 2016 The Space Mono Project Authors (https://github.com/googlefonts/spacemono)
+Copyright: © 2016 The Space Mono Project Authors (https://github.com/googlefonts/spacemono).
 CopyrightUrl: https://github.com/googlefonts/spacemono/blob/HEAD/OFL.txt
 ShortDescription: An original monospace display typeface
 Description: Space Mono is an original monospace display typeface family designed by Colophon Foundry for Google Design. Developed explicitly for headline and display typography, the letterforms infuse a geometric slab core with novel over-rationalized forms. It supports an Extended Latin glyph set, enabling typesetting for English and other Western European languages.

--- a/fonts/g/Google/Tinos/1.340/Google.Tinos.locale.en-US.yaml
+++ b/fonts/g/Google/Tinos/1.340/Google.Tinos.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Tinos
 PackageUrl: https://fonts.google.com/specimen/Tinos
 License: Apache-2.0
 LicenseUrl: https://github.com/googlefonts/tinos/blob/HEAD/OFL.txt
-Copyright: © 2026 The Tinos Project Authors (https://github.com/googlefonts/tinos)
+Copyright: © 2026 The Tinos Project Authors (https://github.com/googlefonts/tinos).
 CopyrightUrl: https://github.com/googlefonts/tinos/blob/HEAD/OFL.txt
 ShortDescription: A serif typeface metrically compatible with Times New Roman.
 Description: Tinos is a serif typeface by Steve Matteson, designed as a metric-compatible substitute for Times New Roman.

--- a/fonts/g/Google/Tinos/1.340/Google.Tinos.locale.en-US.yaml
+++ b/fonts/g/Google/Tinos/1.340/Google.Tinos.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Tinos
 PackageUrl: https://fonts.google.com/specimen/Tinos
 License: Apache-2.0
 LicenseUrl: https://github.com/googlefonts/tinos/blob/HEAD/OFL.txt
-Copyright: Copyright 2026 The Tinos Project Authors (https://github.com/googlefonts/tinos)
+Copyright: © 2026 The Tinos Project Authors (https://github.com/googlefonts/tinos)
 CopyrightUrl: https://github.com/googlefonts/tinos/blob/HEAD/OFL.txt
 ShortDescription: A serif typeface metrically compatible with Times New Roman.
 Description: Tinos is a serif typeface by Steve Matteson, designed as a metric-compatible substitute for Times New Roman.

--- a/fonts/g/gabrielelana/AwesomeTerminalFonts/1.1.0/gabrielelana.AwesomeTerminalFonts.locale.en-US.yaml
+++ b/fonts/g/gabrielelana/AwesomeTerminalFonts/1.1.0/gabrielelana.AwesomeTerminalFonts.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Awesome Terminal Fonts
 PackageUrl: https://github.com/gabrielelana/awesome-terminal-fonts
 License: MIT
 LicenseUrl: https://github.com/gabrielelana/awesome-terminal-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2013 Gabriele Lana
+Copyright: © 2013 Gabriele Lana
 ShortDescription: Symbol-font collection for compact, informative terminal prompts.
 Description: Awesome Terminal Fonts adapts Font Awesome, Devicons, Octicons, and Pomicons as fallback symbol fonts for terminal environments and provides font maps for referring to glyphs by name.
 Moniker: awesome-terminal-fonts

--- a/fonts/g/gabrielelana/AwesomeTerminalFonts/1.1.0/gabrielelana.AwesomeTerminalFonts.locale.en-US.yaml
+++ b/fonts/g/gabrielelana/AwesomeTerminalFonts/1.1.0/gabrielelana.AwesomeTerminalFonts.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Awesome Terminal Fonts
 PackageUrl: https://github.com/gabrielelana/awesome-terminal-fonts
 License: MIT
 LicenseUrl: https://github.com/gabrielelana/awesome-terminal-fonts/blob/HEAD/LICENSE
-Copyright: © 2013 Gabriele Lana
+Copyright: © 2013 Gabriele Lana.
 ShortDescription: Symbol-font collection for compact, informative terminal prompts.
 Description: Awesome Terminal Fonts adapts Font Awesome, Devicons, Octicons, and Pomicons as fallback symbol fonts for terminal environments and provides font maps for referring to glyphs by name.
 Moniker: awesome-terminal-fonts

--- a/fonts/h/Huawei/HarmonyOSSans/1.0/Huawei.HarmonyOSSans.locale.en-US.yaml
+++ b/fonts/h/Huawei/HarmonyOSSans/1.0/Huawei.HarmonyOSSans.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: HarmonyOS Sans
 PackageUrl: https://developer.huawei.com/consumer/en/design/resource/
 License: Freeware
 LicenseUrl: https://gitcode.com/openharmony/global_system_resources/blob/master/LICENSE_Fonts
-Copyright: Copyright 2021 Huawei Device Co., Ltd.
+Copyright: © 2021 Huawei Device Co., Ltd.
 ShortDescription: A variable font family designed and developed for full-scenario experience.
 Moniker: harmony-os-sans
 Tags:

--- a/fonts/i/IBM/Plex/Math/1.1.0/IBM.Plex.Math.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Math/1.1.0/IBM.Plex.Math.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Math
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: Mathematical typeface compatible with IBM Plex Serif Regular.
 Description: IBM Plex Math contains more than 5,000 mathematical glyphs, including operators, scripts, arrows, Greek letters, phonetics, and technical and geometric shapes. It is designed for use with LaTeX or equivalent mathematical typesetting software.

--- a/fonts/i/IBM/Plex/Mono/2.5.0/IBM.Plex.Mono.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Mono/2.5.0/IBM.Plex.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Mono
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's monospaced typeface for coding and technical content.
 Description: IBM Plex Mono is the monospaced member of IBM's corporate typeface family. Every glyph fits a 600-unit space, drawing on typewriter forms for coding, code snippets, and technical communication.

--- a/fonts/i/IBM/Plex/Sans/1.1.0/IBM.Plex.Sans.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/1.1.0/IBM.Plex.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate typeface family, a global and versatile sans-serif font designed for user interface and digital environments.
 Description: IBM Plex Sans is IBM's corporate typeface, carefully designed to meet the needs of a global technology company. This open-source font family is versatile and distinctly IBM, featuring both Roman and true italic variants. It supports extended Latin, Arabic, Chinese (Traditional), Cyrillic, Devanagari, Greek, Hebrew, Japanese, Korean, and Thai, making it suitable for international applications. IBM Plex Sans is designed to work well in user interface (UI) environments and other mediums, offering a comprehensive solution for professional typography.

--- a/fonts/i/IBM/Plex/Sans/Arabic/1.1.0/IBM.Plex.Sans.Arabic.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/Arabic/1.1.0/IBM.Plex.Sans.Arabic.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans Arabic
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate sans-serif typeface for Arabic script.
 Description: IBM Plex Sans Arabic extends IBM's corporate typeface to Arabic-script communications while retaining the family's balance of natural and engineered forms.

--- a/fonts/i/IBM/Plex/Sans/Condensed/2.0.0/IBM.Plex.Sans.Condensed.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/Condensed/2.0.0/IBM.Plex.Sans.Condensed.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans Condensed
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: Condensed member of IBM's corporate sans-serif typeface family.
 Description: IBM Plex Sans Condensed provides the Plex Sans design in narrower proportions across a broad range of weights with matching italic styles.

--- a/fonts/i/IBM/Plex/Sans/Devanagari/1.1.0/IBM.Plex.Sans.Devanagari.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/Devanagari/1.1.0/IBM.Plex.Sans.Devanagari.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans Devanagari
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate sans-serif typeface for Devanagari script.
 Description: IBM Plex Sans Devanagari extends IBM's corporate typeface to Devanagari-script communications while retaining the family's balance of natural and engineered forms.

--- a/fonts/i/IBM/Plex/Sans/Hebrew/1.1.0/IBM.Plex.Sans.Hebrew.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/Hebrew/1.1.0/IBM.Plex.Sans.Hebrew.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans Hebrew
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate sans-serif typeface for Hebrew script.
 Description: IBM Plex Sans Hebrew extends IBM's corporate typeface to Hebrew-script communications while retaining the family's balance of natural and engineered forms.

--- a/fonts/i/IBM/Plex/Sans/JP/3.0.0/IBM.Plex.Sans.JP.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/JP/3.0.0/IBM.Plex.Sans.JP.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans JP
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate sans-serif typeface for Japanese text.
 Description: IBM Plex Sans JP extends IBM's corporate typeface to Japanese communications and works alongside other Plex families in multilingual typography.

--- a/fonts/i/IBM/Plex/Sans/KR/1.1.0/IBM.Plex.Sans.KR.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/KR/1.1.0/IBM.Plex.Sans.KR.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans KR
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate sans-serif typeface for Korean text.
 Description: IBM Plex Sans KR extends IBM's corporate typeface to Korean communications and works alongside other Plex families in multilingual typography.

--- a/fonts/i/IBM/Plex/Sans/SC/1.1.0/IBM.Plex.Sans.SC.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/SC/1.1.0/IBM.Plex.Sans.SC.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans SC
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate sans-serif typeface for Simplified Chinese text.
 Description: IBM Plex Sans SC extends IBM's corporate typeface to Simplified Chinese communications and works alongside other Plex families in multilingual typography.

--- a/fonts/i/IBM/Plex/Sans/TC/1.1.1/IBM.Plex.Sans.TC.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/TC/1.1.1/IBM.Plex.Sans.TC.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans TC
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate sans-serif typeface for Traditional Chinese text.
 Description: IBM Plex Sans TC extends IBM's corporate typeface to Traditional Chinese communications and works alongside other Plex families in multilingual typography.

--- a/fonts/i/IBM/Plex/Sans/Thai/1.1.0/IBM.Plex.Sans.Thai.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/Thai/1.1.0/IBM.Plex.Sans.Thai.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans Thai
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: IBM's corporate sans-serif typeface for Thai script.
 Description: IBM Plex Sans Thai extends IBM's corporate typeface to Thai-script communications while retaining the family's balance of natural and engineered forms.

--- a/fonts/i/IBM/Plex/Sans/Thai/Looped/1.1.0/IBM.Plex.Sans.Thai.Looped.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/Thai/Looped/1.1.0/IBM.Plex.Sans.Thai.Looped.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans Thai Looped
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: Looped Thai-script member of IBM's corporate sans-serif family.
 Description: IBM Plex Sans Thai Looped provides a looped Thai design within IBM's corporate typeface family for Thai-script communications.

--- a/fonts/i/IBM/Plex/Sans/Variable/0.2.0/IBM.Plex.Sans.Variable.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Sans/Variable/0.2.0/IBM.Plex.Sans.Variable.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Sans Variable
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: Variable-font build of IBM's corporate sans-serif typeface.
 Description: IBM Plex Sans Variable packages IBM's corporate sans-serif design as variable fonts for continuous typographic adjustment while retaining the Plex family's natural and engineered character.

--- a/fonts/i/IBM/Plex/Serif/2.0.0/IBM.Plex.Serif.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Serif/2.0.0/IBM.Plex.Serif.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Serif
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: Serif member of IBM's corporate typeface family.
 Description: IBM Plex Serif is the serif member of IBM's corporate typeface family, provided across a broad range of weights with matching italic styles for text and display typography.

--- a/fonts/i/IBM/Plex/Serif/Variable/2.0.0/IBM.Plex.Serif.Variable.locale.en-US.yaml
+++ b/fonts/i/IBM/Plex/Serif/Variable/2.0.0/IBM.Plex.Serif.Variable.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: IBM Plex Serif Variable
 PackageUrl: https://www.ibm.com/plex/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
-Copyright: Copyright © 2017 IBM Corp.
+Copyright: © 2017 IBM Corp.
 CopyrightUrl: https://github.com/IBM/plex/blob/HEAD/LICENSE.txt
 ShortDescription: Variable-font build of IBM's corporate serif typeface.
 Description: IBM Plex Serif Variable packages IBM's corporate serif design as variable fonts for continuous typographic adjustment in text and display typography.

--- a/fonts/i/IdreesInc/Monocraft/NerdFont/4.2.1/IdreesInc.Monocraft.NerdFont.locale.en-US.yaml
+++ b/fonts/i/IdreesInc/Monocraft/NerdFont/4.2.1/IdreesInc.Monocraft.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monocraft Nerd Font
 PackageUrl: https://github.com/IdreesInc/Monocraft
 License: OFL-1.1
 LicenseUrl: https://github.com/IdreesInc/Monocraft/blob/HEAD/LICENSE
-Copyright: © 2022 Idrees Hassan (https://github.com/IdreesInc/Monocraft)
+Copyright: © 2022 Idrees Hassan (https://github.com/IdreesInc/Monocraft).
 ShortDescription: A monospaced programming font inspired by the Minecraft UI typeface.
 Description: Monocraft is a monospaced programming font for developers that emulates the typeface used in the Minecraft UI. It includes programming ligatures and alternate glyphs while keeping the blocky visual style of the game interface.
 Moniker: monocraft-nf

--- a/fonts/i/IdreesInc/Monocraft/NerdFont/4.2.1/IdreesInc.Monocraft.NerdFont.locale.en-US.yaml
+++ b/fonts/i/IdreesInc/Monocraft/NerdFont/4.2.1/IdreesInc.Monocraft.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monocraft Nerd Font
 PackageUrl: https://github.com/IdreesInc/Monocraft
 License: OFL-1.1
 LicenseUrl: https://github.com/IdreesInc/Monocraft/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2022, Idrees Hassan (https://github.com/IdreesInc/Monocraft)
+Copyright: © 2022 Idrees Hassan (https://github.com/IdreesInc/Monocraft)
 ShortDescription: A monospaced programming font inspired by the Minecraft UI typeface.
 Description: Monocraft is a monospaced programming font for developers that emulates the typeface used in the Minecraft UI. It includes programming ligatures and alternate glyphs while keeping the blocky visual style of the game interface.
 Moniker: monocraft-nf

--- a/fonts/i/InformationArchitects/iAWriter/Duo/2.000/InformationArchitects.iAWriter.Duo.locale.en-US.yaml
+++ b/fonts/i/InformationArchitects/iAWriter/Duo/2.000/InformationArchitects.iAWriter.Duo.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: iA Writer Duo
 PackageUrl: https://ia.net/downloads
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/iaolo/iA-Fonts/blob/HEAD/iA%20Writer%20Duo/LICENSE.md
-Copyright: Copyright (c) 2018 Information Architects Inc.; Copyright (c) 2017 IBM Corp.
+Copyright: © 2018 Information Architects Inc.; © 2017 IBM Corp.
 ShortDescription: Duospaced writing typeface based on IBM Plex that gives extra width to M and W.
 Description: iA Writer Duo is a two-spaced writing typeface built upon IBM Plex. It gives extra room to M and W while retaining much of the rhythm and letter discernibility of monospaced text.
 Moniker: ia-writer-duo

--- a/fonts/i/InformationArchitects/iAWriter/Mono/2.000/InformationArchitects.iAWriter.Mono.locale.en-US.yaml
+++ b/fonts/i/InformationArchitects/iAWriter/Mono/2.000/InformationArchitects.iAWriter.Mono.locale.en-US.yaml
@@ -13,8 +13,8 @@ PackageUrl: https://ia.net/downloads
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/iaolo/iA-Fonts/blob/HEAD/iA%20Writer%20Mono/LICENSE.md
 Copyright: |-
-  Copyright (c) 2018 Information Architects Inc.
-  Copyright (c) 2017 IBM Corp.
+  © 2018 Information Architects Inc.
+  © 2017 IBM Corp.
 ShortDescription: Classic monospaced writing typeface based on IBM Plex.
 Description: iA Writer Mono is the classic monospaced member of the iA Writer typeface collection. It was built upon IBM Plex and redesigned with square dots and adjusted letterforms to give the Mono, Duo, and Quattro families a common look.
 Moniker: ia-writer-mono

--- a/fonts/i/InformationArchitects/iAWriter/Quattro/2.000/InformationArchitects.iAWriter.Quattro.locale.en-US.yaml
+++ b/fonts/i/InformationArchitects/iAWriter/Quattro/2.000/InformationArchitects.iAWriter.Quattro.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: iA Writer Quattro
 PackageUrl: https://ia.net/downloads
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/iaolo/iA-Fonts/blob/HEAD/iA%20Writer%20Quattro/LICENSE.md
-Copyright: Copyright (c) 2018 Information Architects Inc.; Copyright (c) 2017 IBM Corp.
+Copyright: © 2018 Information Architects Inc.; © 2017 IBM Corp.
 ShortDescription: Four-width writing typeface based on IBM Plex with a proportional appearance.
 Description: iA Writer Quattro is a four-width writing typeface built upon IBM Plex. It resembles proportional type while retaining wide word spacing and monospaced punctuation for a regular text image.
 Moniker: ia-writer-quattro

--- a/fonts/i/Intel/IntelOneMono/1.4.0/Intel.IntelOneMono.locale.en-US.yaml
+++ b/fonts/i/Intel/IntelOneMono/1.4.0/Intel.IntelOneMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Intel One Mono
 PackageUrl: https://github.com/intel/intel-one-mono
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/intel/intel-one-mono/blob/HEAD/OFL.txt
-Copyright: © 2023-2024 The Intel One Mono Project Authors (https://github.com/intel/intel-one-mono), with Reserved Font Name 'Intel'
+Copyright: © 2023-2024 The Intel One Mono Project Authors (https://github.com/intel/intel-one-mono), with Reserved Font Name 'Intel'.
 CopyrightUrl: https://github.com/intel/intel-one-mono/blob/HEAD/OFL.txt
 ShortDescription: An expressive monospaced font built for developers.
 Description: Intel One Mono is an expressive monospaced font family built with clarity, legibility, and the needs of developers in mind.

--- a/fonts/i/Intel/IntelOneMono/1.4.0/Intel.IntelOneMono.locale.en-US.yaml
+++ b/fonts/i/Intel/IntelOneMono/1.4.0/Intel.IntelOneMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Intel One Mono
 PackageUrl: https://github.com/intel/intel-one-mono
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/intel/intel-one-mono/blob/HEAD/OFL.txt
-Copyright: Copyright 2023-2024 The Intel One Mono Project Authors (https://github.com/intel/intel-one-mono), with Reserved Font Name 'Intel'
+Copyright: © 2023-2024 The Intel One Mono Project Authors (https://github.com/intel/intel-one-mono), with Reserved Font Name 'Intel'
 CopyrightUrl: https://github.com/intel/intel-one-mono/blob/HEAD/OFL.txt
 ShortDescription: An expressive monospaced font built for developers.
 Description: Intel One Mono is an expressive monospaced font family built with clarity, legibility, and the needs of developers in mind.

--- a/fonts/j/JensKutilek/Sudo/3.6/JensKutilek.Sudo.locale.en-US.yaml
+++ b/fonts/j/JensKutilek/Sudo/3.6/JensKutilek.Sudo.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Sudo
 PackageUrl: https://www.kutilek.de/sudo-font/
 License: OFL-1.1
 LicenseUrl: https://github.com/jenskutilek/sudo-font/blob/HEAD/OFL.txt
-Copyright: © 2024 The Sudo Font Project Authors (https://github.com/jenskutilek/sudo-font.git)
+Copyright: © 2024 The Sudo Font Project Authors (https://github.com/jenskutilek/sudo-font.git).
 ShortDescription: Font family for terminals, programming, and user interfaces.
 Description: Sudo includes a monospaced family for terminals and programming and a proportional Sudo UI family for user interfaces. Its variable fonts provide a descender-length axis, and the family supports common Powerline glyphs without programming ligatures.
 Moniker: sudo-font

--- a/fonts/j/JensKutilek/Sudo/3.6/JensKutilek.Sudo.locale.en-US.yaml
+++ b/fonts/j/JensKutilek/Sudo/3.6/JensKutilek.Sudo.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Sudo
 PackageUrl: https://www.kutilek.de/sudo-font/
 License: OFL-1.1
 LicenseUrl: https://github.com/jenskutilek/sudo-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2024 The Sudo Font Project Authors (https://github.com/jenskutilek/sudo-font.git)
+Copyright: © 2024 The Sudo Font Project Authors (https://github.com/jenskutilek/sudo-font.git)
 ShortDescription: Font family for terminals, programming, and user interfaces.
 Description: Sudo includes a monospaced family for terminals and programming and a proportional Sudo UI family for user interfaces. Its variable fonts provide a descender-length axis, and the family supports common Powerline glyphs without programming ligatures.
 Moniker: sudo-font

--- a/fonts/j/JetBrains/Mono/2.304/JetBrains.Mono.locale.en-US.yaml
+++ b/fonts/j/JetBrains/Mono/2.304/JetBrains.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: JetBrains Mono
 PackageUrl: https://www.jetbrains.com/lp/mono/
 License: OFL-1.1
 LicenseUrl: https://github.com/JetBrains/JetBrainsMono/blob/HEAD/OFL.txt
-Copyright: © The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
+Copyright: © The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono).
 CopyrightUrl: https://github.com/JetBrains/JetBrainsMono/blob/HEAD/OFL.txt
 ShortDescription: A free and open-source monospaced font with code-specific ligatures, designed by JetBrains.
 Description: JetBrains Mono is a typeface designed for code and inspired by JetBrains' developer-driven approach. It features increased letter height for better reading, adapted for reading code with optimal symbol distinction, and includes code-specific ligatures. Available in multiple weights with matching italics.

--- a/fonts/j/JetBrains/Mono/2.304/JetBrains.Mono.locale.en-US.yaml
+++ b/fonts/j/JetBrains/Mono/2.304/JetBrains.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: JetBrains Mono
 PackageUrl: https://www.jetbrains.com/lp/mono/
 License: OFL-1.1
 LicenseUrl: https://github.com/JetBrains/JetBrainsMono/blob/HEAD/OFL.txt
-Copyright: Copyright (c), The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
+Copyright: © The JetBrains Mono Project Authors (https://github.com/JetBrains/JetBrainsMono)
 CopyrightUrl: https://github.com/JetBrains/JetBrainsMono/blob/HEAD/OFL.txt
 ShortDescription: A free and open-source monospaced font with code-specific ligatures, designed by JetBrains.
 Description: JetBrains Mono is a typeface designed for code and inspired by JetBrains' developer-driven approach. It features increased letter height for better reading, adapted for reading code with optimal symbol distinction, and includes code-specific ligatures. Available in multiple weights with matching italics.

--- a/fonts/l/Lato/Lato/2.015/Lato.Lato.locale.en-US.yaml
+++ b/fonts/l/Lato/Lato/2.015/Lato.Lato.locale.en-US.yaml
@@ -10,7 +10,7 @@ Author: Łukasz Dziedzic
 PackageName: Lato
 PackageUrl: https://www.latofonts.com/
 License: OFL-1.1-RFN
-Copyright: Copyright (c) 2010-2015 by tyPoland Lukasz Dziedzic with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version 1.1.
+Copyright: © 2010-2015 by tyPoland Lukasz Dziedzic with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version 1.1.
 ShortDescription: A sanserif typeface family with nine weights and warm, friendly character.
 Description: Lato is a sanserif typeface family designed by Łukasz Dziedzic in 2010. It features nine weights (Hairline to Black) with corresponding italics, supporting 100+ Latin-based languages, 50+ Cyrillic-based languages, and Greek. The family balances transparency in body text with distinctive traits in larger sizes, combining classical proportions with a modern sanserif look and semi-rounded details that give it warmth and stability.
 Moniker: lato

--- a/fonts/l/larsenwork/Monoid/0.610/larsenwork.Monoid.locale.en-US.yaml
+++ b/fonts/l/larsenwork/Monoid/0.610/larsenwork.Monoid.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monoid
 PackageUrl: https://larsenwork.com/monoid/
 License: OFL-1.1 OR MIT
 LicenseUrl: https://github.com/larsenwork/monoid#licenses
-Copyright: Copyright (c) 2015, Dave Gandy, Andreas Larsen and contributors.
+Copyright: © 2015 Dave Gandy, Andreas Larsen and contributors.
 CopyrightUrl: https://github.com/larsenwork/monoid#licenses
 ShortDescription: A customizable coding font with alternates, ligatures, and a large x-height.
 Description: Monoid is a customizable coding font with alternates, ligatures, and a large x-height.

--- a/fonts/m/MarkSimonson/AnonymousPro/1.002/MarkSimonson.AnonymousPro.locale.en-US.yaml
+++ b/fonts/m/MarkSimonson/AnonymousPro/1.002/MarkSimonson.AnonymousPro.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: Mark Simonson
 PackageName: Anonymous Pro
 PackageUrl: https://www.marksimonson.com/fonts/view/anonymous/
 License: OFL-1.1-RFN
-Copyright: Copyright (c) 2009, Mark Simonson (http://www.ms-studio.com, mark@marksimonson.com)
+Copyright: © 2009 Mark Simonson (http://www.ms-studio.com, mark@marksimonson.com)
 ShortDescription: Anonymous Pro is a family of four fixed-width fonts designed with coding in mind.
 Description: Anonymous Pro (2009) is a family of four fixed-width fonts designed with coding in mind. Anonymous Pro features an international, Unicode-based character set, with support for most Western and Central European Latin-based languages, plus Greek and Cyrillic. Anonymous Pro is based on an earlier font, Anonymous™ (2001), my TrueType version of Anonymous 9, a Macintosh bitmap font developed in the mid-’90s by Susan Lesch and David Lamkins.
 Moniker: anonymous-pro

--- a/fonts/m/MarkSimonson/AnonymousPro/1.002/MarkSimonson.AnonymousPro.locale.en-US.yaml
+++ b/fonts/m/MarkSimonson/AnonymousPro/1.002/MarkSimonson.AnonymousPro.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: Mark Simonson
 PackageName: Anonymous Pro
 PackageUrl: https://www.marksimonson.com/fonts/view/anonymous/
 License: OFL-1.1-RFN
-Copyright: © 2009 Mark Simonson (http://www.ms-studio.com, mark@marksimonson.com)
+Copyright: © 2009 Mark Simonson (http://www.ms-studio.com, mark@marksimonson.com).
 ShortDescription: Anonymous Pro is a family of four fixed-width fonts designed with coding in mind.
 Description: Anonymous Pro (2009) is a family of four fixed-width fonts designed with coding in mind. Anonymous Pro features an international, Unicode-based character set, with support for most Western and Central European Latin-based languages, plus Greek and Cyrillic. Anonymous Pro is based on an earlier font, Anonymous™ (2001), my TrueType version of Anonymous 9, a Macintosh bitmap font developed in the mid-’90s by Susan Lesch and David Lamkins.
 Moniker: anonymous-pro

--- a/fonts/m/Microsoft/CascadiaCode/2407.24/Microsoft.CascadiaCode.locale.en-US.yaml
+++ b/fonts/m/Microsoft/CascadiaCode/2407.24/Microsoft.CascadiaCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Cascadia Code
 PackageUrl: https://github.com/microsoft/cascadia-code
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/microsoft/cascadia-code/blob/HEAD/LICENSE
-Copyright: Copyright © 2019 - Present, Microsoft Corporation, with Reserved Font Name Cascadia Code.
+Copyright: © 2019 - Present Microsoft Corporation, with Reserved Font Name Cascadia Code.
 CopyrightUrl: https://github.com/microsoft/cascadia-code/blob/HEAD/LICENSE
 ShortDescription: A fun, modern monospaced font from Microsoft with coding ligatures, designed to enhance the Windows Terminal and Visual Studio.
 Description: Cascadia Code is a fun and modern monospaced font that comes bundled with Windows Terminal and is the default font in Visual Studio. It features coding ligatures, arrow support, and stylistic sets for enhanced readability in code editors. The font is available in multiple variants including Cascadia Code (with ligatures), Cascadia Mono (without ligatures), Cascadia PL (with Powerline symbols), and Cascadia NF (with Nerd Font symbols). It includes italic and cursive variants, and supports a comprehensive character set for programming and development.

--- a/fonts/m/Mozilla/Fira/Mono/3.206/Mozilla.Fira.Mono.locale.en-US.yaml
+++ b/fonts/m/Mozilla/Fira/Mono/3.206/Mozilla.Fira.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Mono
 PackageUrl: https://mozilla.github.io/Fira/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/mozilla/Fira/blob/4.202/LICENSE
-Copyright: Digitized data copyright (c) 2012-2015, The Mozilla Foundation and Telefonica S.A.
+Copyright: Digitized data © 2012-2015 The Mozilla Foundation and Telefonica S.A.
 ShortDescription: Monospaced member of Mozilla's Fira type family, commissioned for Firefox OS.
 Description: Fira Mono is the monospaced member of the Fira type family commissioned by Mozilla for Firefox OS. It is provided in regular, medium, and bold weights.
 Moniker: fira-mono

--- a/fonts/m/Mozilla/Fira/Sans/4.202/Mozilla.Fira.Sans.locale.en-US.yaml
+++ b/fonts/m/Mozilla/Fira/Sans/4.202/Mozilla.Fira.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Sans
 PackageUrl: https://mozilla.github.io/Fira/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/mozilla/Fira/blob/4.202/LICENSE
-Copyright: Digitized data copyright (c) 2012-2015, The Mozilla Foundation and Telefonica S.A.
+Copyright: Digitized data © 2012-2015 The Mozilla Foundation and Telefonica S.A.
 ShortDescription: Mozilla's humanist sans-serif typeface, commissioned for Firefox OS.
 Description: Fira Sans is a humanist sans-serif typeface commissioned by Mozilla for Firefox OS. The family provides a broad range of weights and matching italics for interface and text use.
 Moniker: fira-sans

--- a/fonts/m/Mozilla/Fira/Sans/Condensed/4.202/Mozilla.Fira.Sans.Condensed.locale.en-US.yaml
+++ b/fonts/m/Mozilla/Fira/Sans/Condensed/4.202/Mozilla.Fira.Sans.Condensed.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Sans Condensed
 PackageUrl: https://mozilla.github.io/Fira/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/mozilla/Fira/blob/4.202/LICENSE
-Copyright: Digitized data copyright (c) 2012-2015, The Mozilla Foundation and Telefonica S.A.
+Copyright: Digitized data © 2012-2015 The Mozilla Foundation and Telefonica S.A.
 ShortDescription: Condensed-width member of Mozilla's humanist Fira Sans typeface family.
 Description: Fira Sans Condensed is the condensed-width member of the humanist Fira Sans family commissioned by Mozilla for Firefox OS, with a broad range of weights and matching italics.
 Moniker: fira-sans-condensed

--- a/fonts/m/madmalik/mononoki/1.6/madmalik.mononoki.locale.en-US.yaml
+++ b/fonts/m/madmalik/mononoki/1.6/madmalik.mononoki.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: mononoki
 PackageUrl: http://madmalik.github.io/mononoki/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/madmalik/mononoki/blob/HEAD/LICENSE
-Copyright: © 2022 Matthias Tellen matthias.tellen@googlemail.com, with Reserved Font Name mononoki
+Copyright: © 2022 Matthias Tellen matthias.tellen@googlemail.com, with Reserved Font Name mononoki.
 CopyrightUrl: https://github.com/madmalik/mononoki/blob/HEAD/LICENSE
 ShortDescription: A programming typeface designed for code formatting and code review
 Description: Mononoki is a monospace typeface designed for programming and code review. It works well on both high and low resolution displays, with glyphs optimized to survive when squashed into a grid of a few pixels while maintaining appropriate detail for print and retina displays. Each character is designed to be clearly distinguishable from similar looking characters. The font supports Latin, Cyrillic, Greek, and includes mathematical symbols, box-drawing characters, and an alternate stylistic set with dotted zero.

--- a/fonts/m/madmalik/mononoki/1.6/madmalik.mononoki.locale.en-US.yaml
+++ b/fonts/m/madmalik/mononoki/1.6/madmalik.mononoki.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: mononoki
 PackageUrl: http://madmalik.github.io/mononoki/
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/madmalik/mononoki/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2022, Matthias Tellen matthias.tellen@googlemail.com, with Reserved Font Name mononoki
+Copyright: © 2022 Matthias Tellen matthias.tellen@googlemail.com, with Reserved Font Name mononoki
 CopyrightUrl: https://github.com/madmalik/mononoki/blob/HEAD/LICENSE
 ShortDescription: A programming typeface designed for code formatting and code review
 Description: Mononoki is a monospace typeface designed for programming and code review. It works well on both high and low resolution displays, with glyphs optimized to survive when squashed into a grid of a few pixels while maintaining appropriate detail for print and retina displays. Each character is designed to be clearly distinguishable from similar looking characters. The font supports Latin, Cyrillic, Greek, and includes mathematical symbols, box-drawing characters, and an alternate stylistic set with dotted zero.

--- a/fonts/m/mishamyrt/Lilex/2.621/mishamyrt.Lilex.locale.en-US.yaml
+++ b/fonts/m/mishamyrt/Lilex/2.621/mishamyrt.Lilex.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Lilex
 PackageUrl: https://mishamyrt.github.io/Lilex/
 License: OFL-1.1
 LicenseUrl: https://github.com/mishamyrt/Lilex/blob/HEAD/OFL.txt
-Copyright: Copyright (c) Mikhael Khrustik
+Copyright: © Mikhael Khrustik
 CopyrightUrl: https://github.com/mishamyrt/Lilex/blob/HEAD/OFL.txt
 ShortDescription: An extended developer font based on IBM Plex Mono.
 Description: Lilex is an extended font on top of IBM Plex Mono designed for developers. It includes ligatures, special characters, Greek, and a variable format.

--- a/fonts/m/mishamyrt/Lilex/2.621/mishamyrt.Lilex.locale.en-US.yaml
+++ b/fonts/m/mishamyrt/Lilex/2.621/mishamyrt.Lilex.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Lilex
 PackageUrl: https://mishamyrt.github.io/Lilex/
 License: OFL-1.1
 LicenseUrl: https://github.com/mishamyrt/Lilex/blob/HEAD/OFL.txt
-Copyright: © Mikhael Khrustik
+Copyright: © Mikhael Khrustik.
 CopyrightUrl: https://github.com/mishamyrt/Lilex/blob/HEAD/OFL.txt
 ShortDescription: An extended developer font based on IBM Plex Mono.
 Description: Lilex is an extended font on top of IBM Plex Mono designed for developers. It includes ligatures, special characters, Greek, and a variable format.

--- a/fonts/m/mishamyrt/Lilex/2.700/mishamyrt.Lilex.locale.en-US.yaml
+++ b/fonts/m/mishamyrt/Lilex/2.700/mishamyrt.Lilex.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Lilex
 PackageUrl: https://mishamyrt.github.io/Lilex/
 License: OFL-1.1
 LicenseUrl: https://github.com/mishamyrt/Lilex/blob/HEAD/OFL.txt
-Copyright: Copyright (c) Mikhael Khrustik
+Copyright: © Mikhael Khrustik
 CopyrightUrl: https://github.com/mishamyrt/Lilex/blob/HEAD/OFL.txt
 ShortDescription: An extended developer font based on IBM Plex Mono.
 Description: Lilex is an extended font on top of IBM Plex Mono designed for developers. It includes ligatures, special characters, Greek, and a variable format.

--- a/fonts/m/mishamyrt/Lilex/2.700/mishamyrt.Lilex.locale.en-US.yaml
+++ b/fonts/m/mishamyrt/Lilex/2.700/mishamyrt.Lilex.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Lilex
 PackageUrl: https://mishamyrt.github.io/Lilex/
 License: OFL-1.1
 LicenseUrl: https://github.com/mishamyrt/Lilex/blob/HEAD/OFL.txt
-Copyright: © Mikhael Khrustik
+Copyright: © Mikhael Khrustik.
 CopyrightUrl: https://github.com/mishamyrt/Lilex/blob/HEAD/OFL.txt
 ShortDescription: An extended developer font based on IBM Plex Mono.
 Description: Lilex is an extended font on top of IBM Plex Mono designed for developers. It includes ligatures, special characters, Greek, and a variable format.

--- a/fonts/n/naver/D2Coding/1.3.2/naver.D2Coding.locale.en-US.yaml
+++ b/fonts/n/naver/D2Coding/1.3.2/naver.D2Coding.locale.en-US.yaml
@@ -13,8 +13,8 @@ PackageUrl: https://github.com/naver/d2codingfont
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/naver/d2codingfont/wiki/Open-Font-License
 Copyright: |-
-  Copyright (c) 2015, NAVER Corporation (http://www.navercorp.com), with Reserved Font Name D2Coding.
-  Copyright (c) 2015, NAVER Corporation (http://www.navercorp.com), with Reserved Font Name D2Coding-Bold.
+  © 2015 NAVER Corporation (http://www.navercorp.com), with Reserved Font Name D2Coding.
+  © 2015 NAVER Corporation (http://www.navercorp.com), with Reserved Font Name D2Coding-Bold.
 CopyrightUrl: https://github.com/naver/d2codingfont/wiki/Open-Font-License
 ShortDescription: A fixed-width font optimized for coding and character distinction.
 Description: D2 Coding is a fixed-width font optimized for coding, readability, and distinction between similar Latin, Hangul, numeric, and symbol characters.

--- a/fonts/n/naver/D2Coding/1.3.3/naver.D2Coding.locale.en-US.yaml
+++ b/fonts/n/naver/D2Coding/1.3.3/naver.D2Coding.locale.en-US.yaml
@@ -13,8 +13,8 @@ PackageUrl: https://github.com/naver/d2codingfont
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/naver/d2codingfont/wiki/Open-Font-License
 Copyright: |-
-  Copyright (c) 2015, NAVER Corporation (http://www.navercorp.com), with Reserved Font Name D2Coding.
-  Copyright (c) 2015, NAVER Corporation (http://www.navercorp.com), with Reserved Font Name D2Coding-Bold.
+  © 2015 NAVER Corporation (http://www.navercorp.com), with Reserved Font Name D2Coding.
+  © 2015 NAVER Corporation (http://www.navercorp.com), with Reserved Font Name D2Coding-Bold.
 CopyrightUrl: https://github.com/naver/d2codingfont/wiki/Open-Font-License
 ShortDescription: A fixed-width font optimized for coding and character distinction.
 Description: D2 Coding is a fixed-width font optimized for coding, readability, and distinction between similar Latin, Hangul, numeric, and symbol characters.

--- a/fonts/o/orioncactus/Pretendard/1.3.9/orioncactus.Pretendard.locale.en-US.yaml
+++ b/fonts/o/orioncactus/Pretendard/1.3.9/orioncactus.Pretendard.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Pretendard
 PackageUrl: https://github.com/orioncactus/pretendard
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/orioncactus/pretendard/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2021, Kil Hyung-jin, with Reserved Font Name Pretendard.
+Copyright: © 2021 Kil Hyung-jin, with Reserved Font Name Pretendard.
 ShortDescription: Cross-platform system-UI alternative for natural multilingual typography.
 Description: Pretendard is a modern cross-platform typeface based on Inter, Source Han Sans, and M PLUS 1p. It is designed for legibility and optical balance in multilingual reading environments and provides nine weights plus a variable font.
 Moniker: pretendard

--- a/fonts/p/Powerline/PowerlineSymbols/2.8.4/Powerline.PowerlineSymbols.locale.en-US.yaml
+++ b/fonts/p/Powerline/PowerlineSymbols/2.8.4/Powerline.PowerlineSymbols.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Powerline Symbols
 PackageUrl: https://powerline.readthedocs.io/en/latest/
 License: MIT
 LicenseUrl: https://github.com/powerline/powerline/blob/HEAD/LICENSE
-Copyright: © 2013 Kim Silkebækken and other contributors
+Copyright: © 2013 Kim Silkebækken and other contributors.
 CopyrightUrl: https://github.com/powerline/powerline/blob/HEAD/LICENSE
 ShortDescription: Symbol font containing glyphs used by Powerline statuslines and prompts
 Description: Powerline Symbols is a symbol font that provides the special glyphs used by the Powerline statusline and prompt plugin for vim, shells (bash, zsh, fish), tmux, and other applications. It supplies separators and additional symbols intended to be used alongside patched monospace fonts or as a fallback for Powerline-aware themes.

--- a/fonts/p/Powerline/PowerlineSymbols/2.8.4/Powerline.PowerlineSymbols.locale.en-US.yaml
+++ b/fonts/p/Powerline/PowerlineSymbols/2.8.4/Powerline.PowerlineSymbols.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Powerline Symbols
 PackageUrl: https://powerline.readthedocs.io/en/latest/
 License: MIT
 LicenseUrl: https://github.com/powerline/powerline/blob/HEAD/LICENSE
-Copyright: Copyright 2013 Kim Silkebækken and other contributors
+Copyright: © 2013 Kim Silkebækken and other contributors
 CopyrightUrl: https://github.com/powerline/powerline/blob/HEAD/LICENSE
 ShortDescription: Symbol font containing glyphs used by Powerline statuslines and prompts
 Description: Powerline Symbols is a symbol font that provides the special glyphs used by the Powerline statusline and prompt plugin for vim, shells (bash, zsh, fish), tmux, and other applications. It supplies separators and additional symbols intended to be used alongside patched monospace fonts or as a fallback for Powerline-aware themes.

--- a/fonts/r/RasmusAndersson/Inter/4.1/RasmusAndersson.Inter.locale.en-US.yaml
+++ b/fonts/r/RasmusAndersson/Inter/4.1/RasmusAndersson.Inter.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Inter
 PackageUrl: https://rsms.me/inter/
 License: OFL-1.1
 LicenseUrl: https://github.com/rsms/inter/blob/HEAD/LICENSE.txt
-Copyright: © The Inter Project Authors (https://github.com/rsms/inter)
+Copyright: © The Inter Project Authors (https://github.com/rsms/inter).
 CopyrightUrl: https://github.com/rsms/inter/blob/HEAD/LICENSE.txt
 ShortDescription: Inter is a workhorse of a typeface carefully crafted & designed for a wide range of applications, from detailed user interfaces to marketing & signage.
 Description: |-

--- a/fonts/r/RasmusAndersson/Inter/4.1/RasmusAndersson.Inter.locale.en-US.yaml
+++ b/fonts/r/RasmusAndersson/Inter/4.1/RasmusAndersson.Inter.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Inter
 PackageUrl: https://rsms.me/inter/
 License: OFL-1.1
 LicenseUrl: https://github.com/rsms/inter/blob/HEAD/LICENSE.txt
-Copyright: Copyright (c) The Inter Project Authors (https://github.com/rsms/inter)
+Copyright: © The Inter Project Authors (https://github.com/rsms/inter)
 CopyrightUrl: https://github.com/rsms/inter/blob/HEAD/LICENSE.txt
 ShortDescription: Inter is a workhorse of a typeface carefully crafted & designed for a wide range of applications, from detailed user interfaces to marketing & signage.
 Description: |-

--- a/fonts/r/rbanffy/3270/3.0.1/rbanffy.3270.locale.en-US.yaml
+++ b/fonts/r/rbanffy/3270/3.0.1/rbanffy.3270.locale.en-US.yaml
@@ -13,14 +13,14 @@ PackageUrl: https://github.com/rbanffy/3270font
 License: OFL-1.1
 LicenseUrl: https://github.com/rbanffy/3270font/blob/HEAD/LICENSE.txt
 Copyright: |-
-  Copyright 2022 The 3270font Authors (https://github.com/rbanffy/3270font)
+  © 2022 The 3270font Authors (https://github.com/rbanffy/3270font)
 
-  Copyright (c) 2011-2022, Ricardo Banffy.
-  Copyright (c) 1993-2011, Paul Mattes.
-  Copyright (c) 2004-2005, Don Russell.
-  Copyright (c) 2004, Dick Altenbern.
-  Copyright (c) 1990, Jeff Sparkes.
-  Copyright (c) 1989, Georgia Tech Research Corporation (GTRC), Atlanta, GA 30332.
+  © 2011-2022 Ricardo Banffy.
+  © 1993-2011 Paul Mattes.
+  © 2004-2005 Don Russell.
+  © 2004 Dick Altenbern.
+  © 1990 Jeff Sparkes.
+  © 1989 Georgia Tech Research Corporation (GTRC), Atlanta, GA 30332.
   All rights reserved.
 CopyrightUrl: https://github.com/rbanffy/3270font/blob/HEAD/LICENSE.txt
 ShortDescription: A 3270 font in a modern format

--- a/fonts/r/rbanffy/3270/3.0.1/rbanffy.3270.locale.en-US.yaml
+++ b/fonts/r/rbanffy/3270/3.0.1/rbanffy.3270.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageUrl: https://github.com/rbanffy/3270font
 License: OFL-1.1
 LicenseUrl: https://github.com/rbanffy/3270font/blob/HEAD/LICENSE.txt
 Copyright: |-
-  © 2022 The 3270font Authors (https://github.com/rbanffy/3270font)
+  © 2022 The 3270font Authors (https://github.com/rbanffy/3270font).
 
   © 2011-2022 Ricardo Banffy.
   © 1993-2011 Paul Mattes.

--- a/fonts/r/rubjo/VictorMono/1.5.6/rubjo.VictorMono.locale.en-US.yaml
+++ b/fonts/r/rubjo/VictorMono/1.5.6/rubjo.VictorMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Victor Mono
 PackageUrl: https://rubjo.github.io/victor-mono/
 License: OFL-1.1
 LicenseUrl: https://github.com/rubjo/victor-mono/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2021, Rune Bjørnerås (https://github.com/rubjo)
+Copyright: © 2021 Rune Bjørnerås (https://github.com/rubjo)
 CopyrightUrl: https://github.com/rubjo/victor-mono/blob/HEAD/LICENSE
 ShortDescription: Free programming font with cursive italics and ligatures
 Description: Victor Mono is a free and open-source programming font featuring semi-connected cursive italics and symbol ligatures. Designed for readability and aesthetics in code editors, it combines a monospace design with expressive italic variants to enhance code readability.

--- a/fonts/r/rubjo/VictorMono/1.5.6/rubjo.VictorMono.locale.en-US.yaml
+++ b/fonts/r/rubjo/VictorMono/1.5.6/rubjo.VictorMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Victor Mono
 PackageUrl: https://rubjo.github.io/victor-mono/
 License: OFL-1.1
 LicenseUrl: https://github.com/rubjo/victor-mono/blob/HEAD/LICENSE
-Copyright: © 2021 Rune Bjørnerås (https://github.com/rubjo)
+Copyright: © 2021 Rune Bjørnerås (https://github.com/rubjo).
 CopyrightUrl: https://github.com/rubjo/victor-mono/blob/HEAD/LICENSE
 ShortDescription: Free programming font with cursive italics and ligatures
 Description: Victor Mono is a free and open-source programming font featuring semi-connected cursive italics and symbol ligatures. Designed for readability and aesthetics in code editors, it combines a monospace design with expressive italic variants to enhance code readability.

--- a/fonts/r/ryanoasis/0xProto/3.4.0/ryanoasis.0xProto.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/0xProto/3.4.0/ryanoasis.0xProto.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: 0xProto Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A programming font focused on source code legibility
 Description: |-

--- a/fonts/r/ryanoasis/0xProto/3.5.0/ryanoasis.0xProto.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/0xProto/3.5.0/ryanoasis.0xProto.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: 0xProto Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A programming font focused on source code legibility
 Description: |-

--- a/fonts/r/ryanoasis/3270/3.4.0/ryanoasis.3270.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/3270/3.4.0/ryanoasis.3270.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: 3270 Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A 3270 font in a modern format
 Moniker: 3270-nerd-font

--- a/fonts/r/ryanoasis/3270/3.5.0/ryanoasis.3270.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/3270/3.5.0/ryanoasis.3270.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: 3270 Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A 3270 font in a modern format
 Moniker: 3270-nerd-font

--- a/fonts/r/ryanoasis/AdwaitaMono/3.4.0/ryanoasis.AdwaitaMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AdwaitaMono/3.4.0/ryanoasis.AdwaitaMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: AdwaitaMono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced typeface in the Adwaita family for coding and interface use.
 Moniker: adwaitamono-nerd-font

--- a/fonts/r/ryanoasis/AdwaitaMono/3.5.0/ryanoasis.AdwaitaMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AdwaitaMono/3.5.0/ryanoasis.AdwaitaMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: AdwaitaMono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced typeface in the Adwaita family for coding and interface use.
 Moniker: adwaitamono-nerd-font

--- a/fonts/r/ryanoasis/Agave/3.4.0/ryanoasis.Agave.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Agave/3.4.0/ryanoasis.Agave.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Agave Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A small, monospaced, outline font that is geometrically regular and simple
 Description: Agave is a fixed-width outline typeface designed for programming and terminal use. It features a simple, geometrically regular design based on the power of two and golden ratio principles. The font supports over 2,400 glyphs including ASCII, Latin extended, Greek, Cyrillic, IPA, mathematical symbols, arrows, box-drawing characters, Braille, and Powerline symbols.

--- a/fonts/r/ryanoasis/Agave/3.5.0/ryanoasis.Agave.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Agave/3.5.0/ryanoasis.Agave.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Agave Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A small, monospaced, outline font that is geometrically regular and simple
 Description: Agave is a fixed-width outline typeface designed for programming and terminal use. It features a simple, geometrically regular design based on the power of two and golden ratio principles. The font supports over 2,400 glyphs including ASCII, Latin extended, Greek, Cyrillic, IPA, mathematical symbols, arrows, box-drawing characters, Braille, and Powerline symbols.

--- a/fonts/r/ryanoasis/AnonymicePro/3.4.0/ryanoasis.AnonymicePro.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AnonymicePro/3.4.0/ryanoasis.AnonymicePro.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Anonymice Pro Nerd Font (Anonymous Pro)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Anonymous Pro is a family of four fixed-width fonts designed with coding in mind.
 Description: Anonymous Pro (2009) is a family of four fixed-width fonts designed with coding in mind. Anonymous Pro features an international, Unicode-based character set, with support for most Western and Central European Latin-based languages, plus Greek and Cyrillic. Anonymous Pro is based on an earlier font, Anonymous™ (2001), my TrueType version of Anonymous 9, a Macintosh bitmap font developed in the mid-’90s by Susan Lesch and David Lamkins.

--- a/fonts/r/ryanoasis/AnonymicePro/3.5.0/ryanoasis.AnonymicePro.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AnonymicePro/3.5.0/ryanoasis.AnonymicePro.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Anonymice Pro Nerd Font (Anonymous Pro)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Anonymous Pro is a family of four fixed-width fonts designed with coding in mind.
 Description: Anonymous Pro (2009) is a family of four fixed-width fonts designed with coding in mind. Anonymous Pro features an international, Unicode-based character set, with support for most Western and Central European Latin-based languages, plus Greek and Cyrillic. Anonymous Pro is based on an earlier font, Anonymous™ (2001), my TrueType version of Anonymous 9, a Macintosh bitmap font developed in the mid-’90s by Susan Lesch and David Lamkins.

--- a/fonts/r/ryanoasis/Arimo/3.4.0/ryanoasis.Arimo.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Arimo/3.4.0/ryanoasis.Arimo.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Arimo Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A sans-serif font metrically compatible with Arial, designed for improved on-screen readability
 Description: Arimo is an innovative, refreshing sans-serif font designed by Steve Matteson to be metrically compatible with Arial while providing improved on-screen readability characteristics. It features a pan-European WGL character set and is ideal for developers looking for a width-compatible font to address document portability across platforms. Available in Regular, Italic, Medium, SemiBold, Bold, and Bold Italic styles, Arimo combines elegant design with excellent screen rendering and was updated in May 2013 with improved hinting.

--- a/fonts/r/ryanoasis/Arimo/3.5.0/ryanoasis.Arimo.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Arimo/3.5.0/ryanoasis.Arimo.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Arimo Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A sans-serif font metrically compatible with Arial, designed for improved on-screen readability
 Description: Arimo is an innovative, refreshing sans-serif font designed by Steve Matteson to be metrically compatible with Arial while providing improved on-screen readability characteristics. It features a pan-European WGL character set and is ideal for developers looking for a width-compatible font to address document portability across platforms. Available in Regular, Italic, Medium, SemiBold, Bold, and Bold Italic styles, Arimo combines elegant design with excellent screen rendering and was updated in May 2013 with improved hinting.

--- a/fonts/r/ryanoasis/AtkynsonMono/3.4.0/ryanoasis.AtkynsonMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AtkynsonMono/3.4.0/ryanoasis.AtkynsonMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: AtkynsonMono Nerd Font (Atkinson Hyperlegible Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced companion to Atkinson Hyperlegible with clear, highly distinct letterforms.
 Moniker: atkynsonmono-nerd-font

--- a/fonts/r/ryanoasis/AtkynsonMono/3.5.0/ryanoasis.AtkynsonMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AtkynsonMono/3.5.0/ryanoasis.AtkynsonMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: AtkynsonMono Nerd Font (Atkinson Hyperlegible Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced companion to Atkinson Hyperlegible with clear, highly distinct letterforms.
 Moniker: atkynsonmono-nerd-font

--- a/fonts/r/ryanoasis/AurulentSansMono/3.4.0/ryanoasis.AurulentSansMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AurulentSansMono/3.4.0/ryanoasis.AurulentSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Aurulent Sans Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Aurulent Sans Mono is a sans serif font designed by Stephen G. Hartke who also created Verily Serif.
 Moniker: aurulent-sans-mono-nerd-font

--- a/fonts/r/ryanoasis/AurulentSansMono/3.5.0/ryanoasis.AurulentSansMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AurulentSansMono/3.5.0/ryanoasis.AurulentSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Aurulent Sans Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Aurulent Sans Mono is a sans serif font designed by Stephen G. Hartke who also created Verily Serif.
 Moniker: aurulent-sans-mono-nerd-font

--- a/fonts/r/ryanoasis/BigBlueTerminal/3.4.0/ryanoasis.BigBlueTerminal.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/BigBlueTerminal/3.4.0/ryanoasis.BigBlueTerminal.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Big Blue Terminal Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An oldschool fixed-width pixel font for terminal environments
 Description: BigBlue Terminal is a monospaced pixel font designed for use in fixed-width textual environments such as consoles, terminals, and code editors. Based on IBM's classic 8x14 EGA/VGA character set, it fits into an 8x12-pixel cell with the metrics and dimensions of Windows' old Terminal font. The font is compact and readable, featuring a classic retro aesthetic while supporting Unicode and extended character sets for international scripts and symbols.

--- a/fonts/r/ryanoasis/BigBlueTerminal/3.5.0/ryanoasis.BigBlueTerminal.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/BigBlueTerminal/3.5.0/ryanoasis.BigBlueTerminal.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Big Blue Terminal Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An oldschool fixed-width pixel font for terminal environments
 Description: BigBlue Terminal is a monospaced pixel font designed for use in fixed-width textual environments such as consoles, terminals, and code editors. Based on IBM's classic 8x14 EGA/VGA character set, it fits into an 8x12-pixel cell with the metrics and dimensions of Windows' old Terminal font. The font is compact and readable, featuring a classic retro aesthetic while supporting Unicode and extended character sets for international scripts and symbols.

--- a/fonts/r/ryanoasis/BitstromWera/3.4.0/ryanoasis.BitstromWera.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/BitstromWera/3.4.0/ryanoasis.BitstromWera.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Bitstrom Wera Sans Mono Nerd Font (Bitstream Vera Sans Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A digital typeface superfamily with generous open-source licensing
 Description: Bitstream Vera is a comprehensive digital typeface superfamily designed by Jim Lyles at Bitstream Inc., featuring serif, sans-serif, and monospace font families. Released in 2003 with liberal open-source licensing terms, it provides full TrueType hinting instructions for improved rendering on low-resolution displays. The monospace variant is particularly well-suited for technical work, clearly distinguishing similar characters like lowercase "l" from "1" and "0" from "O". Bitstream Vera Sans is also the default font for the Python Matplotlib library.

--- a/fonts/r/ryanoasis/BitstromWera/3.5.0/ryanoasis.BitstromWera.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/BitstromWera/3.5.0/ryanoasis.BitstromWera.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Bitstrom Wera Sans Mono Nerd Font (Bitstream Vera Sans Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A digital typeface superfamily with generous open-source licensing
 Description: Bitstream Vera is a comprehensive digital typeface superfamily designed by Jim Lyles at Bitstream Inc., featuring serif, sans-serif, and monospace font families. Released in 2003 with liberal open-source licensing terms, it provides full TrueType hinting instructions for improved rendering on low-resolution displays. The monospace variant is particularly well-suited for technical work, clearly distinguishing similar characters like lowercase "l" from "1" and "0" from "O". Bitstream Vera Sans is also the default font for the Python Matplotlib library.

--- a/fonts/r/ryanoasis/BlexMono/3.4.0/ryanoasis.BlexMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/BlexMono/3.4.0/ryanoasis.BlexMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Blex Mono Nerd Font (IBM Plex Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: IBM's monospaced typeface, a versatile monospace font designed for code and terminal environments.
 Description: IBM Plex Mono is IBM's monospaced typeface from the Plex font family, carefully designed to meet the needs of a global technology company. This open-source font is optimized for code editors, terminals, and developer environments. Available in multiple weights with both Roman and true italic variants, IBM Plex Mono supports extended Latin, Arabic, Chinese (Traditional), Cyrillic, Devanagari, Greek, Hebrew, Japanese, Korean, and Thai. It provides a monospaced alternative to the IBM Plex Sans family while maintaining the same design philosophy and versatility. The font is ideal for programming, terminal usage, and other monospace typography needs.

--- a/fonts/r/ryanoasis/BlexMono/3.5.0/ryanoasis.BlexMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/BlexMono/3.5.0/ryanoasis.BlexMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Blex Mono Nerd Font (IBM Plex Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: IBM's monospaced typeface, a versatile monospace font designed for code and terminal environments.
 Description: IBM Plex Mono is IBM's monospaced typeface from the Plex font family, carefully designed to meet the needs of a global technology company. This open-source font is optimized for code editors, terminals, and developer environments. Available in multiple weights with both Roman and true italic variants, IBM Plex Mono supports extended Latin, Arabic, Chinese (Traditional), Cyrillic, Devanagari, Greek, Hebrew, Japanese, Korean, and Thai. It provides a monospaced alternative to the IBM Plex Sans family while maintaining the same design philosophy and versatility. The font is ideal for programming, terminal usage, and other monospace typography needs.

--- a/fonts/r/ryanoasis/Caskaydia/Cove/3.4.0/ryanoasis.Caskaydia.Cove.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Caskaydia/Cove/3.4.0/ryanoasis.Caskaydia.Cove.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: CaskaydiaCove Nerd Font (Cascadia Code)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Monospaced font family for user interface and coding environments.
 Description: Cascadia is a coding font bundled with Windows Terminal and used as the default font in Visual Studio. Cascadia Code includes programming ligatures, while Cascadia Mono omits ligatures.

--- a/fonts/r/ryanoasis/Caskaydia/Cove/3.5.0/ryanoasis.Caskaydia.Cove.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Caskaydia/Cove/3.5.0/ryanoasis.Caskaydia.Cove.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: CaskaydiaCove Nerd Font (Cascadia Code)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: © 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Monospaced font family for user interface and coding environments.
 Description: Cascadia is a coding font bundled with Windows Terminal and used as the default font in Visual Studio. Cascadia Code includes programming ligatures, while Cascadia Mono omits ligatures.

--- a/fonts/r/ryanoasis/Caskaydia/Mono/3.4.0/ryanoasis.Caskaydia.Mono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Caskaydia/Mono/3.4.0/ryanoasis.Caskaydia.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: CaskaydiaMono Nerd Font (Cascadia Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Monospaced font family for user interface and coding environments.
 Description: Cascadia is a coding font bundled with Windows Terminal and used as the default font in Visual Studio. Cascadia Code includes programming ligatures, while Cascadia Mono omits ligatures.

--- a/fonts/r/ryanoasis/Caskaydia/Mono/3.5.0/ryanoasis.Caskaydia.Mono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Caskaydia/Mono/3.5.0/ryanoasis.Caskaydia.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: CaskaydiaMono Nerd Font (Cascadia Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Monospaced font family for user interface and coding environments.
 Description: Cascadia is a coding font bundled with Windows Terminal and used as the default font in Visual Studio. Cascadia Code includes programming ligatures, while Cascadia Mono omits ligatures.

--- a/fonts/r/ryanoasis/CodeNewRoman/3.4.0/ryanoasis.CodeNewRoman.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/CodeNewRoman/3.4.0/ryanoasis.CodeNewRoman.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Code New Roman Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospace typeface combining classic design with modern readability for code.
 Description: Code New Roman is a monospace typeface designed for source code and terminal use. It combines the timeless elegance of serif monospace fonts with excellent character legibility and distinction. The font features even spacing and clarity, making it suitable for extended reading in development environments and terminal applications.

--- a/fonts/r/ryanoasis/CodeNewRoman/3.5.0/ryanoasis.CodeNewRoman.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/CodeNewRoman/3.5.0/ryanoasis.CodeNewRoman.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Code New Roman Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospace typeface combining classic design with modern readability for code.
 Description: Code New Roman is a monospace typeface designed for source code and terminal use. It combines the timeless elegance of serif monospace fonts with excellent character legibility and distinction. The font features even spacing and clarity, making it suitable for extended reading in development environments and terminal applications.

--- a/fonts/r/ryanoasis/ComicShannsMono/3.4.0/ryanoasis.ComicShannsMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ComicShannsMono/3.4.0/ryanoasis.ComicShannsMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Comic Shanns Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced programming font based on Comic Shanns.
 Description: Comic Shanns Mono is a monospaced programming font based on Comic Shanns, packaged with regular and bold styles.

--- a/fonts/r/ryanoasis/ComicShannsMono/3.5.0/ryanoasis.ComicShannsMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ComicShannsMono/3.5.0/ryanoasis.ComicShannsMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Comic Shanns Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced programming font based on Comic Shanns.
 Description: Comic Shanns Mono is a monospaced programming font based on Comic Shanns, packaged with regular and bold styles.

--- a/fonts/r/ryanoasis/CommitMono/3.4.0/ryanoasis.CommitMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/CommitMono/3.4.0/ryanoasis.CommitMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Commit Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Commit Mono is an anonymous and neutral programming typeface.
 Description: Commit Mono is an anonymous and neutral coding font focused on creating a better reading experience for developers. The typeface is designed for use in code editors and terminals, with careful attention to legibility and character distinction. It features multiple weights and customizable design variations to suit different coding preferences.

--- a/fonts/r/ryanoasis/CommitMono/3.5.0/ryanoasis.CommitMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/CommitMono/3.5.0/ryanoasis.CommitMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Commit Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Commit Mono is an anonymous and neutral programming typeface.
 Description: Commit Mono is an anonymous and neutral coding font focused on creating a better reading experience for developers. The typeface is designed for use in code editors and terminals, with careful attention to legibility and character distinction. It features multiple weights and customizable design variations to suit different coding preferences.

--- a/fonts/r/ryanoasis/Cousine/3.4.0/ryanoasis.Cousine.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Cousine/3.4.0/ryanoasis.Cousine.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Cousine Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospace font metrically compatible with Courier New, designed for improved readability
 Description: Cousine is an innovative, refreshing monospace sans-serif font designed by Steve Matteson to be metrically compatible with Courier New while providing improved on-screen readability characteristics. It features a pan-European WGL character set and is ideal for developers looking for a width-compatible font to address document portability across platforms. Available in Regular, Italic, Bold, and Bold Italic styles, Cousine combines clean design with excellent screen rendering.

--- a/fonts/r/ryanoasis/Cousine/3.5.0/ryanoasis.Cousine.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Cousine/3.5.0/ryanoasis.Cousine.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Cousine Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospace font metrically compatible with Courier New, designed for improved readability
 Description: Cousine is an innovative, refreshing monospace sans-serif font designed by Steve Matteson to be metrically compatible with Courier New while providing improved on-screen readability characteristics. It features a pan-European WGL character set and is ideal for developers looking for a width-compatible font to address document portability across platforms. Available in Regular, Italic, Bold, and Bold Italic styles, Cousine combines clean design with excellent screen rendering.

--- a/fonts/r/ryanoasis/D2Koding/3.4.0/ryanoasis.D2Koding.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/D2Koding/3.4.0/ryanoasis.D2Koding.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: D2Koding Nerd Font (D2Coding)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A fixed-width font optimized for coding and character distinction.
 Description: D2 Coding is a fixed-width font optimized for coding, readability, and distinction between similar Latin, Hangul, numeric, and symbol characters.

--- a/fonts/r/ryanoasis/D2Koding/3.5.0/ryanoasis.D2Koding.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/D2Koding/3.5.0/ryanoasis.D2Koding.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: D2Koding Nerd Font (D2Coding)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A fixed-width font optimized for coding and character distinction.
 Description: D2 Coding is a fixed-width font optimized for coding, readability, and distinction between similar Latin, Hangul, numeric, and symbol characters.

--- a/fonts/r/ryanoasis/DaddyTimeMono/3.4.0/ryanoasis.DaddyTimeMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DaddyTimeMono/3.4.0/ryanoasis.DaddyTimeMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Daddy Time Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced typeface by James O. Friends.
 Description: Daddy Time Mono is a monospaced typeface by James O. Friends with regular, mono, and proportional variants.

--- a/fonts/r/ryanoasis/DaddyTimeMono/3.5.0/ryanoasis.DaddyTimeMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DaddyTimeMono/3.5.0/ryanoasis.DaddyTimeMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Daddy Time Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced typeface by James O. Friends.
 Description: Daddy Time Mono is a monospaced typeface by James O. Friends with regular, mono, and proportional variants.

--- a/fonts/r/ryanoasis/DejaVuSansMono/3.4.0/ryanoasis.DejaVuSansMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DejaVuSansMono/3.4.0/ryanoasis.DejaVuSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: DejaVu Sans Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A versatile monospace font derived from Bitstream Vera with comprehensive Unicode support for technical and professional use
 Description: DejaVu Sans Mono is a monospace typeface designed for optimal readability in technical environments. Based on the Bitstream Vera font family, it provides extensive Unicode coverage including Latin, Greek, Cyrillic, Armenian, and Georgian scripts, plus mathematical symbols and arrows. The font features clear visual distinction between easily-confused characters such as zero (0) and the letter O, numeral one (1) and lowercase L, and uppercase I, making it ideal for code editors, terminals, and programming. Available in Book, Bold, Oblique, and Bold Oblique styles.

--- a/fonts/r/ryanoasis/DejaVuSansMono/3.5.0/ryanoasis.DejaVuSansMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DejaVuSansMono/3.5.0/ryanoasis.DejaVuSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: DejaVu Sans Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A versatile monospace font derived from Bitstream Vera with comprehensive Unicode support for technical and professional use
 Description: DejaVu Sans Mono is a monospace typeface designed for optimal readability in technical environments. Based on the Bitstream Vera font family, it provides extensive Unicode coverage including Latin, Greek, Cyrillic, Armenian, and Georgian scripts, plus mathematical symbols and arrows. The font features clear visual distinction between easily-confused characters such as zero (0) and the letter O, numeral one (1) and lowercase L, and uppercase I, making it ideal for code editors, terminals, and programming. Available in Book, Bold, Oblique, and Bold Oblique styles.

--- a/fonts/r/ryanoasis/DepartureMono/3.4.0/ryanoasis.DepartureMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DepartureMono/3.4.0/ryanoasis.DepartureMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Departure Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A pixel-inspired monospaced typeface.
 Description: Departure Mono is a pixel-inspired monospaced typeface with regular, mono, and proportional variants.

--- a/fonts/r/ryanoasis/DepartureMono/3.5.0/ryanoasis.DepartureMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DepartureMono/3.5.0/ryanoasis.DepartureMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Departure Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A pixel-inspired monospaced typeface.
 Description: Departure Mono is a pixel-inspired monospaced typeface with regular, mono, and proportional variants.

--- a/fonts/r/ryanoasis/DroidSansMono/3.4.0/ryanoasis.DroidSansMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DroidSansMono/3.4.0/ryanoasis.DroidSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Droid Sans Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A versatile monospaced font with extensive character set support, originally designed for mobile devices and optimized for code editors and terminals
 Moniker: droid-sans-nerd-font

--- a/fonts/r/ryanoasis/DroidSansMono/3.5.0/ryanoasis.DroidSansMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DroidSansMono/3.5.0/ryanoasis.DroidSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Droid Sans Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A versatile monospaced font with extensive character set support, originally designed for mobile devices and optimized for code editors and terminals
 Moniker: droid-sans-nerd-font

--- a/fonts/r/ryanoasis/EnvyCodeR/3.4.0/ryanoasis.EnvyCodeR.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/EnvyCodeR/3.4.0/ryanoasis.EnvyCodeR.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Envy Code R Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A programming font by Damien Guard.
 Description: Envy Code R is a programming font by Damien Guard with regular, mono, and proportional variants.

--- a/fonts/r/ryanoasis/EnvyCodeR/3.5.0/ryanoasis.EnvyCodeR.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/EnvyCodeR/3.5.0/ryanoasis.EnvyCodeR.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Envy Code R Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A programming font by Damien Guard.
 Description: Envy Code R is a programming font by Damien Guard with regular, mono, and proportional variants.

--- a/fonts/r/ryanoasis/FantasqueSansMono/3.4.0/ryanoasis.FantasqueSansMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/FantasqueSansMono/3.4.0/ryanoasis.FantasqueSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fantasque Sans Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A programming font with handwriting-like fuzziness
 Description: A programming font designed with functionality in mind, featuring wibbly-wobbly handwriting-like fuzziness that makes it unassumingly cool. Includes bold and italic variants with the same metrics, extensive glyph coverage including Latin letters, accented glyphs, Greek letters, and arrows. Inspirational sources include Inconsolata, Monaco, and Consolas.

--- a/fonts/r/ryanoasis/FantasqueSansMono/3.5.0/ryanoasis.FantasqueSansMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/FantasqueSansMono/3.5.0/ryanoasis.FantasqueSansMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fantasque Sans Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A programming font with handwriting-like fuzziness
 Description: A programming font designed with functionality in mind, featuring wibbly-wobbly handwriting-like fuzziness that makes it unassumingly cool. Includes bold and italic variants with the same metrics, extensive glyph coverage including Latin letters, accented glyphs, Greek letters, and arrows. Inspirational sources include Inconsolata, Monaco, and Consolas.

--- a/fonts/r/ryanoasis/FiraCode/3.4.0/ryanoasis.FiraCode.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/FiraCode/3.4.0/ryanoasis.FiraCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Code Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Extension of the Fira Mono font with programming ligatures.
 Description: |-

--- a/fonts/r/ryanoasis/FiraCode/3.5.0/ryanoasis.FiraCode.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/FiraCode/3.5.0/ryanoasis.FiraCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Code Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Extension of the Fira Mono font with programming ligatures.
 Description: |-

--- a/fonts/r/ryanoasis/FiraMono/3.4.0/ryanoasis.FiraMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/FiraMono/3.4.0/ryanoasis.FiraMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Fira Mono is a Mozilla-designed monospaced family with crisp glyphs plus icon and powerline coverage tuned for terminals and tooling.
 Moniker: fira-mono-nerd-font

--- a/fonts/r/ryanoasis/FiraMono/3.5.0/ryanoasis.FiraMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/FiraMono/3.5.0/ryanoasis.FiraMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Fira Mono is a Mozilla-designed monospaced family with crisp glyphs plus icon and powerline coverage tuned for terminals and tooling.
 Moniker: fira-mono-nerd-font

--- a/fonts/r/ryanoasis/GeistMono/3.4.0/ryanoasis.GeistMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/GeistMono/3.4.0/ryanoasis.GeistMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/r/ryanoasis/GeistMono/3.5.0/ryanoasis.GeistMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/GeistMono/3.5.0/ryanoasis.GeistMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/r/ryanoasis/GoMono/3.4.0/ryanoasis.GoMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/GoMono/3.4.0/ryanoasis.GoMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Go Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A workhorse monospace typeface designed for source code, with excellent legibility and Powerline support included.
 Description: |-

--- a/fonts/r/ryanoasis/GoMono/3.5.0/ryanoasis.GoMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/GoMono/3.5.0/ryanoasis.GoMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Go Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A workhorse monospace typeface designed for source code, with excellent legibility and Powerline support included.
 Description: |-

--- a/fonts/r/ryanoasis/Gohu/3.4.0/ryanoasis.Gohu.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Gohu/3.4.0/ryanoasis.Gohu.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Gohu Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Legible monospace bitmap font optimized for terminals and programming
 Description: |-

--- a/fonts/r/ryanoasis/Gohu/3.5.0/ryanoasis.Gohu.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Gohu/3.5.0/ryanoasis.Gohu.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Gohu Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Legible monospace bitmap font optimized for terminals and programming
 Description: |-

--- a/fonts/r/ryanoasis/Hack/3.4.0/ryanoasis.Hack.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Hack/3.4.0/ryanoasis.Hack.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Hack Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A workhorse monospace typeface designed for source code, with excellent legibility and Powerline support included.
 Description: Hack is a carefully hand-groomed and optically balanced monospace typeface designed for source code. It features a large x-height, wide aperture, and low contrast design for optimal legibility at commonly used source code text sizes (8-14pt range). Available in four styles (Regular, Bold, Italic, Bold Italic), Hack includes over 1500 glyphs supporting extended Latin, Greek, and Cyrillic character sets, plus Powerline symbols included by default with no patching required. The font is based on the Bitstream Vera and DejaVu projects, re-designed with an expanded glyph set, optimized metrics, and distinctive features like strategically placed serifs on narrow characters and semi-bold punctuation for better code clarity.

--- a/fonts/r/ryanoasis/Hack/3.5.0/ryanoasis.Hack.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Hack/3.5.0/ryanoasis.Hack.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Hack Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A workhorse monospace typeface designed for source code, with excellent legibility and Powerline support included.
 Description: Hack is a carefully hand-groomed and optically balanced monospace typeface designed for source code. It features a large x-height, wide aperture, and low contrast design for optimal legibility at commonly used source code text sizes (8-14pt range). Available in four styles (Regular, Bold, Italic, Bold Italic), Hack includes over 1500 glyphs supporting extended Latin, Greek, and Cyrillic character sets, plus Powerline symbols included by default with no patching required. The font is based on the Bitstream Vera and DejaVu projects, re-designed with an expanded glyph set, optimized metrics, and distinctive features like strategically placed serifs on narrow characters and semi-bold punctuation for better code clarity.

--- a/fonts/r/ryanoasis/Hasklug/3.4.0/ryanoasis.Hasklug.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Hasklug/3.4.0/ryanoasis.Hasklug.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Hasklug Nerd Font (Hasklig)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Code font with monospaced ligatures for improved readability
 Description: Hasklig is a code font based on Source Code Pro that adds ligatures for commonly used multi-character operators and symbols. It improves the readability of complex code by rendering combined character operators like ->, =>, >>=, and other Haskell-specific symbols as cohesive glyphs while preserving the underlying multi-character representation. This allows for better visual representation of code without alignment issues that occur with Unicode substitutes.

--- a/fonts/r/ryanoasis/Hasklug/3.5.0/ryanoasis.Hasklug.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Hasklug/3.5.0/ryanoasis.Hasklug.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Hasklug Nerd Font (Hasklig)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Code font with monospaced ligatures for improved readability
 Description: Hasklig is a code font based on Source Code Pro that adds ligatures for commonly used multi-character operators and symbols. It improves the readability of complex code by rendering combined character operators like ->, =>, >>=, and other Haskell-specific symbols as cohesive glyphs while preserving the underlying multi-character representation. This allows for better visual representation of code without alignment issues that occur with Unicode substitutes.

--- a/fonts/r/ryanoasis/HeavyDataMono/3.4.0/ryanoasis.HeavyDataMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/HeavyDataMono/3.4.0/ryanoasis.HeavyDataMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Heavy Data Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced display typeface with a dotted zero.
 Description: Heavy Data is a monospaced display typeface with a novel design and dotted zero.

--- a/fonts/r/ryanoasis/HeavyDataMono/3.5.0/ryanoasis.HeavyDataMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/HeavyDataMono/3.5.0/ryanoasis.HeavyDataMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Heavy Data Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced display typeface with a dotted zero.
 Description: Heavy Data is a monospaced display typeface with a novel design and dotted zero.

--- a/fonts/r/ryanoasis/Hurmit/3.4.0/ryanoasis.Hurmit.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Hurmit/3.4.0/ryanoasis.Hurmit.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Hurmit Nerd Font (Hermit)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced font designed for coding and terminal use.
 Description: Hurmit is a monospaced font designed for coding and terminal use, with symbols that stand out from common text.

--- a/fonts/r/ryanoasis/Hurmit/3.5.0/ryanoasis.Hurmit.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Hurmit/3.5.0/ryanoasis.Hurmit.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Hurmit Nerd Font (Hermit)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced font designed for coding and terminal use.
 Description: Hurmit is a monospaced font designed for coding and terminal use, with symbols that stand out from common text.

--- a/fonts/r/ryanoasis/Inconsolata/3.4.0/ryanoasis.Inconsolata.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Inconsolata/3.4.0/ryanoasis.Inconsolata.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Inconsolata Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Monospaced font family for user interface and coding environments.
 Description: Inconsolata is an open-source monospace font designed for code listings.

--- a/fonts/r/ryanoasis/Inconsolata/3.5.0/ryanoasis.Inconsolata.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Inconsolata/3.5.0/ryanoasis.Inconsolata.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Inconsolata Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Monospaced font family for user interface and coding environments.
 Description: Inconsolata is an open-source monospace font designed for code listings.

--- a/fonts/r/ryanoasis/InconsolataGo/3.4.0/ryanoasis.InconsolataGo.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/InconsolataGo/3.4.0/ryanoasis.InconsolataGo.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Inconsolata Go Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A humanist sans monospace font designed for code listings and print
 Description: Inconsolata Go is a humanist sans monospace font designed for code listings and print. Inspired by Luc de Groot's Consolas and Adrian Frutiger's Avenir, it combines the clarity of clean lines with careful attention to detail for high resolution rendering. The font features subtle curves in select lowercase letters, micro-serifs borrowed from Japanese Gothic fonts for enhanced crispness, and numerals influenced by Morris Fuller Benton's Franklin Gothic family.

--- a/fonts/r/ryanoasis/InconsolataGo/3.5.0/ryanoasis.InconsolataGo.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/InconsolataGo/3.5.0/ryanoasis.InconsolataGo.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Inconsolata Go Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A humanist sans monospace font designed for code listings and print
 Description: Inconsolata Go is a humanist sans monospace font designed for code listings and print. Inspired by Luc de Groot's Consolas and Adrian Frutiger's Avenir, it combines the clarity of clean lines with careful attention to detail for high resolution rendering. The font features subtle curves in select lowercase letters, micro-serifs borrowed from Japanese Gothic fonts for enhanced crispness, and numerals influenced by Morris Fuller Benton's Franklin Gothic family.

--- a/fonts/r/ryanoasis/InconsolataLGC/3.4.0/ryanoasis.InconsolataLGC.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/InconsolataLGC/3.4.0/ryanoasis.InconsolataLGC.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Inconsolata LGC Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A modified Inconsolata with Cyrillic, Greek, bold, and italic styles.
 Description: Inconsolata LGC is a modified version of Inconsolata with Cyrillic alphabet support, modern Greek support, and added bold and italic styles.

--- a/fonts/r/ryanoasis/InconsolataLGC/3.5.0/ryanoasis.InconsolataLGC.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/InconsolataLGC/3.5.0/ryanoasis.InconsolataLGC.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Inconsolata LGC Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A modified Inconsolata with Cyrillic, Greek, bold, and italic styles.
 Description: Inconsolata LGC is a modified version of Inconsolata with Cyrillic alphabet support, modern Greek support, and added bold and italic styles.

--- a/fonts/r/ryanoasis/IntoneMono/3.4.0/ryanoasis.IntoneMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/IntoneMono/3.4.0/ryanoasis.IntoneMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Intone Mono Nerd Font (Intel One Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An expressive monospaced font built for developers.
 Description: Intel One Mono is an expressive monospaced font family built with clarity, legibility, and the needs of developers in mind.

--- a/fonts/r/ryanoasis/IntoneMono/3.5.0/ryanoasis.IntoneMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/IntoneMono/3.5.0/ryanoasis.IntoneMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Intone Mono Nerd Font (Intel One Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An expressive monospaced font built for developers.
 Description: Intel One Mono is an expressive monospaced font family built with clarity, legibility, and the needs of developers in mind.

--- a/fonts/r/ryanoasis/Iosevka/3.4.0/ryanoasis.Iosevka.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Iosevka/3.4.0/ryanoasis.Iosevka.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/r/ryanoasis/Iosevka/3.5.0/ryanoasis.Iosevka.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Iosevka/3.5.0/ryanoasis.Iosevka.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/r/ryanoasis/Iosevka/Term/3.4.0/ryanoasis.Iosevka.Term.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Iosevka/Term/3.4.0/ryanoasis.Iosevka.Term.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/r/ryanoasis/Iosevka/Term/3.5.0/ryanoasis.Iosevka.Term.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Iosevka/Term/3.5.0/ryanoasis.Iosevka.Term.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Versatile typeface for code, from code.
 Description: Iosevka is a slender monospace sans-serif or slab-serif typeface inspired by Pragmata Pro, M+ and PF DIN Mono, designed to be the most readable the most expressive, and most logically modular typeface for code. The font family is divided into multiple sub-families, which can be used to achieve a particular variation of the font.

--- a/fonts/r/ryanoasis/Iosevka/Term/Slab/3.4.0/ryanoasis.Iosevka.Term.Slab.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Iosevka/Term/Slab/3.4.0/ryanoasis.Iosevka.Term.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Slab Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A slab-serif terminal variant of Iosevka.
 Description: Iosevka Term Slab is a slab-serif terminal variant of Iosevka designed for code and terminal use.

--- a/fonts/r/ryanoasis/Iosevka/Term/Slab/3.5.0/ryanoasis.Iosevka.Term.Slab.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Iosevka/Term/Slab/3.5.0/ryanoasis.Iosevka.Term.Slab.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Iosevka Term Slab Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A slab-serif terminal variant of Iosevka.
 Description: Iosevka Term Slab is a slab-serif terminal variant of Iosevka designed for code and terminal use.

--- a/fonts/r/ryanoasis/JetBrainsMono/3.4.0/ryanoasis.JetBrainsMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/JetBrainsMono/3.4.0/ryanoasis.JetBrainsMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Jetbrains Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A free and open-source monospaced font with code-specific ligatures, designed by JetBrains.
 Description: JetBrains Mono is a typeface designed for code and inspired by JetBrains' developer-driven approach. It features increased letter height for better reading, adapted for reading code with optimal symbol distinction, and includes code-specific ligatures. Available in multiple weights with matching italics.

--- a/fonts/r/ryanoasis/JetBrainsMono/3.5.0/ryanoasis.JetBrainsMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/JetBrainsMono/3.5.0/ryanoasis.JetBrainsMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Jetbrains Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A free and open-source monospaced font with code-specific ligatures, designed by JetBrains.
 Description: JetBrains Mono is a typeface designed for code and inspired by JetBrains' developer-driven approach. It features increased letter height for better reading, adapted for reading code with optimal symbol distinction, and includes code-specific ligatures. Available in multiple weights with matching italics.

--- a/fonts/r/ryanoasis/Lekton/3.4.0/ryanoasis.Lekton.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Lekton/3.4.0/ryanoasis.Lekton.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Lekton Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A typewriter-inspired font family by ISIA Urbino.
 Description: Lekton is a typewriter-inspired font family by ISIA Urbino with regular, bold, and italic styles.

--- a/fonts/r/ryanoasis/Lekton/3.5.0/ryanoasis.Lekton.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Lekton/3.5.0/ryanoasis.Lekton.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Lekton Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A typewriter-inspired font family by ISIA Urbino.
 Description: Lekton is a typewriter-inspired font family by ISIA Urbino with regular, bold, and italic styles.

--- a/fonts/r/ryanoasis/Lilex/3.4.0/ryanoasis.Lilex.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Lilex/3.4.0/ryanoasis.Lilex.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Lilex Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An extended developer font based on IBM Plex Mono.
 Description: Lilex is an extended font on top of IBM Plex Mono designed for developers. It includes ligatures, special characters, Greek, and a variable format.

--- a/fonts/r/ryanoasis/Lilex/3.5.0/ryanoasis.Lilex.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Lilex/3.5.0/ryanoasis.Lilex.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Lilex Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An extended developer font based on IBM Plex Mono.
 Description: Lilex is an extended font on top of IBM Plex Mono designed for developers. It includes ligatures, special characters, Greek, and a variable format.

--- a/fonts/r/ryanoasis/Literation/3.4.0/ryanoasis.Literation.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Literation/3.4.0/ryanoasis.Literation.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Literation Mono Nerd Font (Liberation Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A patched font family based on Liberation fonts.
 Description: Literation packages the Liberation Mono, Sans, and Serif families with patched mono, proporitional, and sans-serif variants.

--- a/fonts/r/ryanoasis/Literation/3.5.0/ryanoasis.Literation.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Literation/3.5.0/ryanoasis.Literation.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Literation Mono Nerd Font (Liberation Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A patched font family based on Liberation fonts.
 Description: Literation packages the Liberation Mono, Sans, and Serif families with patched mono, proporitional, and sans-serif variants.

--- a/fonts/r/ryanoasis/MPlus/3.4.0/ryanoasis.MPlus.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/MPlus/3.4.0/ryanoasis.MPlus.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: M+ Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced Japanese and Latin typeface for programming.
 Description: MPLUS 1 Code is a monospaced Japanese and Latin typeface for programming with multiple styles and weights.

--- a/fonts/r/ryanoasis/MPlus/3.5.0/ryanoasis.MPlus.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/MPlus/3.5.0/ryanoasis.MPlus.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: M+ Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced Japanese and Latin typeface for programming.
 Description: MPLUS 1 Code is a monospaced Japanese and Latin typeface for programming with multiple styles and weights.

--- a/fonts/r/ryanoasis/MartianMono/3.4.0/ryanoasis.MartianMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/MartianMono/3.4.0/ryanoasis.MartianMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Martian Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced version of Martian Grotesk.
 Description: Martian Mono is a monospaced version of Martian Grotesk for code and interface design, with a tall x-height.

--- a/fonts/r/ryanoasis/MartianMono/3.5.0/ryanoasis.MartianMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/MartianMono/3.5.0/ryanoasis.MartianMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Martian Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced version of Martian Grotesk.
 Description: Martian Mono is a monospaced version of Martian Grotesk for code and interface design, with a tall x-height.

--- a/fonts/r/ryanoasis/MesloLG/3.4.0/ryanoasis.MesloLG.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/MesloLG/3.4.0/ryanoasis.MesloLG.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Meslo LG Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Meslo LG is a customized version of Apple's Menlo-Regular font (which is a customized Bitstream Vera Sans Mono).
 Moniker: meslolg-nerd-font

--- a/fonts/r/ryanoasis/MesloLG/3.5.0/ryanoasis.MesloLG.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/MesloLG/3.5.0/ryanoasis.MesloLG.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Meslo LG Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Meslo LG is a customized version of Apple's Menlo-Regular font (which is a customized Bitstream Vera Sans Mono).
 Moniker: meslolg-nerd-font

--- a/fonts/r/ryanoasis/Monaspice/3.4.0/ryanoasis.Monaspice.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Monaspice/3.4.0/ryanoasis.Monaspice.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monaspice Nerd Font (Monaspace)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An innovative superfamily of fonts for code.
 Description: The Monaspace type system is a monospaced type superfamily with some modern tricks up its sleeve. It consists of five variable axis typefaces. Each one has a distinct voice, but they are all metrics-compatible with one another, allowing you to mix and match them for a more expressive typographical palette.

--- a/fonts/r/ryanoasis/Monaspice/3.5.0/ryanoasis.Monaspice.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Monaspice/3.5.0/ryanoasis.Monaspice.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monaspice Nerd Font (Monaspace)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An innovative superfamily of fonts for code.
 Description: The Monaspace type system is a monospaced type superfamily with some modern tricks up its sleeve. It consists of five variable axis typefaces. Each one has a distinct voice, but they are all metrics-compatible with one another, allowing you to mix and match them for a more expressive typographical palette.

--- a/fonts/r/ryanoasis/Monofur/3.4.0/ryanoasis.Monofur.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Monofur/3.4.0/ryanoasis.Monofur.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monofur Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A rounded monospaced sans-serif typeface.
 Description: Monofur is a rounded monospaced sans-serif typeface with regular, bold, and italic styles.

--- a/fonts/r/ryanoasis/Monofur/3.5.0/ryanoasis.Monofur.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Monofur/3.5.0/ryanoasis.Monofur.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monofur Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A rounded monospaced sans-serif typeface.
 Description: Monofur is a rounded monospaced sans-serif typeface with regular, bold, and italic styles.

--- a/fonts/r/ryanoasis/Monoid/3.4.0/ryanoasis.Monoid.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Monoid/3.4.0/ryanoasis.Monoid.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monoid Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A customizable coding font with ligatures and alternates.
 Description: Monoid is a customizable coding font with alternates, ligatures, contextual positioning, and a compact design tuned for small sizes.

--- a/fonts/r/ryanoasis/Monoid/3.5.0/ryanoasis.Monoid.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Monoid/3.5.0/ryanoasis.Monoid.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Monoid Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A customizable coding font with ligatures and alternates.
 Description: Monoid is a customizable coding font with alternates, ligatures, contextual positioning, and a compact design tuned for small sizes.

--- a/fonts/r/ryanoasis/Mononoki/3.4.0/ryanoasis.Mononoki.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Mononoki/3.4.0/ryanoasis.Mononoki.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Mononoki Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A programming typeface designed for code formatting and code review
 Description: Mononoki is a monospace typeface designed for programming and code review. It works well on both high and low resolution displays, with glyphs optimized to survive when squashed into a grid of a few pixels while maintaining appropriate detail for print and retina displays. Each character is designed to be clearly distinguishable from similar looking characters. The font supports Latin, Cyrillic, Greek, and includes mathematical symbols, box-drawing characters, and an alternate stylistic set with dotted zero.

--- a/fonts/r/ryanoasis/Mononoki/3.5.0/ryanoasis.Mononoki.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Mononoki/3.5.0/ryanoasis.Mononoki.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Mononoki Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A programming typeface designed for code formatting and code review
 Description: Mononoki is a monospace typeface designed for programming and code review. It works well on both high and low resolution displays, with glyphs optimized to survive when squashed into a grid of a few pixels while maintaining appropriate detail for print and retina displays. Each character is designed to be clearly distinguishable from similar looking characters. The font supports Latin, Cyrillic, Greek, and includes mathematical symbols, box-drawing characters, and an alternate stylistic set with dotted zero.

--- a/fonts/r/ryanoasis/NotoSans/3.4.0/ryanoasis.NotoSans.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/NotoSans/3.4.0/ryanoasis.NotoSans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Noto Sans Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A global sans-serif font for writing in the Latin, Cyrillic, and Greek scripts
 Description: Noto is a global font collection designed to support writing in all modern and ancient languages. Noto Sans is an unmodulated sans-serif design for texts in the Latin, Cyrillic, and Greek scripts, suitable as a complementary choice for other script-specific Noto Sans fonts. It features italic styles, multiple weights and widths, and comprehensive Unicode support with 3,741 glyphs.

--- a/fonts/r/ryanoasis/NotoSans/3.5.0/ryanoasis.NotoSans.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/NotoSans/3.5.0/ryanoasis.NotoSans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Noto Sans Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A global sans-serif font for writing in the Latin, Cyrillic, and Greek scripts
 Description: Noto is a global font collection designed to support writing in all modern and ancient languages. Noto Sans is an unmodulated sans-serif design for texts in the Latin, Cyrillic, and Greek scripts, suitable as a complementary choice for other script-specific Noto Sans fonts. It features italic styles, multiple weights and widths, and comprehensive Unicode support with 3,741 glyphs.

--- a/fonts/r/ryanoasis/OpenDyslexic/3.4.0/ryanoasis.OpenDyslexic.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/OpenDyslexic/3.4.0/ryanoasis.OpenDyslexic.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: OpenDyslexic Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: OpenDyslexic is a typeface designed against some common symptoms of dyslexia.
 Description: |-

--- a/fonts/r/ryanoasis/OpenDyslexic/3.5.0/ryanoasis.OpenDyslexic.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/OpenDyslexic/3.5.0/ryanoasis.OpenDyslexic.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: OpenDyslexic Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: OpenDyslexic is a typeface designed against some common symptoms of dyslexia.
 Description: |-

--- a/fonts/r/ryanoasis/Overpass/3.4.0/ryanoasis.Overpass.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Overpass/3.4.0/ryanoasis.Overpass.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Overpass Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced companion to the Overpass type family.
 Description: Overpass Mono is a monospaced companion to the Overpass type family with regular, bold, italic, and semibold styles.

--- a/fonts/r/ryanoasis/Overpass/3.5.0/ryanoasis.Overpass.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Overpass/3.5.0/ryanoasis.Overpass.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Overpass Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced companion to the Overpass type family.
 Description: Overpass Mono is a monospaced companion to the Overpass type family with regular, bold, italic, and semibold styles.

--- a/fonts/r/ryanoasis/ProFont/3.4.0/ryanoasis.ProFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ProFont/3.4.0/ryanoasis.ProFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: ProFont Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A compact monospaced font designed for programming.
 Description: ProFont is a compact monospaced font designed for programming, available in IIx and Windows variants.

--- a/fonts/r/ryanoasis/ProFont/3.5.0/ryanoasis.ProFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ProFont/3.5.0/ryanoasis.ProFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: ProFont Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A compact monospaced font designed for programming.
 Description: ProFont is a compact monospaced font designed for programming, available in IIx and Windows variants.

--- a/fonts/r/ryanoasis/ProggyCleanTT/3.4.0/ryanoasis.ProggyCleanTT.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ProggyCleanTT/3.4.0/ryanoasis.ProggyCleanTT.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Proggy Clean TT Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A small monospaced programming font.
 Description: Proggy Clean TT is a small monospaced programming font designed for use at small point sizes.

--- a/fonts/r/ryanoasis/ProggyCleanTT/3.5.0/ryanoasis.ProggyCleanTT.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ProggyCleanTT/3.5.0/ryanoasis.ProggyCleanTT.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Proggy Clean TT Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A small monospaced programming font.
 Description: Proggy Clean TT is a small monospaced programming font designed for use at small point sizes.

--- a/fonts/r/ryanoasis/Recursive/3.4.0/ryanoasis.Recursive.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Recursive/3.4.0/ryanoasis.Recursive.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Recursive Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A variable type family for code and user interfaces.
 Description: Recursive Sans and Mono is a variable type family for code and user interfaces, inspired by casual script signpainting.

--- a/fonts/r/ryanoasis/Recursive/3.5.0/ryanoasis.Recursive.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Recursive/3.5.0/ryanoasis.Recursive.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Recursive Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A variable type family for code and user interfaces.
 Description: Recursive Sans and Mono is a variable type family for code and user interfaces, inspired by casual script signpainting.

--- a/fonts/r/ryanoasis/RobotoMono/3.4.0/ryanoasis.RobotoMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/RobotoMono/3.4.0/ryanoasis.RobotoMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Roboto Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced font from the Roboto family, optimized for readability on screens. Features clear differentiation between similar characters, making it ideal for code and terminal use.
 Moniker: roboto-mono-nerd-font

--- a/fonts/r/ryanoasis/RobotoMono/3.5.0/ryanoasis.RobotoMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/RobotoMono/3.5.0/ryanoasis.RobotoMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Roboto Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced font from the Roboto family, optimized for readability on screens. Features clear differentiation between similar characters, making it ideal for code and terminal use.
 Moniker: roboto-mono-nerd-font

--- a/fonts/r/ryanoasis/SauceCodePro/3.4.0/ryanoasis.SauceCodePro.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/SauceCodePro/3.4.0/ryanoasis.SauceCodePro.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: SauceCodePro Nerd Font (Source Code Pro)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Monospaced font family for user interface and coding environments.
 Moniker: sauce-code-pro-nerd-font

--- a/fonts/r/ryanoasis/SauceCodePro/3.5.0/ryanoasis.SauceCodePro.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/SauceCodePro/3.5.0/ryanoasis.SauceCodePro.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: SauceCodePro Nerd Font (Source Code Pro)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Monospaced font family for user interface and coding environments.
 Moniker: sauce-code-pro-nerd-font

--- a/fonts/r/ryanoasis/ShureTechMono/3.4.0/ryanoasis.ShureTechMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ShureTechMono/3.4.0/ryanoasis.ShureTechMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Shure Tech Mono Nerd Font (Share Tech Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced version of the Share Tech typeface.
 Description: Share Tech Mono is a monospaced version of the Share Tech typeface with regular, mono, and proportional variants.

--- a/fonts/r/ryanoasis/ShureTechMono/3.5.0/ryanoasis.ShureTechMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ShureTechMono/3.5.0/ryanoasis.ShureTechMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Shure Tech Mono Nerd Font (Share Tech Mono)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced version of the Share Tech typeface.
 Description: Share Tech Mono is a monospaced version of the Share Tech typeface with regular, mono, and proportional variants.

--- a/fonts/r/ryanoasis/SpaceMono/3.4.0/ryanoasis.SpaceMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/SpaceMono/3.4.0/ryanoasis.SpaceMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Space Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An original monospace display typeface
 Description: Space Mono is an original monospace display typeface family designed by Colophon Foundry for Google Design. Developed explicitly for headline and display typography, the letterforms infuse a geometric slab core with novel over-rationalized forms. It supports an Extended Latin glyph set, enabling typesetting for English and other Western European languages.

--- a/fonts/r/ryanoasis/SpaceMono/3.5.0/ryanoasis.SpaceMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/SpaceMono/3.5.0/ryanoasis.SpaceMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Space Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: An original monospace display typeface
 Description: Space Mono is an original monospace display typeface family designed by Colophon Foundry for Google Design. Developed explicitly for headline and display typography, the letterforms infuse a geometric slab core with novel over-rationalized forms. It supports an Extended Latin glyph set, enabling typesetting for English and other Western European languages.

--- a/fonts/r/ryanoasis/Symbols/3.4.0/ryanoasis.Symbols.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Symbols/3.4.0/ryanoasis.Symbols.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Symbols Nerd Font (Symbols Only)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Symbols only nerd font.
 Moniker: symbols-nerd-font

--- a/fonts/r/ryanoasis/Symbols/3.5.0/ryanoasis.Symbols.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Symbols/3.5.0/ryanoasis.Symbols.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Symbols Nerd Font (Symbols Only)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Symbols only nerd font.
 Moniker: symbols-nerd-font

--- a/fonts/r/ryanoasis/Terminess/3.4.0/ryanoasis.Terminess.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Terminess/3.4.0/ryanoasis.Terminess.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Terminess Nerd Font (Terminus)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: TrueType conversion of the fixed-width Terminus bitmap font, optimized for long computer use.
 Description: |-

--- a/fonts/r/ryanoasis/Terminess/3.5.0/ryanoasis.Terminess.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Terminess/3.5.0/ryanoasis.Terminess.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Terminess Nerd Font (Terminus)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: TrueType conversion of the fixed-width Terminus bitmap font, optimized for long computer use.
 Description: |-

--- a/fonts/r/ryanoasis/Tinos/3.4.0/ryanoasis.Tinos.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Tinos/3.4.0/ryanoasis.Tinos.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Tinos Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A serif typeface metrically compatible with Times New Roman.
 Description: Tinos is a serif typeface by Steve Matteson, designed as a metric-compatible substitute for Times New Roman.

--- a/fonts/r/ryanoasis/Tinos/3.5.0/ryanoasis.Tinos.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Tinos/3.5.0/ryanoasis.Tinos.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Tinos Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A serif typeface metrically compatible with Times New Roman.
 Description: Tinos is a serif typeface by Steve Matteson, designed as a metric-compatible substitute for Times New Roman.

--- a/fonts/r/ryanoasis/Ubuntu/3.4.0/ryanoasis.Ubuntu.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/3.4.0/ryanoasis.Ubuntu.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Ubuntu Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/r/ryanoasis/Ubuntu/3.5.0/ryanoasis.Ubuntu.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/3.5.0/ryanoasis.Ubuntu.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Ubuntu Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/r/ryanoasis/Ubuntu/Mono/3.4.0/ryanoasis.Ubuntu.Mono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/Mono/3.4.0/ryanoasis.Ubuntu.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Ubuntu Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/r/ryanoasis/Ubuntu/Mono/3.5.0/ryanoasis.Ubuntu.Mono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/Mono/3.5.0/ryanoasis.Ubuntu.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Ubuntu Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/r/ryanoasis/Ubuntu/Sans/3.4.0/ryanoasis.Ubuntu.Sans.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/Sans/3.4.0/ryanoasis.Ubuntu.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Ubuntu Sans Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/r/ryanoasis/Ubuntu/Sans/3.5.0/ryanoasis.Ubuntu.Sans.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/Sans/3.5.0/ryanoasis.Ubuntu.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Ubuntu Sans Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: The Ubuntu Font Family is a contemporary sans-serif typeface commissioned by Canonical.
 Description: The Ubuntu Font Family is a set of matching libre/open fonts that includes Ubuntu, Ubuntu Mono, and the complete typeface family with multiple weights and styles. The fonts cover over 200 languages and include 1,200 glyphs. The family was specially created to complement the Ubuntu brand and uses OpenType features with careful hinting for clarity on desktop and mobile screens.

--- a/fonts/r/ryanoasis/VictorMono/3.4.0/ryanoasis.VictorMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/VictorMono/3.4.0/ryanoasis.VictorMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Victor Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Free programming font with cursive italics and ligatures
 Description: Victor Mono is a free and open-source programming font featuring semi-connected cursive italics and symbol ligatures. Designed for readability and aesthetics in code editors, it combines a monospace design with expressive italic variants to enhance code readability.

--- a/fonts/r/ryanoasis/VictorMono/3.5.0/ryanoasis.VictorMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/VictorMono/3.5.0/ryanoasis.VictorMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Victor Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: Free programming font with cursive italics and ligatures
 Description: Victor Mono is a free and open-source programming font featuring semi-connected cursive italics and symbol ligatures. Designed for readability and aesthetics in code editors, it combines a monospace design with expressive italic variants to enhance code readability.

--- a/fonts/r/ryanoasis/ZedMono/3.4.0/ryanoasis.ZedMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ZedMono/3.4.0/ryanoasis.ZedMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Zed Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A custom monospace font built from Iosevka for the Zed editor
 Description: Zed Mono is a custom monospace typeface built from Iosevka and designed specifically for use in the Zed editor. The font combines Iosevka's clean, geometric design with optimizations for code editing and developer workflows. It includes multiple weights and features to support modern development environments.

--- a/fonts/r/ryanoasis/ZedMono/3.5.0/ryanoasis.ZedMono.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ZedMono/3.5.0/ryanoasis.ZedMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Zed Mono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A custom monospace font built from Iosevka for the Zed editor
 Description: Zed Mono is a custom monospace typeface built from Iosevka and designed specifically for use in the Zed editor. The font combines Iosevka's clean, geometric design with optimizations for code editing and developer workflows. It includes multiple weights and features to support modern development environments.

--- a/fonts/r/ryanoasis/iMWriting/3.4.0/ryanoasis.iMWriting.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/iMWriting/3.4.0/ryanoasis.iMWriting.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: iMWriting Nerd Font (iA Writer)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced typeface made for focused writing.
 Description: iA Writer Mono is a monospaced typeface made for focused writing, based on iA Writer.

--- a/fonts/r/ryanoasis/iMWriting/3.5.0/ryanoasis.iMWriting.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/iMWriting/3.5.0/ryanoasis.iMWriting.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: iMWriting Nerd Font (iA Writer)
 PackageUrl: https://www.nerdfonts.com/
 License: OFL-1.1
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
+Copyright: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
 CopyrightUrl: https://github.com/ryanoasis/nerd-fonts/blob/HEAD/LICENSE
 ShortDescription: A monospaced typeface made for focused writing.
 Description: iA Writer Mono is a monospaced typeface made for focused writing, based on iA Writer.

--- a/fonts/s/SourceFoundry/Hack/3.003/SourceFoundry.Hack.locale.en-US.yaml
+++ b/fonts/s/SourceFoundry/Hack/3.003/SourceFoundry.Hack.locale.en-US.yaml
@@ -13,9 +13,9 @@ PackageUrl: https://sourcefoundry.org/hack/
 License: MIT
 LicenseUrl: https://github.com/source-foundry/Hack/blob/HEAD/LICENSE.md
 Copyright: |-
-  Copyright (c) 2018 Source Foundry Authors
+  © 2018 Source Foundry Authors
   Work in the DejaVu project was committed to the public domain.
-  Copyright (c) 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
+  © 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
 CopyrightUrl: https://github.com/source-foundry/Hack/blob/HEAD/LICENSE.md
 ShortDescription: A workhorse monospace typeface designed for source code, with excellent legibility and Powerline support included.
 Description: Hack is a carefully hand-groomed and optically balanced monospace typeface designed for source code. It features a large x-height, wide aperture, and low contrast design for optimal legibility at commonly used source code text sizes (8-14pt range). Available in four styles (Regular, Bold, Italic, Bold Italic), Hack includes over 1500 glyphs supporting extended Latin, Greek, and Cyrillic character sets, plus Powerline symbols included by default with no patching required. The font is based on the Bitstream Vera and DejaVu projects, re-designed with an expanded glyph set, optimized metrics, and distinctive features like strategically placed serifs on narrow characters and semi-bold punctuation for better code clarity.

--- a/fonts/s/SourceFoundry/Hack/3.003/SourceFoundry.Hack.locale.en-US.yaml
+++ b/fonts/s/SourceFoundry/Hack/3.003/SourceFoundry.Hack.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageUrl: https://sourcefoundry.org/hack/
 License: MIT
 LicenseUrl: https://github.com/source-foundry/Hack/blob/HEAD/LICENSE.md
 Copyright: |-
-  © 2018 Source Foundry Authors
+  © 2018 Source Foundry Authors.
   Work in the DejaVu project was committed to the public domain.
   © 2003 by Bitstream, Inc. All Rights Reserved. Bitstream Vera is a trademark of Bitstream, Inc.
 CopyrightUrl: https://github.com/source-foundry/Hack/blob/HEAD/LICENSE.md

--- a/fonts/s/shaunsingh/SFMonoLigaturized/16.0/shaunsingh.SFMonoLigaturized.locale.en-US.yaml
+++ b/fonts/s/shaunsingh/SFMonoLigaturized/16.0/shaunsingh.SFMonoLigaturized.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: SF Mono Ligaturized Nerd Font
 PackageUrl: https://github.com/shaunsingh/SFMono-Nerd-Font-Ligaturized
 License: Unlicense
 LicenseUrl: https://github.com/shaunsingh/SFMono-Nerd-Font-Ligaturized/blob/HEAD/LICENSE
-Copyright: © shaunsingh
+Copyright: © shaunsingh.
 CopyrightUrl: https://github.com/shaunsingh/SFMono-Nerd-Font-Ligaturized/blob/HEAD/LICENSE
 ShortDescription: A pre-patched version of SF Mono with ligatures.
 Description: SF Mono Ligaturized is a pre-patched version of Apple's SF Mono with ligatures and extra icon glyphs.

--- a/fonts/s/shaunsingh/SFMonoLigaturized/16.0/shaunsingh.SFMonoLigaturized.locale.en-US.yaml
+++ b/fonts/s/shaunsingh/SFMonoLigaturized/16.0/shaunsingh.SFMonoLigaturized.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: SF Mono Ligaturized Nerd Font
 PackageUrl: https://github.com/shaunsingh/SFMono-Nerd-Font-Ligaturized
 License: Unlicense
 LicenseUrl: https://github.com/shaunsingh/SFMono-Nerd-Font-Ligaturized/blob/HEAD/LICENSE
-Copyright: Copyright (c) shaunsingh
+Copyright: © shaunsingh
 CopyrightUrl: https://github.com/shaunsingh/SFMono-Nerd-Font-Ligaturized/blob/HEAD/LICENSE
 ShortDescription: A pre-patched version of SF Mono with ligatures.
 Description: SF Mono Ligaturized is a pre-patched version of Apple's SF Mono with ligatures and extra icon glyphs.

--- a/fonts/s/subframe7536/MapleMono/7.8/subframe7536.MapleMono.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/7.8/subframe7536.MapleMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font with round corners, ligatures, Nerd-Font icons for IDE and terminal, and fine-grained customization options.
 Moniker: maple-mono

--- a/fonts/s/subframe7536/MapleMono/7.8/subframe7536.MapleMono.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/7.8/subframe7536.MapleMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font with round corners, ligatures, Nerd-Font icons for IDE and terminal, and fine-grained customization options.
 Moniker: maple-mono

--- a/fonts/s/subframe7536/MapleMono/7.9/subframe7536.MapleMono.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/7.9/subframe7536.MapleMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono

--- a/fonts/s/subframe7536/MapleMono/7.9/subframe7536.MapleMono.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/7.9/subframe7536.MapleMono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono

--- a/fonts/s/subframe7536/MapleMono/CN/7.9/subframe7536.MapleMono.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/CN/7.9/subframe7536.MapleMono.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-cn

--- a/fonts/s/subframe7536/MapleMono/CN/7.9/subframe7536.MapleMono.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/CN/7.9/subframe7536.MapleMono.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-cn

--- a/fonts/s/subframe7536/MapleMono/NerdFont/7.8/subframe7536.MapleMono.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NerdFont/7.8/subframe7536.MapleMono.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Nerd Font
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font with round corners, ligatures, Nerd-Font icons for IDE and terminal, and fine-grained customization options.
 Moniker: maple-mono-nf

--- a/fonts/s/subframe7536/MapleMono/NerdFont/7.8/subframe7536.MapleMono.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NerdFont/7.8/subframe7536.MapleMono.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Nerd Font
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font with round corners, ligatures, Nerd-Font icons for IDE and terminal, and fine-grained customization options.
 Moniker: maple-mono-nf

--- a/fonts/s/subframe7536/MapleMono/NerdFont/7.9/subframe7536.MapleMono.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NerdFont/7.9/subframe7536.MapleMono.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Nerd Font
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nf

--- a/fonts/s/subframe7536/MapleMono/NerdFont/7.9/subframe7536.MapleMono.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NerdFont/7.9/subframe7536.MapleMono.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Nerd Font
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nf

--- a/fonts/s/subframe7536/MapleMono/NerdFont/CN/7.9/subframe7536.MapleMono.NerdFont.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NerdFont/CN/7.9/subframe7536.MapleMono.NerdFont.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NF CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nf-cn

--- a/fonts/s/subframe7536/MapleMono/NerdFont/CN/7.9/subframe7536.MapleMono.NerdFont.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NerdFont/CN/7.9/subframe7536.MapleMono.NerdFont.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NF CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nf-cn

--- a/fonts/s/subframe7536/MapleMono/NoLigatures/7.9/subframe7536.MapleMono.NoLigatures.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NoLigatures/7.9/subframe7536.MapleMono.NoLigatures.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NL
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nl

--- a/fonts/s/subframe7536/MapleMono/NoLigatures/7.9/subframe7536.MapleMono.NoLigatures.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NoLigatures/7.9/subframe7536.MapleMono.NoLigatures.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NL
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nl

--- a/fonts/s/subframe7536/MapleMono/NoLigatures/CN/7.9/subframe7536.MapleMono.NoLigatures.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NoLigatures/CN/7.9/subframe7536.MapleMono.NoLigatures.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NL CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nl-cn

--- a/fonts/s/subframe7536/MapleMono/NoLigatures/CN/7.9/subframe7536.MapleMono.NoLigatures.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NoLigatures/CN/7.9/subframe7536.MapleMono.NoLigatures.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NL CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nl-cn

--- a/fonts/s/subframe7536/MapleMono/NoLigatures/NerdFont/7.9/subframe7536.MapleMono.NoLigatures.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NoLigatures/NerdFont/7.9/subframe7536.MapleMono.NoLigatures.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NL NF
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nl-nf

--- a/fonts/s/subframe7536/MapleMono/NoLigatures/NerdFont/7.9/subframe7536.MapleMono.NoLigatures.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NoLigatures/NerdFont/7.9/subframe7536.MapleMono.NoLigatures.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NL NF
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nl-nf

--- a/fonts/s/subframe7536/MapleMono/NoLigatures/NerdFont/CN/7.9/subframe7536.MapleMono.NoLigatures.NerdFont.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NoLigatures/NerdFont/CN/7.9/subframe7536.MapleMono.NoLigatures.NerdFont.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NL NF CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nl-nf-cn

--- a/fonts/s/subframe7536/MapleMono/NoLigatures/NerdFont/CN/7.9/subframe7536.MapleMono.NoLigatures.NerdFont.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/NoLigatures/NerdFont/CN/7.9/subframe7536.MapleMono.NoLigatures.NerdFont.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono NL NF CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-nl-nf-cn

--- a/fonts/s/subframe7536/MapleMono/Normal/7.9/subframe7536.MapleMono.Normal.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/7.9/subframe7536.MapleMono.Normal.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal

--- a/fonts/s/subframe7536/MapleMono/Normal/7.9/subframe7536.MapleMono.Normal.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/7.9/subframe7536.MapleMono.Normal.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal

--- a/fonts/s/subframe7536/MapleMono/Normal/CN/7.9/subframe7536.MapleMono.Normal.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/CN/7.9/subframe7536.MapleMono.Normal.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-cn

--- a/fonts/s/subframe7536/MapleMono/Normal/CN/7.9/subframe7536.MapleMono.Normal.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/CN/7.9/subframe7536.MapleMono.Normal.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-cn

--- a/fonts/s/subframe7536/MapleMono/Normal/NerdFont/7.9/subframe7536.MapleMono.Normal.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NerdFont/7.9/subframe7536.MapleMono.Normal.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NF
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nf

--- a/fonts/s/subframe7536/MapleMono/Normal/NerdFont/7.9/subframe7536.MapleMono.Normal.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NerdFont/7.9/subframe7536.MapleMono.Normal.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NF
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nf

--- a/fonts/s/subframe7536/MapleMono/Normal/NerdFont/CN/7.9/subframe7536.MapleMono.Normal.NerdFont.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NerdFont/CN/7.9/subframe7536.MapleMono.Normal.NerdFont.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NF CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nf-cn

--- a/fonts/s/subframe7536/MapleMono/Normal/NerdFont/CN/7.9/subframe7536.MapleMono.Normal.NerdFont.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NerdFont/CN/7.9/subframe7536.MapleMono.Normal.NerdFont.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NF CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nf-cn

--- a/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/7.9/subframe7536.MapleMono.Normal.NoLigatures.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/7.9/subframe7536.MapleMono.Normal.NoLigatures.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NL
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nl

--- a/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/7.9/subframe7536.MapleMono.Normal.NoLigatures.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/7.9/subframe7536.MapleMono.Normal.NoLigatures.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NL
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nl

--- a/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/CN/7.9/subframe7536.MapleMono.Normal.NoLigatures.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/CN/7.9/subframe7536.MapleMono.Normal.NoLigatures.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NL CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nl-cn

--- a/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/CN/7.9/subframe7536.MapleMono.Normal.NoLigatures.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/CN/7.9/subframe7536.MapleMono.Normal.NoLigatures.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NL CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nl-cn

--- a/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/NerdFont/7.9/subframe7536.MapleMono.Normal.NoLigatures.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/NerdFont/7.9/subframe7536.MapleMono.Normal.NoLigatures.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NL NF
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nl-nf

--- a/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/NerdFont/7.9/subframe7536.MapleMono.Normal.NoLigatures.NerdFont.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/NerdFont/7.9/subframe7536.MapleMono.Normal.NoLigatures.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NL NF
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nl-nf

--- a/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/NerdFont/CN/7.9/subframe7536.MapleMono.Normal.NoLigatures.NerdFont.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/NerdFont/CN/7.9/subframe7536.MapleMono.Normal.NoLigatures.NerdFont.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NL NF CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: Copyright 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nl-nf-cn

--- a/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/NerdFont/CN/7.9/subframe7536.MapleMono.Normal.NoLigatures.NerdFont.CN.locale.en-US.yaml
+++ b/fonts/s/subframe7536/MapleMono/Normal/NoLigatures/NerdFont/CN/7.9/subframe7536.MapleMono.Normal.NoLigatures.NerdFont.CN.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Maple Mono Normal NL NF CN
 PackageUrl: https://font.subf.dev/en/
 License: OFL-1.1
 LicenseUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
-Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font)
+Copyright: © 2022 The Maple Mono Project Authors (https://github.com/subframe7536/maple-font).
 CopyrightUrl: https://github.com/subframe7536/maple-font/blob/HEAD/OFL.txt
 ShortDescription: Open source monospace font focused on coding, with rounded corners and fine-grained customization options.
 Moniker: maple-mono-normal-nl-nf-cn

--- a/fonts/t/tonsky/FiraCode/6.2/tonsky.FiraCode.locale.en-US.yaml
+++ b/fonts/t/tonsky/FiraCode/6.2/tonsky.FiraCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Code
 PackageUrl: https://github.com/tonsky/FiraCode
 License: OFL-1.1
 LicenseUrl: https://github.com/tonsky/FiraCode/blob/HEAD/LICENSE
-Copyright: © The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
+Copyright: © The Fira Code Project Authors (https://github.com/tonsky/FiraCode).
 CopyrightUrl: https://github.com/tonsky/FiraCode/blob/HEAD/LICENSE
 ShortDescription: Extension of the Fira Mono font with programming ligatures.
 Description: |-

--- a/fonts/t/tonsky/FiraCode/6.2/tonsky.FiraCode.locale.en-US.yaml
+++ b/fonts/t/tonsky/FiraCode/6.2/tonsky.FiraCode.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Fira Code
 PackageUrl: https://github.com/tonsky/FiraCode
 License: OFL-1.1
 LicenseUrl: https://github.com/tonsky/FiraCode/blob/HEAD/LICENSE
-Copyright: Copyright (c), The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
+Copyright: © The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
 CopyrightUrl: https://github.com/tonsky/FiraCode/blob/HEAD/LICENSE
 ShortDescription: Extension of the Fira Mono font with programming ligatures.
 Description: |-

--- a/fonts/v/Vercel/Geist/Mono/1.6.0/Vercel.Geist.Mono.locale.en-US.yaml
+++ b/fonts/v/Vercel/Geist/Mono/1.6.0/Vercel.Geist.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Mono
 PackageUrl: https://vercel.com/font
 License: OFL-1.1
 LicenseUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
-Copyright: © 2023 Vercel, in collaboration with basement.studio
+Copyright: © 2023 Vercel, in collaboration with basement.studio.
 CopyrightUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/v/Vercel/Geist/Mono/1.6.0/Vercel.Geist.Mono.locale.en-US.yaml
+++ b/fonts/v/Vercel/Geist/Mono/1.6.0/Vercel.Geist.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Mono
 PackageUrl: https://vercel.com/font
 License: OFL-1.1
 LicenseUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
-Copyright: Copyright (c) 2023 Vercel, in collaboration with basement.studio
+Copyright: © 2023 Vercel, in collaboration with basement.studio
 CopyrightUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/v/Vercel/Geist/Mono/1.7.2/Vercel.Geist.Mono.locale.en-US.yaml
+++ b/fonts/v/Vercel/Geist/Mono/1.7.2/Vercel.Geist.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Mono
 PackageUrl: https://vercel.com/font
 License: OFL-1.1
 LicenseUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
-Copyright: © 2023 Vercel, in collaboration with basement.studio
+Copyright: © 2023 Vercel, in collaboration with basement.studio.
 CopyrightUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/v/Vercel/Geist/Mono/1.7.2/Vercel.Geist.Mono.locale.en-US.yaml
+++ b/fonts/v/Vercel/Geist/Mono/1.7.2/Vercel.Geist.Mono.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Mono
 PackageUrl: https://vercel.com/font
 License: OFL-1.1
 LicenseUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
-Copyright: Copyright (c) 2023 Vercel, in collaboration with basement.studio
+Copyright: © 2023 Vercel, in collaboration with basement.studio
 CopyrightUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/v/Vercel/Geist/Sans/1.6.0/Vercel.Geist.Sans.locale.en-US.yaml
+++ b/fonts/v/Vercel/Geist/Sans/1.6.0/Vercel.Geist.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Sans
 PackageUrl: https://vercel.com/font
 License: OFL-1.1
 LicenseUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
-Copyright: © 2023 Vercel, in collaboration with basement.studio
+Copyright: © 2023 Vercel, in collaboration with basement.studio.
 CopyrightUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/v/Vercel/Geist/Sans/1.6.0/Vercel.Geist.Sans.locale.en-US.yaml
+++ b/fonts/v/Vercel/Geist/Sans/1.6.0/Vercel.Geist.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Sans
 PackageUrl: https://vercel.com/font
 License: OFL-1.1
 LicenseUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
-Copyright: Copyright (c) 2023 Vercel, in collaboration with basement.studio
+Copyright: © 2023 Vercel, in collaboration with basement.studio
 CopyrightUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/v/Vercel/Geist/Sans/1.7.2/Vercel.Geist.Sans.locale.en-US.yaml
+++ b/fonts/v/Vercel/Geist/Sans/1.7.2/Vercel.Geist.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Sans
 PackageUrl: https://vercel.com/font
 License: OFL-1.1
 LicenseUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
-Copyright: © 2023 Vercel, in collaboration with basement.studio
+Copyright: © 2023 Vercel, in collaboration with basement.studio.
 CopyrightUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/v/Vercel/Geist/Sans/1.7.2/Vercel.Geist.Sans.locale.en-US.yaml
+++ b/fonts/v/Vercel/Geist/Sans/1.7.2/Vercel.Geist.Sans.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: Geist Sans
 PackageUrl: https://vercel.com/font
 License: OFL-1.1
 LicenseUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
-Copyright: Copyright (c) 2023 Vercel, in collaboration with basement.studio
+Copyright: © 2023 Vercel, in collaboration with basement.studio
 CopyrightUrl: https://github.com/vercel/geist-font/blob/HEAD/LICENSE.txt
 ShortDescription: Geist is a new font family for Vercel, created by Vercel in collaboration with Basement Studio.
 Description: |-

--- a/fonts/v/VileR/BigBlueTerminal/1.0/VileR.BigBlueTerminal.locale.en-US.yaml
+++ b/fonts/v/VileR/BigBlueTerminal/1.0/VileR.BigBlueTerminal.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: BigBlue Terminal
 PackageUrl: https://int10h.org/blog/2015/12/bigblue-terminal-oldschool-fixed-width-font/
 License: CC-BY-SA-4.0
 LicenseUrl: https://int10h.org/blog/2015/12/bigblue-terminal-oldschool-fixed-width-font/
-Copyright: © 2015 VileR
+Copyright: © 2015 VileR.
 ShortDescription: Monospaced pixel font for fixed-width consoles, terminals, and code editors.
 Description: BigBlue Terminal follows the metrics of Windows' old Terminal font while drawing its appearance from classic IBM PC text-mode character sets. Its extended variant adds international scripts and symbol sets.
 Moniker: bigblue-terminal

--- a/fonts/v/VileR/BigBlueTerminal/1.0/VileR.BigBlueTerminal.locale.en-US.yaml
+++ b/fonts/v/VileR/BigBlueTerminal/1.0/VileR.BigBlueTerminal.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: BigBlue Terminal
 PackageUrl: https://int10h.org/blog/2015/12/bigblue-terminal-oldschool-fixed-width-font/
 License: CC-BY-SA-4.0
 LicenseUrl: https://int10h.org/blog/2015/12/bigblue-terminal-oldschool-fixed-width-font/
-Copyright: Copyright (c) 2015 VileR
+Copyright: © 2015 VileR
 ShortDescription: Monospaced pixel font for fixed-width consoles, terminals, and code editors.
 Description: BigBlue Terminal follows the metrics of Windows' old Terminal font while drawing its appearance from classic IBM PC text-mode character sets. Its extended variant adds international scripts and symbol sets.
 Moniker: bigblue-terminal

--- a/fonts/y/yuru7/PlemolJP/3.0.0/yuru7.PlemolJP.locale.en-US.yaml
+++ b/fonts/y/yuru7/PlemolJP/3.0.0/yuru7.PlemolJP.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: PlemolJP
 PackageUrl: https://github.com/yuru7/PlemolJP
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/yuru7/PlemolJP/blob/HEAD/LICENSE
-Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP"
+Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP".
 ShortDescription: Japanese programming font combining IBM Plex Mono and IBM Plex Sans JP.
 Description: PlemolJP combines IBM Plex Mono for Latin characters with IBM Plex Sans JP for Japanese characters. It provides normal and italic styles, eight weights, console variants, and visible full-width spaces.
 Moniker: plemol-jp

--- a/fonts/y/yuru7/PlemolJP/3.0.0/yuru7.PlemolJP.locale.en-US.yaml
+++ b/fonts/y/yuru7/PlemolJP/3.0.0/yuru7.PlemolJP.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: PlemolJP
 PackageUrl: https://github.com/yuru7/PlemolJP
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/yuru7/PlemolJP/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2021, Yuko OTAWARA. with Reserved Font Name "PlemolJP"
+Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP"
 ShortDescription: Japanese programming font combining IBM Plex Mono and IBM Plex Sans JP.
 Description: PlemolJP combines IBM Plex Mono for Latin characters with IBM Plex Sans JP for Japanese characters. It provides normal and italic styles, eight weights, console variants, and visible full-width spaces.
 Moniker: plemol-jp

--- a/fonts/y/yuru7/PlemolJP/HiddenSpace/3.0.0/yuru7.PlemolJP.HiddenSpace.locale.en-US.yaml
+++ b/fonts/y/yuru7/PlemolJP/HiddenSpace/3.0.0/yuru7.PlemolJP.HiddenSpace.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: PlemolJP Hidden Space
 PackageUrl: https://github.com/yuru7/PlemolJP
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/yuru7/PlemolJP/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2021, Yuko OTAWARA. with Reserved Font Name "PlemolJP"
+Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP"
 ShortDescription: Japanese programming font combining IBM Plex Mono and IBM Plex Sans JP.
 Description: PlemolJP combines IBM Plex Mono for Latin characters with IBM Plex Sans JP for Japanese characters. This Hidden Space variant leaves full-width spaces invisible while retaining the family’s normal and italic styles and eight weights.
 Moniker: plemol-jp-hs

--- a/fonts/y/yuru7/PlemolJP/HiddenSpace/3.0.0/yuru7.PlemolJP.HiddenSpace.locale.en-US.yaml
+++ b/fonts/y/yuru7/PlemolJP/HiddenSpace/3.0.0/yuru7.PlemolJP.HiddenSpace.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: PlemolJP Hidden Space
 PackageUrl: https://github.com/yuru7/PlemolJP
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/yuru7/PlemolJP/blob/HEAD/LICENSE
-Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP"
+Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP".
 ShortDescription: Japanese programming font combining IBM Plex Mono and IBM Plex Sans JP.
 Description: PlemolJP combines IBM Plex Mono for Latin characters with IBM Plex Sans JP for Japanese characters. This Hidden Space variant leaves full-width spaces invisible while retaining the family’s normal and italic styles and eight weights.
 Moniker: plemol-jp-hs

--- a/fonts/y/yuru7/PlemolJP/NerdFont/3.0.0/yuru7.PlemolJP.NerdFont.locale.en-US.yaml
+++ b/fonts/y/yuru7/PlemolJP/NerdFont/3.0.0/yuru7.PlemolJP.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: PlemolJP Nerd Font
 PackageUrl: https://github.com/yuru7/PlemolJP
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/yuru7/PlemolJP/blob/HEAD/LICENSE
-Copyright: Copyright (c) 2021, Yuko OTAWARA. with Reserved Font Name "PlemolJP"
+Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP"
 ShortDescription: Japanese programming font combining IBM Plex Mono and IBM Plex Sans JP.
 Description: PlemolJP combines IBM Plex Mono for Latin characters with IBM Plex Sans JP for Japanese characters. It provides normal and italic styles, eight weights, console variants, and visible full-width spaces.
 Moniker: plemol-jp-nf

--- a/fonts/y/yuru7/PlemolJP/NerdFont/3.0.0/yuru7.PlemolJP.NerdFont.locale.en-US.yaml
+++ b/fonts/y/yuru7/PlemolJP/NerdFont/3.0.0/yuru7.PlemolJP.NerdFont.locale.en-US.yaml
@@ -12,7 +12,7 @@ PackageName: PlemolJP Nerd Font
 PackageUrl: https://github.com/yuru7/PlemolJP
 License: OFL-1.1-RFN
 LicenseUrl: https://github.com/yuru7/PlemolJP/blob/HEAD/LICENSE
-Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP"
+Copyright: © 2021 Yuko OTAWARA. with Reserved Font Name "PlemolJP".
 ShortDescription: Japanese programming font combining IBM Plex Mono and IBM Plex Sans JP.
 Description: PlemolJP combines IBM Plex Mono for Latin characters with IBM Plex Sans JP for Japanese characters. It provides normal and italic styles, eight weights, console variants, and visible full-width spaces.
 Moniker: plemol-jp-nf

--- a/manifests/a/AMD/BugReportTool/25.30.17.01/AMD.BugReportTool.locale.en-US.yaml
+++ b/manifests/a/AMD/BugReportTool/25.30.17.01/AMD.BugReportTool.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://www.amd.com/en/support
 PackageName: AMD Bug Report Tool
 PackageUrl: https://www.amd.com/en/resources/support-articles/faqs/AMDBRT.html
 License: Proprietary
-Copyright: Copyright Advanced Micro Devices, Inc. All rights reserved.
+Copyright: © Advanced Micro Devices, Inc. All rights reserved.
 ShortDescription: A tool that allows users with AMD Radeon Series Graphics or AMD Ryzen Processor powered systems to report bugs directly to AMD.
 Moniker: amdbrt
 Tags:

--- a/manifests/a/AVerMedia/AssistCentral/1.2.0.13/AVerMedia.AssistCentral.locale.en-US.yaml
+++ b/manifests/a/AVerMedia/AssistCentral/1.2.0.13/AVerMedia.AssistCentral.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: AVerMedia Technologies
 PackageName: AVerMedia Assist Central
 PackageUrl: https://www.avermedia.com/
 License: Freeware
-Copyright: © AVerMedia
+Copyright: © AVerMedia.
 ShortDescription: Firmware and settings management utility for AVerMedia devices.
 Moniker: assistcentral
 ManifestType: defaultLocale

--- a/manifests/a/AVerMedia/AssistCentral/1.2.0.13/AVerMedia.AssistCentral.locale.en-US.yaml
+++ b/manifests/a/AVerMedia/AssistCentral/1.2.0.13/AVerMedia.AssistCentral.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: AVerMedia Technologies
 PackageName: AVerMedia Assist Central
 PackageUrl: https://www.avermedia.com/
 License: Freeware
-Copyright: Copyright (c) AVerMedia
+Copyright: © AVerMedia
 ShortDescription: Firmware and settings management utility for AVerMedia devices.
 Moniker: assistcentral
 ManifestType: defaultLocale

--- a/manifests/a/AVerMedia/RECentral/4.7.114.1/AVerMedia.RECentral.locale.en-US.yaml
+++ b/manifests/a/AVerMedia/RECentral/4.7.114.1/AVerMedia.RECentral.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: AVerMedia Technologies
 PackageName: RECentral
 PackageUrl: https://www.avermedia.com/
 License: Freeware
-Copyright: Copyright (c) AVerMedia
+Copyright: © AVerMedia
 ShortDescription: Recording and live-streaming software for AVerMedia capture devices.
 Moniker: recentral
 ManifestType: defaultLocale

--- a/manifests/a/AVerMedia/RECentral/4.7.114.1/AVerMedia.RECentral.locale.en-US.yaml
+++ b/manifests/a/AVerMedia/RECentral/4.7.114.1/AVerMedia.RECentral.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: AVerMedia Technologies
 PackageName: RECentral
 PackageUrl: https://www.avermedia.com/
 License: Freeware
-Copyright: © AVerMedia
+Copyright: © AVerMedia.
 ShortDescription: Recording and live-streaming software for AVerMedia capture devices.
 Moniker: recentral
 ManifestType: defaultLocale

--- a/manifests/a/AVerMedia/RECentral/4.7.44.1/AVerMedia.RECentral.locale.en-US.yaml
+++ b/manifests/a/AVerMedia/RECentral/4.7.44.1/AVerMedia.RECentral.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: AVerMedia Technologies
 PackageName: RECentral
 PackageUrl: https://www.avermedia.com/
 License: Freeware
-Copyright: Copyright (c) AVerMedia
+Copyright: © AVerMedia
 ShortDescription: Recording and live-streaming software for AVerMedia capture devices.
 Moniker: recentral
 ManifestType: defaultLocale

--- a/manifests/a/AVerMedia/RECentral/4.7.44.1/AVerMedia.RECentral.locale.en-US.yaml
+++ b/manifests/a/AVerMedia/RECentral/4.7.44.1/AVerMedia.RECentral.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: AVerMedia Technologies
 PackageName: RECentral
 PackageUrl: https://www.avermedia.com/
 License: Freeware
-Copyright: © AVerMedia
+Copyright: © AVerMedia.
 ShortDescription: Recording and live-streaming software for AVerMedia capture devices.
 Moniker: recentral
 ManifestType: defaultLocale

--- a/manifests/a/Auslogics/DiskDefragUltimate/4.13.0.3/Auslogics.DiskDefragUltimate.locale.en-US.yaml
+++ b/manifests/a/Auslogics/DiskDefragUltimate/4.13.0.3/Auslogics.DiskDefragUltimate.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Auslogics Disk Defrag Ultimate
 PackageUrl: https://www.auslogics.com/en/software/disk-defrag-ultimate/
 License: Proprietary
 LicenseUrl: https://www.auslogics.com/en/eula/
-Copyright: © 2008-2025 Auslogics Labs Pty Ltd
+Copyright: © 2008-2025 Auslogics Labs Pty Ltd.
 ShortDescription: Disk defragmentation and optimization utility.
 Moniker: disk-defrag-ultimate
 ManifestType: defaultLocale

--- a/manifests/a/Auslogics/DiskDefragUltimate/4.13.0.3/Auslogics.DiskDefragUltimate.locale.en-US.yaml
+++ b/manifests/a/Auslogics/DiskDefragUltimate/4.13.0.3/Auslogics.DiskDefragUltimate.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Auslogics Disk Defrag Ultimate
 PackageUrl: https://www.auslogics.com/en/software/disk-defrag-ultimate/
 License: Proprietary
 LicenseUrl: https://www.auslogics.com/en/eula/
-Copyright: Copyright © 2008-2025 Auslogics Labs Pty Ltd
+Copyright: © 2008-2025 Auslogics Labs Pty Ltd
 ShortDescription: Disk defragmentation and optimization utility.
 Moniker: disk-defrag-ultimate
 ManifestType: defaultLocale

--- a/manifests/b/BinaryFortress/NotepadReplacer/1.6c/BinaryFortress.NotepadReplacer.locale.en-US.yaml
+++ b/manifests/b/BinaryFortress/NotepadReplacer/1.6c/BinaryFortress.NotepadReplacer.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://www.binaryfortress.com/
 PackageName: Notepad Replacer
 PackageUrl: https://www.binaryfortress.com/NotepadReplacer/
 License: Proprietary
-Copyright: © 2007-2023 Binary Fortress Software
+Copyright: © 2007-2023 Binary Fortress Software.
 ShortDescription: Replaces Windows Notepad with the text editor of your choice.
 Moniker: notepadreplacer
 ManifestType: defaultLocale

--- a/manifests/b/BinaryFortress/NotepadReplacer/1.6c/BinaryFortress.NotepadReplacer.locale.en-US.yaml
+++ b/manifests/b/BinaryFortress/NotepadReplacer/1.6c/BinaryFortress.NotepadReplacer.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://www.binaryfortress.com/
 PackageName: Notepad Replacer
 PackageUrl: https://www.binaryfortress.com/NotepadReplacer/
 License: Proprietary
-Copyright: Copyright Â© 2007-2023 Binary Fortress Software
+Copyright: © 2007-2023 Binary Fortress Software
 ShortDescription: Replaces Windows Notepad with the text editor of your choice.
 Moniker: notepadreplacer
 ManifestType: defaultLocale

--- a/manifests/c/Composer/WindowsSetup/6.3.0/Composer.WindowsSetup.locale.en-US.yaml
+++ b/manifests/c/Composer/WindowsSetup/6.3.0/Composer.WindowsSetup.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Composer
 PackageName: Composer Windows Setup
 PackageUrl: https://github.com/composer/windows-setup
 License: MIT
-Copyright: © 2012-2026 John Stevenson
+Copyright: © 2012-2026 John Stevenson.
 ShortDescription: Helps you declare, manage, and install dependencies of PHP projects.
 Description: Composer's official .exe for initial installations of the PHP dependency manager Composer. It fetches the newest or near-newest Composer version (For instance 2.10.1), has an internal temp runphp.exe to configure PHP and PATH to work better with Composer, and provides an uninstaller if needed.
 Moniker: composer

--- a/manifests/f/FlexRadioSystems/SmartSDR/3.4.24/FlexRadioSystems.SmartSDR.locale.en-US.yaml
+++ b/manifests/f/FlexRadioSystems/SmartSDR/3.4.24/FlexRadioSystems.SmartSDR.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: FlexRadio Systems
 PackageName: SmartSDR
 PackageUrl: https://www.flexradio.com/software/
 License: Proprietary
-Copyright: © 2012-2023 FlexRadio Systems
+Copyright: © 2012-2023 FlexRadio Systems.
 ShortDescription: Client software for FlexRadio Signature series software-defined radios.
 Moniker: smartsdr
 ManifestType: defaultLocale

--- a/manifests/f/FlexRadioSystems/SmartSDR/3.4.24/FlexRadioSystems.SmartSDR.locale.en-US.yaml
+++ b/manifests/f/FlexRadioSystems/SmartSDR/3.4.24/FlexRadioSystems.SmartSDR.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: FlexRadio Systems
 PackageName: SmartSDR
 PackageUrl: https://www.flexradio.com/software/
 License: Proprietary
-Copyright: Copyright © 2012-2023 FlexRadio Systems
+Copyright: © 2012-2023 FlexRadio Systems
 ShortDescription: Client software for FlexRadio Signature series software-defined radios.
 Moniker: smartsdr
 ManifestType: defaultLocale

--- a/manifests/f/FlexRadioSystems/SmartSDR/4.2.20/FlexRadioSystems.SmartSDR.locale.en-US.yaml
+++ b/manifests/f/FlexRadioSystems/SmartSDR/4.2.20/FlexRadioSystems.SmartSDR.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: FlexRadio Systems
 PackageName: SmartSDR
 PackageUrl: https://www.flexradio.com/software/
 License: Proprietary
-Copyright: © 2012-2023 FlexRadio Systems
+Copyright: © 2012-2023 FlexRadio Systems.
 ShortDescription: Client software for FlexRadio Signature series software-defined radios.
 Moniker: smartsdr
 ManifestType: defaultLocale

--- a/manifests/f/FlexRadioSystems/SmartSDR/4.2.20/FlexRadioSystems.SmartSDR.locale.en-US.yaml
+++ b/manifests/f/FlexRadioSystems/SmartSDR/4.2.20/FlexRadioSystems.SmartSDR.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: FlexRadio Systems
 PackageName: SmartSDR
 PackageUrl: https://www.flexradio.com/software/
 License: Proprietary
-Copyright: Copyright © 2012-2023 FlexRadio Systems
+Copyright: © 2012-2023 FlexRadio Systems
 ShortDescription: Client software for FlexRadio Signature series software-defined radios.
 Moniker: smartsdr
 ManifestType: defaultLocale

--- a/manifests/g/GaijinNetwork/WarThunder/CDK/2026.05.25.10.07/GaijinNetwork.WarThunder.CDK.locale.en-US.yaml
+++ b/manifests/g/GaijinNetwork/WarThunder/CDK/2026.05.25.10.07/GaijinNetwork.WarThunder.CDK.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://support.gaijin.net
 PackageName: War Thunder CDK
 PackageUrl: https://wiki.warthunder.com/index.php?title=Download_War_Thunder_CDK
 License: Proprietary
-Copyright: © 2011-2017 Gaijin Entertainment
+Copyright: © 2011-2017 Gaijin Entertainment.
 ShortDescription: A set of tools for user content creation in War Thunder, available to every player.
 Description: War Thunder CDK (Content Development Kit) is a set of tools for user content creation available to every player. The CDK is installed in the game folder and allows the player to edit or create new unique missions and locations, as well as helps create game models.
 Moniker: warthunder-cdk

--- a/manifests/g/GaijinNetwork/WarThunder/CDK/2026.05.25.10.07/GaijinNetwork.WarThunder.CDK.locale.en-US.yaml
+++ b/manifests/g/GaijinNetwork/WarThunder/CDK/2026.05.25.10.07/GaijinNetwork.WarThunder.CDK.locale.en-US.yaml
@@ -10,7 +10,7 @@ PublisherSupportUrl: https://support.gaijin.net
 PackageName: War Thunder CDK
 PackageUrl: https://wiki.warthunder.com/index.php?title=Download_War_Thunder_CDK
 License: Proprietary
-Copyright: Copyright © 2011-2017 Gaijin Entertainment
+Copyright: © 2011-2017 Gaijin Entertainment
 ShortDescription: A set of tools for user content creation in War Thunder, available to every player.
 Description: War Thunder CDK (Content Development Kit) is a set of tools for user content creation available to every player. The CDK is installed in the game folder and allows the player to edit or create new unique missions and locations, as well as helps create game models.
 Moniker: warthunder-cdk

--- a/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Nmap
 PackageUrl: https://nmap.org/
 License: Proprietary
 LicenseUrl: https://nmap.org/npsl/
-Copyright: Copyright (c) Nmap Software LLC (fyodor@nmap.org)
+Copyright: © Nmap Software LLC (fyodor@nmap.org)
 ShortDescription: Free and open source utility for network discovery and security auditing.
 Moniker: nmap
 ManifestType: defaultLocale

--- a/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Nmap/7.98/Insecure.Nmap.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Nmap
 PackageUrl: https://nmap.org/
 License: Proprietary
 LicenseUrl: https://nmap.org/npsl/
-Copyright: © Nmap Software LLC (fyodor@nmap.org)
+Copyright: © Nmap Software LLC (fyodor@nmap.org).
 ShortDescription: Free and open source utility for network discovery and security auditing.
 Moniker: nmap
 ManifestType: defaultLocale

--- a/manifests/i/Insecure/Nmap/7.99/Insecure.Nmap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Nmap/7.99/Insecure.Nmap.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Nmap
 PackageUrl: https://nmap.org/
 License: Proprietary
 LicenseUrl: https://nmap.org/npsl/
-Copyright: Copyright (c) Nmap Software LLC (fyodor@nmap.org)
+Copyright: © Nmap Software LLC (fyodor@nmap.org)
 ShortDescription: Free and open source utility for network discovery and security auditing.
 Moniker: nmap
 ManifestType: defaultLocale

--- a/manifests/i/Insecure/Nmap/7.99/Insecure.Nmap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Nmap/7.99/Insecure.Nmap.locale.en-US.yaml
@@ -10,7 +10,7 @@ PackageName: Nmap
 PackageUrl: https://nmap.org/
 License: Proprietary
 LicenseUrl: https://nmap.org/npsl/
-Copyright: © Nmap Software LLC (fyodor@nmap.org)
+Copyright: © Nmap Software LLC (fyodor@nmap.org).
 ShortDescription: Free and open source utility for network discovery and security auditing.
 Moniker: nmap
 ManifestType: defaultLocale

--- a/manifests/i/Insecure/Npcap/1.88/Insecure.Npcap.locale.en-US.yaml
+++ b/manifests/i/Insecure/Npcap/1.88/Insecure.Npcap.locale.en-US.yaml
@@ -11,7 +11,7 @@ PackageName: Npcap
 PackageUrl: https://npcap.com/
 License: Proprietary
 LicenseUrl: https://npcap.com/#license
-Copyright: Copyright (c) 2025, Nmap Software LLC.  All rights reserved.
+Copyright: © 2025 Nmap Software LLC.  All rights reserved.
 ShortDescription: Windows packet capture and transmission library and driver, the WinPcap successor.
 Moniker: npcap
 ManifestType: defaultLocale

--- a/manifests/i/InterstellarResearch/Daqarta/12.0.0/InterstellarResearch.Daqarta.locale.en-US.yaml
+++ b/manifests/i/InterstellarResearch/Daqarta/12.0.0/InterstellarResearch.Daqarta.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Interstellar Research
 PackageName: Daqarta
 PackageUrl: https://www.daqarta.com/
 License: Proprietary
-Copyright: © 2026 by Interstellar Research
+Copyright: © 2026 by Interstellar Research.
 ShortDescription: Data acquisition, signal generation and spectrum analysis software for sound cards.
 Moniker: daqarta
 ManifestType: defaultLocale

--- a/manifests/i/InterstellarResearch/Daqarta/12.0.0/InterstellarResearch.Daqarta.locale.en-US.yaml
+++ b/manifests/i/InterstellarResearch/Daqarta/12.0.0/InterstellarResearch.Daqarta.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Interstellar Research
 PackageName: Daqarta
 PackageUrl: https://www.daqarta.com/
 License: Proprietary
-Copyright: Copyright © 2026 by Interstellar Research
+Copyright: © 2026 by Interstellar Research
 ShortDescription: Data acquisition, signal generation and spectrum analysis software for sound cards.
 Moniker: daqarta
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9128.1007/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9128.1007/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Microsoft Corporation
 PackageName: ConfigMgr CMTrace
 License: Proprietary
-Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: CMTrace is one of the Configuration Manager tools. It allows you to view and monitor log files.
 Moniker: cmtrace
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9133.1004/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9133.1004/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Microsoft Corporation
 PackageName: ConfigMgr CMTrace
 License: Proprietary
-Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: CMTrace is one of the Configuration Manager tools. It allows you to view and monitor log files.
 Moniker: cmtrace
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9141.1002/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/CMTrace/5.0.9141.1002/Microsoft.ConfigMgr.CMTrace.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Microsoft Corporation
 PackageName: ConfigMgr CMTrace
 License: Proprietary
-Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: CMTrace is one of the Configuration Manager tools. It allows you to view and monitor log files.
 Moniker: cmtrace
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/ConfigMgr/ClientSpy/5.0.9128.1007/Microsoft.ConfigMgr.ClientSpy.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/ClientSpy/5.0.9128.1007/Microsoft.ConfigMgr.ClientSpy.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr Client Spy
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
-Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: Client Spy is one of the Configuration Manager tools. It's a tool for troubleshooting software distribution, inventory, and software metering on Configuration Manager clients.
 Moniker: clientspy
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/ConfigMgr/DeploymentMonitoring/5.0.9128.1007/Microsoft.ConfigMgr.DeploymentMonitoring.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/DeploymentMonitoring/5.0.9128.1007/Microsoft.ConfigMgr.DeploymentMonitoring.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr Deployment Monitoring Tool
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
-Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: The Deployment Monitoring Tool is one of the Configuration Manager tools. It's a graphical user interface designed to assist in troubleshooting application, software update, and configuration baseline deployments on a Configuration Manager client.
 Moniker: deploymentmonitoring
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/ConfigMgr/PolicySpy/5.0.9128.1007/Microsoft.ConfigMgr.PolicySpy.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/PolicySpy/5.0.9128.1007/Microsoft.ConfigMgr.PolicySpy.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr Policy Spy
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
-Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: Policy Spy is one of the Configuration Manager tools. It's a tool for viewing and troubleshooting the policy system on Configuration Manager clients.
 Moniker: policyspy
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/ConfigMgr/PowerViewer/5.0.9128.1007/Microsoft.ConfigMgr.PowerViewer.locale.en-US.yaml
+++ b/manifests/m/Microsoft/ConfigMgr/PowerViewer/5.0.9128.1007/Microsoft.ConfigMgr.PowerViewer.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Microsoft Corporation
 PackageName: ConfigMgr Power Viewer
 PackageUrl: https://go.microsoft.com/fwlink/?linkid=2237687
 License: Proprietary
-Copyright: Copyright (C) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: The Power Viewer tool is one of the Configuration Manager tools. Use it to view the status of the power management feature on a Configuration Manager client.
 Moniker: powerviewer
 ManifestType: defaultLocale

--- a/manifests/m/Microsoft/GlobalSecureAccessClient/2.24.117/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
+++ b/manifests/m/Microsoft/GlobalSecureAccessClient/2.24.117/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: Microsoft Corporation
 PackageName: Global Secure Access Client
 PackageUrl: https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-install-windows-client
 License: Proprietary
-Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: Windows client for Microsoft Entra Global Secure Access that acquires and forwards selected device traffic to Microsoft's Security Service Edge (Entra Internet Access / Private Access) based on configured forwarding profiles.
 Moniker: global-secure-access-client
 Tags:

--- a/manifests/m/Microsoft/GlobalSecureAccessClient/2.26.108/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
+++ b/manifests/m/Microsoft/GlobalSecureAccessClient/2.26.108/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: Microsoft Corporation
 PackageName: Global Secure Access Client
 PackageUrl: https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-install-windows-client
 License: Proprietary
-Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: Windows client for Microsoft Entra Global Secure Access that acquires and forwards selected device traffic to Microsoft's Security Service Edge (Entra Internet Access / Private Access) based on configured forwarding profiles.
 Moniker: global-secure-access-client
 Tags:

--- a/manifests/m/Microsoft/GlobalSecureAccessClient/2.31.125/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
+++ b/manifests/m/Microsoft/GlobalSecureAccessClient/2.31.125/Microsoft.GlobalSecureAccessClient.locale.en-US.yaml
@@ -10,7 +10,7 @@ Author: Microsoft Corporation
 PackageName: Global Secure Access Client
 PackageUrl: https://learn.microsoft.com/en-us/entra/global-secure-access/how-to-install-windows-client
 License: Proprietary
-Copyright: Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright: © Microsoft Corporation. All rights reserved.
 ShortDescription: Windows client for Microsoft Entra Global Secure Access that acquires and forwards selected device traffic to Microsoft's Security Service Edge (Entra Internet Access / Private Access) based on configured forwarding profiles.
 Moniker: global-secure-access-client
 Tags:

--- a/manifests/m/Microsoft/OneNote/16.0.20131.20090/Microsoft.OneNote.locale.en-US.yaml
+++ b/manifests/m/Microsoft/OneNote/16.0.20131.20090/Microsoft.OneNote.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageName: Microsoft OneNote (Standalone)
 PackageUrl: https://www.microsoft.com/microsoft-365/onenote/digital-note-taking-app
 License: Freeware
 LicenseUrl: https://docs.microsoft.com/legal/termsofuse
-Copyright: © Microsoft Corporation
+Copyright: © Microsoft Corporation.
 CopyrightUrl: https://docs.microsoft.com/legal/termsofuse
 ShortDescription: Your digital notebook for capturing and organizing everything across your devices. Jot down your ideas, keep track of classroom and meeting notes, clip from the web, or make a to-do list, as well as draw and sketch your ideas.
 Moniker: onenote

--- a/manifests/m/Microsoft/VCRedist/2012/arm32/11.0.61030.0/Microsoft.VCRedist.2012.arm32.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2012/arm32/11.0.61030.0/Microsoft.VCRedist.2012.arm32.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: Microsoft Corporation
 PackageName: Microsoft Visual C++ 2012 Redistributable (Arm32)
 PackageUrl: https://www.microsoft.com/en-gb/download/details.aspx?id=30679
 License: Freeware
-Copyright: © Microsoft Corporation
+Copyright: © Microsoft Corporation.
 ShortDescription: The Microsoft Visual C++ 2012 Redistributable Package (Arm32) installs runtime components of Visual C++ Libraries required to run Arm32/ARMv7 applications developed with Visual C++ 2012 on a computer that does not have Visual C++ 2012 installed.
 Agreements:
   - Agreement: "This package is untested, as no test environment was available. Please report any issues here: https://github.com/pl4nty/winget-extras/issues/new?template=package_issue.yml"

--- a/manifests/m/Microsoft/VCRedist/2013/arm32/12.0.40660.0/Microsoft.VCRedist.2013.arm32.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2013/arm32/12.0.40660.0/Microsoft.VCRedist.2013.arm32.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: Microsoft Corporation
 PackageName: Microsoft Visual C++ 2013 Redistributable (Arm32)
 PackageUrl: https://www.microsoft.com/en-gb/download/details.aspx?id=40784
 License: Freeware
-Copyright: © Microsoft Corporation
+Copyright: © Microsoft Corporation.
 ShortDescription: The Microsoft Visual C++ 2013 Redistributable Package (Arm32).
 Description: |-
   The Microsoft Visual C++ 2013 Redistributable Package (Arm32) installs runtime components of Visual C++ Libraries required to run Arm32/ARMv7 applications developed with Visual C++ 2013 on a computer that does not have Visual C++ 2013 installed.

--- a/manifests/m/Microsoft/VCRedist/2013/arm32/12.0.40660.0/Microsoft.VCRedist.2013.arm32.locale.en-US.yaml
+++ b/manifests/m/Microsoft/VCRedist/2013/arm32/12.0.40660.0/Microsoft.VCRedist.2013.arm32.locale.en-US.yaml
@@ -11,7 +11,7 @@ Author: Microsoft Corporation
 PackageName: Microsoft Visual C++ 2013 Redistributable (Arm32)
 PackageUrl: https://www.microsoft.com/en-gb/download/details.aspx?id=40784
 License: Freeware
-Copyright: Copyright © Microsoft Corporation
+Copyright: © Microsoft Corporation
 ShortDescription: The Microsoft Visual C++ 2013 Redistributable Package (Arm32).
 Description: |-
   The Microsoft Visual C++ 2013 Redistributable Package (Arm32) installs runtime components of Visual C++ Libraries required to run Arm32/ARMv7 applications developed with Visual C++ 2013 on a computer that does not have Visual C++ 2013 installed.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.53/Nvidia.Driver.GeForceGameReady.10x0.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.53/Nvidia.Driver.GeForceGameReady.10x0.locale.en.yaml
@@ -7,7 +7,7 @@ Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Freeware
-Copyright: © 2011-2026 NVIDIA Corporation
+Copyright: © 2011-2026 NVIDIA Corporation.
 ShortDescription: Drivers for NVIDIA series 10x0, 9x0, and 7x0 graphics cards.
 Description: |-
   Graphics and audio drivers for NVIDIA series 10x0, 9x0, and 7x0 graphics cards.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.66/Nvidia.Driver.GeForceGameReady.10x0.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/10x0/582.66/Nvidia.Driver.GeForceGameReady.10x0.locale.en.yaml
@@ -7,7 +7,7 @@ Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver (10x0/9x0/7x0 cards)
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Freeware
-Copyright: © 2011-2026 NVIDIA Corporation
+Copyright: © 2011-2026 NVIDIA Corporation.
 ShortDescription: Drivers for NVIDIA series 10x0, 9x0, and 7x0 graphics cards.
 Description: |-
   Graphics and audio drivers for NVIDIA series 10x0, 9x0, and 7x0 graphics cards.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/391.35/Nvidia.Driver.GeForceGameReady.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/391.35/Nvidia.Driver.GeForceGameReady.locale.en.yaml
@@ -7,7 +7,7 @@ Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Freeware
-Copyright: © 2011-2026 NVIDIA Corporation
+Copyright: © 2011-2026 NVIDIA Corporation.
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-
   Graphics and audio drivers for NVIDIA graphics cards.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/591.86/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/591.86/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
@@ -7,7 +7,7 @@ Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Freeware
-Copyright: © 2011-2026 NVIDIA Corporation
+Copyright: © 2011-2026 NVIDIA Corporation.
 ShortDescription: Driver for Nvidia graphics cards.
 Moniker: nvidia-driver
 Tags:

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.47/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.47/Nvidia.Driver.GeForceGameReady.locale.en-US.yaml
@@ -7,7 +7,7 @@ Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Freeware
-Copyright: © 2011-2026 NVIDIA Corporation
+Copyright: © 2011-2026 NVIDIA Corporation.
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-
   Graphics and audio drivers for NVIDIA graphics cards.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.62/Nvidia.Driver.GeForceGameReady.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.62/Nvidia.Driver.GeForceGameReady.locale.en.yaml
@@ -7,7 +7,7 @@ Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Freeware
-Copyright: © 2011-2026 NVIDIA Corporation
+Copyright: © 2011-2026 NVIDIA Corporation.
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-
   Graphics and audio drivers for NVIDIA graphics cards.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.74/Nvidia.Driver.GeForceGameReady.locale.en.yaml
@@ -7,7 +7,7 @@ Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Freeware
-Copyright: © 2011-2026 NVIDIA Corporation
+Copyright: © 2011-2026 NVIDIA Corporation.
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-
   Graphics and audio drivers for NVIDIA graphics cards.

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/610.88/Nvidia.Driver.GeForceGameReady.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/610.88/Nvidia.Driver.GeForceGameReady.locale.en.yaml
@@ -8,7 +8,7 @@ Publisher: NVIDIA Corporation
 PackageName: NVIDIA GeForce Game Ready Driver
 PackageUrl: https://www.nvidia.com/en-gb/geforce/drivers/
 License: Freeware
-Copyright: © 2011-2026 NVIDIA Corporation
+Copyright: © 2011-2026 NVIDIA Corporation.
 ShortDescription: Drivers for NVIDIA graphics cards.
 Description: |-
   Graphics and audio drivers for NVIDIA graphics cards.

--- a/manifests/p/Pantaray/SuperOrca/11.0.0.1/Pantaray.SuperOrca.locale.en-US.yaml
+++ b/manifests/p/Pantaray/SuperOrca/11.0.0.1/Pantaray.SuperOrca.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: Pantaray Research Ltd.
 PackageName: QSetup Installation Suite
 License: Proprietary
-Copyright: Copyright (C) 2002-2012, Pantaray Research Ltd.
+Copyright: © 2002-2012 Pantaray Research Ltd.
 ShortDescription: SuperOrca from "Pantaray Research Ltd." is a direct replacement to the "Orca" MSI Editor from Microsoft. SuperOrca may be used to examine and modify an MSI database in order to distribute a new MSI package.
 Moniker: super-orca
 ManifestType: defaultLocale

--- a/manifests/p/Purslane/RustDesk/1.4.6/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.6/Purslane.RustDesk.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageName: RustDesk
 PackageUrl: https://rustdesk.com/
 License: AGPL-3.0-only
 LicenseUrl: https://github.com/rustdesk/rustdesk/blob/HEAD/LICENCE
-Copyright: Copyright © 2026 Purslane Ltd. All rights reserved.
+Copyright: © 2026 Purslane Ltd. All rights reserved.
 ShortDescription: The fast and open-source remote access and support software. 
 Description: RustDesk is a full-featured open source remote control alternative for self-hosting and security with minimal configuration.
 Moniker: rustdesk

--- a/manifests/p/Purslane/RustDesk/1.4.8/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.8/Purslane.RustDesk.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageName: RustDesk
 PackageUrl: https://rustdesk.com/
 License: AGPL-3.0-only
 LicenseUrl: https://github.com/rustdesk/rustdesk/blob/HEAD/LICENCE
-Copyright: Copyright © 2026 Purslane Ltd. All rights reserved.
+Copyright: © 2026 Purslane Ltd. All rights reserved.
 ShortDescription: The fast and open-source remote access and support software. 
 Description: RustDesk is a full-featured open source remote control alternative for self-hosting and security with minimal configuration.
 Moniker: rustdesk

--- a/manifests/p/Purslane/RustDesk/1.4.9/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.9/Purslane.RustDesk.locale.en-US.yaml
@@ -13,7 +13,7 @@ PackageName: RustDesk
 PackageUrl: https://rustdesk.com/
 License: AGPL-3.0-only
 LicenseUrl: https://github.com/rustdesk/rustdesk/blob/HEAD/LICENCE
-Copyright: Copyright © 2026 Purslane Ltd. All rights reserved.
+Copyright: © 2026 Purslane Ltd. All rights reserved.
 ShortDescription: The fast and open-source remote access and support software.
 Description: RustDesk is a full-featured open source remote control alternative for self-hosting and security with minimal configuration.
 Moniker: rustdesk

--- a/manifests/s/SwisslogForWindows/Swisslog/5.117/SwisslogForWindows.Swisslog.locale.en-US.yaml
+++ b/manifests/s/SwisslogForWindows/Swisslog/5.117/SwisslogForWindows.Swisslog.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Swisslog for Windows
 PackageName: Swisslog
 PackageUrl: https://www.swisslogforwindows.com/
 License: Freeware
-Copyright: © 1987-2026 Walter Baur, HB9BJS
+Copyright: © 1987-2026 Walter Baur, HB9BJS.
 ShortDescription: Amateur radio logging program for Windows.
 Moniker: swisslog
 ManifestType: defaultLocale

--- a/manifests/s/SwisslogForWindows/Swisslog/5.117/SwisslogForWindows.Swisslog.locale.en-US.yaml
+++ b/manifests/s/SwisslogForWindows/Swisslog/5.117/SwisslogForWindows.Swisslog.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Swisslog for Windows
 PackageName: Swisslog
 PackageUrl: https://www.swisslogforwindows.com/
 License: Freeware
-Copyright: Copyright © 1987-2026 Walter Baur, HB9BJS
+Copyright: © 1987-2026 Walter Baur, HB9BJS
 ShortDescription: Amateur radio logging program for Windows.
 Moniker: swisslog
 ManifestType: defaultLocale

--- a/manifests/s/SwisslogForWindows/Swisslog/5.118/SwisslogForWindows.Swisslog.locale.en-US.yaml
+++ b/manifests/s/SwisslogForWindows/Swisslog/5.118/SwisslogForWindows.Swisslog.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Swisslog for Windows
 PackageName: Swisslog
 PackageUrl: https://www.swisslogforwindows.com/
 License: Freeware
-Copyright: © 1987-2026 Walter Baur, HB9BJS
+Copyright: © 1987-2026 Walter Baur, HB9BJS.
 ShortDescription: Amateur radio logging program for Windows.
 Moniker: swisslog
 ManifestType: defaultLocale

--- a/manifests/s/SwisslogForWindows/Swisslog/5.118/SwisslogForWindows.Swisslog.locale.en-US.yaml
+++ b/manifests/s/SwisslogForWindows/Swisslog/5.118/SwisslogForWindows.Swisslog.locale.en-US.yaml
@@ -8,7 +8,7 @@ Publisher: Swisslog for Windows
 PackageName: Swisslog
 PackageUrl: https://www.swisslogforwindows.com/
 License: Freeware
-Copyright: Copyright © 1987-2026 Walter Baur, HB9BJS
+Copyright: © 1987-2026 Walter Baur, HB9BJS
 ShortDescription: Amateur radio logging program for Windows.
 Moniker: swisslog
 ManifestType: defaultLocale

--- a/scripts/manifest-linter/rules/index.ts
+++ b/scripts/manifest-linter/rules/index.ts
@@ -7,6 +7,7 @@ import { installerMetadataRule } from '@/scripts/manifest-linter/rules/installer
 import { returnCodesRule } from '@/scripts/manifest-linter/rules/installer/return-codes';
 import { switchesRule } from '@/scripts/manifest-linter/rules/installer/switches';
 import { repositoryContentsRule } from '@/scripts/manifest-linter/rules/repository/contents';
+import { copyrightFormatRule } from '@/scripts/manifest-linter/rules/repository/copyright-format';
 import { identifierCasingRule } from '@/scripts/manifest-linter/rules/repository/identifier-casing';
 import { licenseSpdxRule } from '@/scripts/manifest-linter/rules/repository/license-spdx';
 import { manifestPathRule } from '@/scripts/manifest-linter/rules/repository/manifest-path';
@@ -34,6 +35,7 @@ export const defaultRules: readonly Rule[] = [
 	repositoryContentsRule,
 	shardCoverageRule,
 	licenseSpdxRule,
+	copyrightFormatRule,
 	upstreamVersionsRule,
 	installerMetadataRule,
 	archiveRule,

--- a/scripts/manifest-linter/rules/repository/copyright-format.test.ts
+++ b/scripts/manifest-linter/rules/repository/copyright-format.test.ts
@@ -25,7 +25,6 @@ describe('copyright format rule', () => {
 			'© 2009, 2010, 2013 André Berg.',
 			'© Microsoft Corporation. All rights reserved.',
 			'Artem Izmaylov',
-			'Digitized data copyright (c) 2012-2015, The Mozilla Foundation.',
 			undefined,
 		]) {
 			expect(await checkCopyright(copyright)).toEqual([]);
@@ -60,6 +59,10 @@ describe('copyright format rule', () => {
 		);
 		expect(await expected('© 2011-2026 NVIDIA Corporation ')).toBe(
 			'Copyright must be written as: © 2011-2026 NVIDIA Corporation.',
+		);
+		// A notice qualified before the marker keeps what the qualifier says.
+		expect(await expected('Digitized data copyright (c) 2012-2015, The Mozilla Foundation')).toBe(
+			'Copyright must be written as: Digitized data © 2012-2015 The Mozilla Foundation.',
 		);
 	});
 

--- a/scripts/manifest-linter/rules/repository/copyright-format.test.ts
+++ b/scripts/manifest-linter/rules/repository/copyright-format.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'bun:test';
+
+import { copyrightFormatRule } from '@/scripts/manifest-linter/rules/repository/copyright-format';
+import { checkRule, manifest, messages, record } from '@/scripts/manifest-linter/rules/test-utils';
+
+function checkCopyright(copyright: string | undefined, raw?: string) {
+	return checkRule(copyrightFormatRule, {
+		records: [
+			record('defaultLocale', {
+				manifest: { ...manifest('defaultLocale'), Copyright: copyright } as never,
+				raw: raw ?? `Copyright: ${copyright}\n`,
+			}),
+		],
+	});
+}
+
+describe('copyright format rule', () => {
+	test('accepts notices already written as © <year> <holder>', async () => {
+		for (const copyright of [
+			'© 2014 Ryan L McIntyre.',
+			'© 2014 Ryan L McIntyre (https://ryanlmcintyre.com).',
+			'© 2011-2026 NVIDIA Corporation',
+			'© Microsoft Corporation. All rights reserved.',
+			'© 2009, 2010, 2013 André Berg',
+			'© 2026 Begonia Holdings. © 2026 Purslane Ltd.',
+			'Artem Izmaylov',
+			'Digitized data copyright (c) 2012-2015, The Mozilla Foundation and Telefonica S.A.',
+			undefined,
+		]) {
+			expect(await checkCopyright(copyright)).toEqual([]);
+		}
+	});
+
+	test('rewrites the notice marker and the comma after the year', async () => {
+		const issues = await checkCopyright(
+			'Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).',
+		);
+		expect(messages(issues)).toEqual([
+			'Copyright must be written as: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).',
+		]);
+		expect(issues[0]?.level).toBe('warning');
+		expect(issues[0]?.search).toBe(
+			'Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).',
+		);
+		expect(issues[0]?.fix).toEqual({
+			kind: 'replacement',
+			from: 'Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).',
+			to: '© 2014 Ryan L McIntyre (https://ryanlmcintyre.com).',
+		});
+	});
+
+	test('collapses every spelling of the marker to the bare symbol', async () => {
+		const expected = async (copyright: string) => (await checkCopyright(copyright)).at(0)?.message;
+		expect(await expected('Copyright © 2017 IBM Corp.')).toBe(
+			'Copyright must be written as: © 2017 IBM Corp.',
+		);
+		expect(await expected('Copyright (C) Microsoft Corporation. All rights reserved.')).toBe(
+			'Copyright must be written as: © Microsoft Corporation. All rights reserved.',
+		);
+		expect(await expected('(c) 2013-2021, type agaric <agaric@protonmail.com>')).toBe(
+			'Copyright must be written as: © 2013-2021 type agaric <agaric@protonmail.com>',
+		);
+		expect(await expected('Copyright 2021 Huawei Device Co., Ltd.')).toBe(
+			'Copyright must be written as: © 2021 Huawei Device Co., Ltd.',
+		);
+		expect(await expected('Copyright (c), The Ubuntu Font Family Project Authors')).toBe(
+			'Copyright must be written as: © The Ubuntu Font Family Project Authors',
+		);
+		expect(await expected('Copyright (c) AVerMedia')).toBe(
+			'Copyright must be written as: © AVerMedia',
+		);
+	});
+
+	test('separates the year from the holder without splitting a year list', async () => {
+		const expected = async (copyright: string) => (await checkCopyright(copyright)).at(0)?.message;
+		// The comma of a year list separates two years rather than the holder.
+		expect(await checkCopyright('© 2009, 2010, 2013 André Berg')).toEqual([]);
+		expect(await expected('Copyright © 2019 - Present, Microsoft Corporation')).toBe(
+			'Copyright must be written as: © 2019 - Present Microsoft Corporation',
+		);
+		expect(await expected('Copyright (c) 2019-07-29, Abbie Gonzalez')).toBe(
+			'Copyright must be written as: © 2019-07-29 Abbie Gonzalez',
+		);
+		expect(await expected('Copyright (c) 2022--2024, atelierAnchor')).toBe(
+			'Copyright must be written as: © 2022--2024 atelierAnchor',
+		);
+		// A holder that opens with a digit is still a holder.
+		expect(await expected('Copyright (c) 2024, 0xType Project Authors')).toBe(
+			'Copyright must be written as: © 2024 0xType Project Authors',
+		);
+	});
+
+	test('reports each notice of a semicolon separated Copyright separately', async () => {
+		const issues = await checkCopyright(
+			'Copyright (c) 2018 Information Architects Inc.; Copyright (c) 2017 IBM Corp.',
+		);
+		expect(messages(issues)).toEqual([
+			'Copyright must be written as: © 2018 Information Architects Inc.',
+			'Copyright must be written as: © 2017 IBM Corp.',
+		]);
+	});
+
+	test('reports each notice of a multi-line Copyright separately', async () => {
+		const raw = [
+			'Copyright: |-',
+			'  Copyright (c) 2018 Information Architects Inc.',
+			'  Work in the DejaVu project was committed to the public domain.',
+			'  Copyright (c) 2017 IBM Corp.',
+			'',
+		].join('\n');
+		const issues = await checkCopyright(
+			'Copyright (c) 2018 Information Architects Inc.\nWork in the DejaVu project was committed to the public domain.\nCopyright (c) 2017 IBM Corp.',
+			raw,
+		);
+		expect(messages(issues)).toEqual([
+			'Copyright must be written as: © 2018 Information Architects Inc.',
+			'Copyright must be written as: © 2017 IBM Corp.',
+		]);
+		expect(issues.map((issue) => issue.fix)).toEqual([
+			{
+				kind: 'replacement',
+				from: 'Copyright (c) 2018 Information Architects Inc.',
+				to: '© 2018 Information Architects Inc.',
+			},
+			{
+				kind: 'replacement',
+				from: 'Copyright (c) 2017 IBM Corp.',
+				to: '© 2017 IBM Corp.',
+			},
+		]);
+	});
+
+	test('reports without a fix when the notice is not unique in the file', async () => {
+		const copyright = 'Copyright (c) AVerMedia';
+		const issues = await checkCopyright(
+			copyright,
+			`Copyright: ${copyright}\nShortDescription: Copyright (c) AVerMedia devices\n`,
+		);
+		expect(messages(issues)).toEqual(['Copyright must be written as: © AVerMedia']);
+		expect(issues[0]?.fix).toBeUndefined();
+	});
+
+	test('reports nothing for manifests without a locale', async () => {
+		expect(
+			await checkRule(copyrightFormatRule, {
+				records: [record('installer'), record('version')],
+			}),
+		).toEqual([]);
+	});
+});

--- a/scripts/manifest-linter/rules/repository/copyright-format.test.ts
+++ b/scripts/manifest-linter/rules/repository/copyright-format.test.ts
@@ -3,35 +3,39 @@ import { describe, expect, test } from 'bun:test';
 import { copyrightFormatRule } from '@/scripts/manifest-linter/rules/repository/copyright-format';
 import { checkRule, manifest, messages, record } from '@/scripts/manifest-linter/rules/test-utils';
 
-function checkCopyright(copyright: string | undefined, raw?: string) {
+function checkCopyright(copyright: string | undefined) {
 	return checkRule(copyrightFormatRule, {
 		records: [
 			record('defaultLocale', {
 				manifest: { ...manifest('defaultLocale'), Copyright: copyright } as never,
-				raw: raw ?? `Copyright: ${copyright}\n`,
 			}),
 		],
 	});
 }
 
+async function expected(copyright: string) {
+	return (await checkCopyright(copyright)).at(0)?.message;
+}
+
 describe('copyright format rule', () => {
-	test('accepts notices already written as © <year> <holder>', async () => {
+	test('accepts a notice already written as © <year> <holder>.', async () => {
 		for (const copyright of [
 			'© 2014 Ryan L McIntyre.',
 			'© 2014 Ryan L McIntyre (https://ryanlmcintyre.com).',
-			'© 2011-2026 NVIDIA Corporation',
+			'© 2009, 2010, 2013 André Berg.',
 			'© Microsoft Corporation. All rights reserved.',
-			'© 2009, 2010, 2013 André Berg',
-			'© 2026 Begonia Holdings. © 2026 Purslane Ltd.',
 			'Artem Izmaylov',
-			'Digitized data copyright (c) 2012-2015, The Mozilla Foundation and Telefonica S.A.',
+			'Digitized data copyright (c) 2012-2015, The Mozilla Foundation.',
 			undefined,
 		]) {
 			expect(await checkCopyright(copyright)).toEqual([]);
 		}
+		expect(
+			await checkRule(copyrightFormatRule, { records: [record('installer'), record('version')] }),
+		).toEqual([]);
 	});
 
-	test('rewrites the notice marker and the comma after the year', async () => {
+	test('collapses every spelling of the marker and closes the notice', async () => {
 		const issues = await checkCopyright(
 			'Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).',
 		);
@@ -39,112 +43,61 @@ describe('copyright format rule', () => {
 			'Copyright must be written as: © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).',
 		]);
 		expect(issues[0]?.level).toBe('warning');
-		expect(issues[0]?.search).toBe(
-			'Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).',
-		);
 		expect(issues[0]?.fix).toEqual({
 			kind: 'replacement',
 			from: 'Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).',
 			to: '© 2014 Ryan L McIntyre (https://ryanlmcintyre.com).',
 		});
-	});
 
-	test('collapses every spelling of the marker to the bare symbol', async () => {
-		const expected = async (copyright: string) => (await checkCopyright(copyright)).at(0)?.message;
 		expect(await expected('Copyright © 2017 IBM Corp.')).toBe(
 			'Copyright must be written as: © 2017 IBM Corp.',
 		);
-		expect(await expected('Copyright (C) Microsoft Corporation. All rights reserved.')).toBe(
-			'Copyright must be written as: © Microsoft Corporation. All rights reserved.',
-		);
-		expect(await expected('(c) 2013-2021, type agaric <agaric@protonmail.com>')).toBe(
-			'Copyright must be written as: © 2013-2021 type agaric <agaric@protonmail.com>',
-		);
-		expect(await expected('Copyright 2021 Huawei Device Co., Ltd.')).toBe(
-			'Copyright must be written as: © 2021 Huawei Device Co., Ltd.',
+		expect(await expected('(c) 2013-2021, type agaric')).toBe(
+			'Copyright must be written as: © 2013-2021 type agaric.',
 		);
 		expect(await expected('Copyright (c), The Ubuntu Font Family Project Authors')).toBe(
-			'Copyright must be written as: © The Ubuntu Font Family Project Authors',
+			'Copyright must be written as: © The Ubuntu Font Family Project Authors.',
 		);
-		expect(await expected('Copyright (c) AVerMedia')).toBe(
-			'Copyright must be written as: © AVerMedia',
+		expect(await expected('© 2011-2026 NVIDIA Corporation ')).toBe(
+			'Copyright must be written as: © 2011-2026 NVIDIA Corporation.',
 		);
 	});
 
 	test('separates the year from the holder without splitting a year list', async () => {
-		const expected = async (copyright: string) => (await checkCopyright(copyright)).at(0)?.message;
-		// The comma of a year list separates two years rather than the holder.
-		expect(await checkCopyright('© 2009, 2010, 2013 André Berg')).toEqual([]);
+		expect(await expected('Copyright 2009, 2010, 2013 André Berg')).toBe(
+			'Copyright must be written as: © 2009, 2010, 2013 André Berg.',
+		);
 		expect(await expected('Copyright © 2019 - Present, Microsoft Corporation')).toBe(
-			'Copyright must be written as: © 2019 - Present Microsoft Corporation',
+			'Copyright must be written as: © 2019 - Present Microsoft Corporation.',
 		);
 		expect(await expected('Copyright (c) 2019-07-29, Abbie Gonzalez')).toBe(
-			'Copyright must be written as: © 2019-07-29 Abbie Gonzalez',
-		);
-		expect(await expected('Copyright (c) 2022--2024, atelierAnchor')).toBe(
-			'Copyright must be written as: © 2022--2024 atelierAnchor',
+			'Copyright must be written as: © 2019-07-29 Abbie Gonzalez.',
 		);
 		// A holder that opens with a digit is still a holder.
 		expect(await expected('Copyright (c) 2024, 0xType Project Authors')).toBe(
-			'Copyright must be written as: © 2024 0xType Project Authors',
+			'Copyright must be written as: © 2024 0xType Project Authors.',
 		);
 	});
 
-	test('reports each notice of a semicolon separated Copyright separately', async () => {
-		const issues = await checkCopyright(
-			'Copyright (c) 2018 Information Architects Inc.; Copyright (c) 2017 IBM Corp.',
-		);
-		expect(messages(issues)).toEqual([
-			'Copyright must be written as: © 2018 Information Architects Inc.',
-			'Copyright must be written as: © 2017 IBM Corp.',
-		]);
-	});
-
-	test('reports each notice of a multi-line Copyright separately', async () => {
-		const raw = [
-			'Copyright: |-',
-			'  Copyright (c) 2018 Information Architects Inc.',
-			'  Work in the DejaVu project was committed to the public domain.',
-			'  Copyright (c) 2017 IBM Corp.',
-			'',
-		].join('\n');
-		const issues = await checkCopyright(
-			'Copyright (c) 2018 Information Architects Inc.\nWork in the DejaVu project was committed to the public domain.\nCopyright (c) 2017 IBM Corp.',
-			raw,
-		);
-		expect(messages(issues)).toEqual([
-			'Copyright must be written as: © 2018 Information Architects Inc.',
-			'Copyright must be written as: © 2017 IBM Corp.',
-		]);
-		expect(issues.map((issue) => issue.fix)).toEqual([
-			{
-				kind: 'replacement',
-				from: 'Copyright (c) 2018 Information Architects Inc.',
-				to: '© 2018 Information Architects Inc.',
-			},
-			{
-				kind: 'replacement',
-				from: 'Copyright (c) 2017 IBM Corp.',
-				to: '© 2017 IBM Corp.',
-			},
-		]);
-	});
-
-	test('reports without a fix when the notice is not unique in the file', async () => {
-		const copyright = 'Copyright (c) AVerMedia';
-		const issues = await checkCopyright(
-			copyright,
-			`Copyright: ${copyright}\nShortDescription: Copyright (c) AVerMedia devices\n`,
-		);
-		expect(messages(issues)).toEqual(['Copyright must be written as: © AVerMedia']);
-		expect(issues[0]?.fix).toBeUndefined();
-	});
-
-	test('reports nothing for manifests without a locale', async () => {
+	test('reports each notice of a multi-notice Copyright separately', async () => {
 		expect(
-			await checkRule(copyrightFormatRule, {
-				records: [record('installer'), record('version')],
-			}),
-		).toEqual([]);
+			messages(
+				await checkCopyright(
+					'Copyright (c) 2018 Information Architects Inc.; Copyright (c) 2017 IBM Corp.',
+				),
+			),
+		).toEqual([
+			'Copyright must be written as: © 2018 Information Architects Inc.',
+			'Copyright must be written as: © 2017 IBM Corp.',
+		]);
+
+		// A line carrying no marker is left alone.
+		expect(
+			messages(
+				await checkCopyright(
+					'Copyright (c) 2018 Source Foundry Authors\nWork in the DejaVu project was committed to the public domain.',
+				),
+			),
+		).toEqual(['Copyright must be written as: © 2018 Source Foundry Authors.']);
 	});
 });

--- a/scripts/manifest-linter/rules/repository/copyright-format.ts
+++ b/scripts/manifest-linter/rules/repository/copyright-format.ts
@@ -1,0 +1,55 @@
+import { defineRule } from '@/scripts/manifest-linter/rules/helpers';
+
+/**
+ * The notice markers upstream metadata uses. They are all spellings of the same
+ * thing, so this repository keeps the bare symbol and rewrites the rest, taking
+ * a run of them together to collapse pairs like `Copyright (c)`.
+ */
+const MARKERS = /^(?:copyright|\(c\)|©)(?:[\s,]*(?:copyright|\(c\)|©))*/i;
+
+/**
+ * A leading year, date or range, up to the comma that upstream metadata tends
+ * to put between it and the holder. A year list such as `2009, 2010, 2013` uses
+ * the same comma to separate its own entries, so a following year holds it.
+ */
+const YEARS =
+	/^(\d{4}(?:-\d{2}-\d{2})?(?:\s*[-–—]+\s*(?:\d{4}(?:-\d{2}-\d{2})?|present))?),\s+(?!\d{4}\b)/i;
+
+/** Rewrites one notice to `© <year> <holder>`, leaving one without a marker alone. */
+function normalize(notice: string): string {
+	const marker = MARKERS.exec(notice);
+	if (!marker) return notice;
+	const holder = notice
+		.slice(marker[0].length)
+		.replace(/^[\s,]+/, '')
+		.replace(YEARS, '$1 ');
+	return holder ? `© ${holder}` : '©';
+}
+
+export const copyrightFormatRule = defineRule({
+	id: 'repository/copyright-format',
+	check({ records, report }) {
+		for (const { file, manifest, raw } of records) {
+			if (manifest.ManifestType !== 'locale' && manifest.ManifestType !== 'defaultLocale') continue;
+			// A Copyright holding several notices separates them with a line break or a
+			// semicolon, and each one is checked and fixed on its own.
+			for (const notice of manifest.Copyright?.split(/\n|;\s*/) ?? []) {
+				const expected = normalize(notice);
+				if (expected === notice) continue;
+				// The notice is only rewritten in place when it appears once in the file,
+				// so the fix cannot land on a description that quotes the same text.
+				const unique = raw.indexOf(notice) >= 0 && raw.indexOf(notice) === raw.lastIndexOf(notice);
+				report({
+					file,
+					level: 'warning',
+					message: `Copyright must be written as: ${expected}`,
+					search: notice,
+					hints: [
+						'write the notice as © <year> <holder>, not Copyright or (c), and separate the year from the holder with a space',
+					],
+					fix: unique ? { kind: 'replacement', from: notice, to: expected } : undefined,
+				});
+			}
+		}
+	},
+});

--- a/scripts/manifest-linter/rules/repository/copyright-format.ts
+++ b/scripts/manifest-linter/rules/repository/copyright-format.ts
@@ -1,7 +1,9 @@
 import { defineRule } from '@/scripts/manifest-linter/rules/helpers';
 
 // Matched as a run, so that a pair like `Copyright (c)` collapses to one symbol.
-const MARKERS = /^(?:copyright|\(c\)|©)(?:[\s,]*(?:copyright|\(c\)|©))*/i;
+// A notice does not always open with one: `Digitized data copyright (c) 2012`
+// qualifies what is covered first.
+const MARKERS = /(?:copyright|\(c\)|©)(?:[\s,]*(?:copyright|\(c\)|©))*/i;
 
 // The comma upstream puts between the year and the holder. A year list such as
 // `2009, 2010, 2013` separates its own entries with the same comma, so a year
@@ -13,12 +15,14 @@ function normalizedNotice(notice: string): string {
 	const marker = MARKERS.exec(notice);
 	if (!marker) return notice;
 	const holder = notice
-		.slice(marker[0].length)
+		.slice(marker.index + marker[0].length)
 		.replace(/^[\s,]+/, '')
 		.replace(YEARS, '$1 ')
 		.trimEnd();
-	if (!holder) return '©';
-	return `© ${holder}${holder.endsWith('.') ? '' : '.'}`;
+	const normalized = [notice.slice(0, marker.index).trimEnd(), '©', holder]
+		.filter(Boolean)
+		.join(' ');
+	return normalized.endsWith('.') ? normalized : `${normalized}.`;
 }
 
 export const copyrightFormatRule = defineRule({

--- a/scripts/manifest-linter/rules/repository/copyright-format.ts
+++ b/scripts/manifest-linter/rules/repository/copyright-format.ts
@@ -1,53 +1,42 @@
 import { defineRule } from '@/scripts/manifest-linter/rules/helpers';
 
-/**
- * The notice markers upstream metadata uses. They are all spellings of the same
- * thing, so this repository keeps the bare symbol and rewrites the rest, taking
- * a run of them together to collapse pairs like `Copyright (c)`.
- */
+// Matched as a run, so that a pair like `Copyright (c)` collapses to one symbol.
 const MARKERS = /^(?:copyright|\(c\)|©)(?:[\s,]*(?:copyright|\(c\)|©))*/i;
 
-/**
- * A leading year, date or range, up to the comma that upstream metadata tends
- * to put between it and the holder. A year list such as `2009, 2010, 2013` uses
- * the same comma to separate its own entries, so a following year holds it.
- */
+// The comma upstream puts between the year and the holder. A year list such as
+// `2009, 2010, 2013` separates its own entries with the same comma, so a year
+// after it holds the match back.
 const YEARS =
 	/^(\d{4}(?:-\d{2}-\d{2})?(?:\s*[-–—]+\s*(?:\d{4}(?:-\d{2}-\d{2})?|present))?),\s+(?!\d{4}\b)/i;
 
-/** Rewrites one notice to `© <year> <holder>`, leaving one without a marker alone. */
-function normalize(notice: string): string {
+function normalizedNotice(notice: string): string {
 	const marker = MARKERS.exec(notice);
 	if (!marker) return notice;
 	const holder = notice
 		.slice(marker[0].length)
 		.replace(/^[\s,]+/, '')
-		.replace(YEARS, '$1 ');
-	return holder ? `© ${holder}` : '©';
+		.replace(YEARS, '$1 ')
+		.trimEnd();
+	if (!holder) return '©';
+	return `© ${holder}${holder.endsWith('.') ? '' : '.'}`;
 }
 
 export const copyrightFormatRule = defineRule({
 	id: 'repository/copyright-format',
 	check({ records, report }) {
-		for (const { file, manifest, raw } of records) {
+		for (const { file, manifest } of records) {
 			if (manifest.ManifestType !== 'locale' && manifest.ManifestType !== 'defaultLocale') continue;
 			// A Copyright holding several notices separates them with a line break or a
-			// semicolon, and each one is checked and fixed on its own.
+			// semicolon, and each one is normalized on its own.
 			for (const notice of manifest.Copyright?.split(/\n|;\s*/) ?? []) {
-				const expected = normalize(notice);
+				const expected = normalizedNotice(notice);
 				if (expected === notice) continue;
-				// The notice is only rewritten in place when it appears once in the file,
-				// so the fix cannot land on a description that quotes the same text.
-				const unique = raw.indexOf(notice) >= 0 && raw.indexOf(notice) === raw.lastIndexOf(notice);
 				report({
 					file,
 					level: 'warning',
 					message: `Copyright must be written as: ${expected}`,
 					search: notice,
-					hints: [
-						'write the notice as © <year> <holder>, not Copyright or (c), and separate the year from the holder with a space',
-					],
-					fix: unique ? { kind: 'replacement', from: notice, to: expected } : undefined,
+					fix: { kind: 'replacement', from: notice, to: expected },
 				});
 			}
 		}


### PR DESCRIPTION
Adds `repository/copyright-format` to the manifest linter and applies its fix across the repository.

The `Copyright` field arrives from upstream font and installer metadata in every spelling of the same notice — `Copyright (c) 2014, ...`, `Copyright © 2017 ...`, `Copyright 2022 ...`, `(c) 2013-2021, ...`. The rule warns when a notice is not written as `© [year] [holder].` and fixes it in place:

```
Copyright (c) 2014, Ryan L McIntyre (https://ryanlmcintyre.com).
→ © 2014 Ryan L McIntyre (https://ryanlmcintyre.com).
```

Three things are normalised: any run of notice markers (`Copyright`, `(c)`, `©`, and combinations) collapses to the bare symbol, the comma upstream tends to put between the year and the holder becomes a space, and the notice is closed with a full stop.

A value with no notice marker at all (`Artem Izmaylov`, `Digitized data copyright (c) 2012-2015, ...`) is left alone.

Details:

- A `Copyright` holding several notices — separated by a line break in a block scalar, or by a semicolon — is checked one notice at a time, so `Copyright (c) 2018 Information Architects Inc.; Copyright (c) 2017 IBM Corp.` is fully rewritten.
- A year list such as `2009, 2010, 2013 André Berg` keeps its own commas; only a comma followed by a non-year is treated as the year/holder boundary. A holder that opens with a digit (`2024, 0xType Project Authors`) is still a holder.

`bun manifests:fix` normalised 429 manifests across the two passes. One more was fixed by hand: `BinaryFortress.NotepadReplacer` carried `Copyright Â© 2007-2023 ...`, a mojibake `©`, and rewriting only the marker would have left the stray character behind.

`40f8251` narrows `Validate`'s changed-files filter to `**/*.installer.yaml`. The old filter matched every manifest, so this branch's 305 changed package directories expanded to 319 matrix entries and tripped GitHub's 256-job limit, failing the run before any job started. None of that work was meaningful — no installer manifest changed here, and copyright text cannot affect `winget install`. Flagged separately in [this comment](https://github.com/pl4nty/winget-extras/pull/747#issuecomment-5161544238), since it changes when validation runs for every future PR.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - No related winget-pkgs issue — this is repository tooling.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate`? — not run; `winget` is unavailable in this environment. `bun manifests:check` and `bun test scripts` pass, and only `Copyright` lines changed.
- [ ] Have you tested your manifest locally with `winget install`? — not applicable; no installer, URL or version data changed.
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?