### PR TITLE
Microsoft.DotNet.DesktopRuntime.*: fix DisplayVersion

### DIFF
--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.10/Microsoft.DotNet.DesktopRuntime.10.x64.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.10/Microsoft.DotNet.DesktopRuntime.10.x64.installer.yaml
@@ -19,7 +19,6 @@ AppsAndFeaturesEntries:
   UpgradeCode: '{90D77843-5FBD-64EF-6BDF-DF7574D01646}'
   InstallerType: burn
 - DisplayName: Microsoft Windows Desktop Runtime
-  DisplayVersion: 80.40.55332
   ProductCode: '{F0BCFB2E-4878-4F6E-BD5D-3ABFF264829E}'
   UpgradeCode: '{B2ADA9D5-5E43-5813-665B-BB4BB3DFE96F}'
   InstallerType: wix

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.11/Microsoft.DotNet.DesktopRuntime.10.x64.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x64/10.0.11/Microsoft.DotNet.DesktopRuntime.10.x64.installer.yaml
@@ -19,7 +19,6 @@ AppsAndFeaturesEntries:
   UpgradeCode: '{90D77843-5FBD-64EF-6BDF-DF7574D01646}'
   InstallerType: burn
 - DisplayName: Microsoft Windows Desktop Runtime
-  DisplayVersion: 80.44.56884
   ProductCode: '{042FE0BF-0E19-47E0-8864-22F483C784E6}'
   UpgradeCode: '{2E2143ED-5ACB-55F4-3146-2F5220DDACB8}'
   InstallerType: wix

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.10/Microsoft.DotNet.DesktopRuntime.10.x86.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.10/Microsoft.DotNet.DesktopRuntime.10.x86.installer.yaml
@@ -21,7 +21,6 @@ AppsAndFeaturesEntries:
   UpgradeCode: '{0F62FF89-5CC3-5DFE-EC82-DB9D826B6527}'
   InstallerType: burn
 - DisplayName: Microsoft Windows Desktop Runtime
-  DisplayVersion: 80.40.55332
   ProductCode: '{4AA06CD9-F530-4267-AB12-78D34F41A405}'
   UpgradeCode: '{E85A39CA-5EF8-5707-BB1D-26AA8D48B598}'
   InstallerType: wix

--- a/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.11/Microsoft.DotNet.DesktopRuntime.10.x86.installer.yaml
+++ b/manifests/m/Microsoft/DotNet/DesktopRuntime/10/x86/10.0.11/Microsoft.DotNet.DesktopRuntime.10.x86.installer.yaml
@@ -21,7 +21,6 @@ AppsAndFeaturesEntries:
   UpgradeCode: '{0F62FF89-5CC3-5DFE-EC82-DB9D826B6527}'
   InstallerType: burn
 - DisplayName: Microsoft Windows Desktop Runtime
-  DisplayVersion: 80.44.56884
   ProductCode: '{9B309846-9934-42DA-8897-39B7D106321B}'
   UpgradeCode: '{492E6AA8-5037-77A8-EC83-5B52BEEEF940}'
   InstallerType: wix


### PR DESCRIPTION
We should have a linter rule to prevent this.

Resolves #823