### PR TITLE
New package: RaspberryPiFoundation.RaspberryPiImager version 2.0.10

### DIFF
--- a/manifests/r/RaspberryPiFoundation/RaspberryPiImager/2.0.10/RaspberryPiFoundation.RaspberryPiImager.installer.yaml
+++ b/manifests/r/RaspberryPiFoundation/RaspberryPiImager/2.0.10/RaspberryPiFoundation.RaspberryPiImager.installer.yaml
@@ -1,0 +1,24 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RaspberryPiFoundation.RaspberryPiImager
+PackageVersion: 2.0.10
+InstallerLocale: en-US
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+UpgradeBehavior: install
+ProductCode: '{46C75BF3-E267-4834-AE1D-BEB77E05BFA1}_is1'
+ReleaseDate: 2026-06-19
+ElevationRequirement: elevatesSelf
+FileExtensions:
+- img
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Raspberry Pi Ltd\Imager'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/raspberrypi/rpi-imager/releases/download/v2.0.10/imager-v2.0.10.exe
+  InstallerSha256: F5B0BD6F149274D8B92C3DBBDEFA274097C9D9098DD4EB08C71B845B58995B2A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RaspberryPiFoundation/RaspberryPiImager/2.0.10/RaspberryPiFoundation.RaspberryPiImager.locale.en-US.yaml
+++ b/manifests/r/RaspberryPiFoundation/RaspberryPiImager/2.0.10/RaspberryPiFoundation.RaspberryPiImager.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RaspberryPiFoundation.RaspberryPiImager
+PackageVersion: 2.0.10
+PackageLocale: en-US
+Publisher: Raspberry Pi Ltd
+PublisherUrl: https://github.com/raspberrypi
+PublisherSupportUrl: https://github.com/raspberrypi/rpi-imager/issues
+PackageName: Raspberry Pi Imager
+PackageUrl: https://github.com/raspberrypi/rpi-imager/
+License: Apache-2.0
+LicenseUrl: https://github.com/raspberrypi/rpi-imager/blob/HEAD/license.txt
+Copyright: © 2026 Raspberry Pi Ltd.
+ShortDescription: Tool for installing Raspberry Pi OS and other operating systems
+Moniker: rpi-imager
+Tags:
+- flash
+- imager
+- raspberrypi
+- sd
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RaspberryPiFoundation/RaspberryPiImager/2.0.10/RaspberryPiFoundation.RaspberryPiImager.yaml
+++ b/manifests/r/RaspberryPiFoundation/RaspberryPiImager/2.0.10/RaspberryPiFoundation.RaspberryPiImager.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RaspberryPiFoundation.RaspberryPiImager
+PackageVersion: 2.0.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/RaspberryPiFoundation.RaspberryPiImager.json
+++ b/shards/json/RaspberryPiFoundation.RaspberryPiImager.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "raspberrypi", "repo": "rpi-imager" },
+	"urls": [
+		"https://github.com/raspberrypi/rpi-imager/releases/download/v{version}/imager-v{version}.exe"
+	]
+}


### PR DESCRIPTION
Adds RaspberryPiFoundation.RaspberryPiImager 2.0.10, requested in #806.

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#390596 (closed: unattended installation was blocked on user input during validation, so it's a good fit for this repo per the README's "interactive-only installers" criterion)

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? Not run — no Windows environment available in this session. The manifests were checked with this repo's own `bun manifests:check` linter (passes with no warnings) and modeled closely on the closed winget-pkgs PR's manifest data (same installer URL/SHA256/ProductCode) and on existing `inno`/`machine`-scope manifests in this repo.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Not run, same reason.
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? Uses schema 1.12.0, consistent with other recently-added `inno` manifests in this repo.

A shard (`shards/json/RaspberryPiFoundation.RaspberryPiImager.json`) is included for automatic future version detection via GitHub releases.

Since the upstream installer fails silent/unattended install, the manifest sets `InstallModes: [interactive]` rather than claiming full silent support.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARh3p597K2RcGURXkBgUfP)_