### PR TITLE
New packages: WingFTPSoftware.WingFTPServer, WingFTPSoftware.WingGateway, PCBPiezotronics.G4LDUtility

### DIFF
--- a/manifests/p/PCBPiezotronics/G4LDUtility/5.6.0.70/PCBPiezotronics.G4LDUtility.installer.yaml
+++ b/manifests/p/PCBPiezotronics/G4LDUtility/5.6.0.70/PCBPiezotronics.G4LDUtility.installer.yaml
@@ -1,0 +1,17 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PCBPiezotronics.G4LDUtility
+PackageVersion: 5.6.0.70
+InstallerType: zip
+NestedInstallerType: burn
+NestedInstallerFiles:
+- RelativeFilePath: G4Setup_v5.6.0_x64.exe
+ElevationRequirement: elevatesSelf
+ReleaseDate: 2026-06-24
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.larsondavis.com/ContentStore/mktg/LD_Software/G4Setup_v5.6.0_x64.zip
+  InstallerSha256: 2EF0584594467B8C3A0DC37B6F5114D511B5BEE5C3FE5F76348EEBF981EEE04A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PCBPiezotronics/G4LDUtility/5.6.0.70/PCBPiezotronics.G4LDUtility.locale.en-US.yaml
+++ b/manifests/p/PCBPiezotronics/G4LDUtility/5.6.0.70/PCBPiezotronics.G4LDUtility.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PCBPiezotronics.G4LDUtility
+PackageVersion: 5.6.0.70
+PackageLocale: en-US
+Publisher: PCB Piezotronics Inc.
+PublisherUrl: https://www.larsondavis.com/
+PublisherSupportUrl: https://www.larsondavis.com/product-support/software/g4-ld-utility
+PackageName: PCB Piezotronics G4 LD Utility
+PackageUrl: https://www.larsondavis.com/Products/software/g4-ld-utility-software
+License: Proprietary
+Copyright: © 2014-2025 PCB Piezotronics Inc.
+ShortDescription: Free software for Larson Davis sound level meters, the HVM200 human vibration meter, and Spartan noise dosimeters
+Description: |-
+  G4 LD Utility connects, controls, downloads, and views data from multiple Larson Davis instruments simultaneously, and lets you organize files and meters by project. View data graphically and in spreadsheet format, generate reports, and export to .xlsx without Excel.
+Moniker: g4-ld-utility
+Tags:
+- larson-davis
+- sound-level-meter
+- noise-dosimeter
+- acoustics
+- vibration
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PCBPiezotronics/G4LDUtility/5.6.0.70/PCBPiezotronics.G4LDUtility.yaml
+++ b/manifests/p/PCBPiezotronics/G4LDUtility/5.6.0.70/PCBPiezotronics.G4LDUtility.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PCBPiezotronics.G4LDUtility
+PackageVersion: 5.6.0.70
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/WingFTPSoftware/WingFTPServer/8.2.1/WingFTPSoftware.WingFTPServer.installer.yaml
+++ b/manifests/w/WingFTPSoftware/WingFTPServer/8.2.1/WingFTPSoftware.WingFTPServer.installer.yaml
@@ -1,0 +1,15 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: WingFTPSoftware.WingFTPServer
+PackageVersion: 8.2.1
+InstallerType: inno
+Scope: machine
+ElevationRequirement: elevatesSelf
+ReleaseDate: 2026-07-14
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.wftpserver.com/download/WingFtpServer.exe
+  InstallerSha256: 65C2BF03E18FCCDDA959171F9E99DAC78F32FF94B2D0447CBF2189C2FA50682F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WingFTPSoftware/WingFTPServer/8.2.1/WingFTPSoftware.WingFTPServer.locale.en-US.yaml
+++ b/manifests/w/WingFTPSoftware/WingFTPServer/8.2.1/WingFTPSoftware.WingFTPServer.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: WingFTPSoftware.WingFTPServer
+PackageVersion: 8.2.1
+PackageLocale: en-US
+Publisher: Wing FTP Software, Inc.
+PublisherUrl: https://www.wftpserver.com/
+PublisherSupportUrl: https://www.wftpserver.com/support.htm
+PackageName: Wing FTP Server
+PackageUrl: https://www.wftpserver.com/wftpserver.htm
+License: Proprietary
+Copyright: © 2003-2026 Wing FTP Software, Inc.
+ShortDescription: A free, secure FTP/FTPS/SFTP server for Windows with a web-based admin dashboard for monitoring, session tracking, and notifications.
+Description: |-
+  Wing FTP Server is a free, easy-to-use, and secure FTP server software for Windows, Linux, and Mac OS. WingFTP not only supports FTP/FTPS protocols, but also supports secure file transfer via its built-in SFTP server and web server. Furthermore, the web-based interface provides a centralized dashboard for remote server administration. From there, you can monitor server performance, track active sessions, and receive email notifications for download/upload events.
+Moniker: wingftpserver
+Tags:
+- ftp
+- ftps
+- sftp
+- file-transfer
+- server
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WingFTPSoftware/WingFTPServer/8.2.1/WingFTPSoftware.WingFTPServer.yaml
+++ b/manifests/w/WingFTPSoftware/WingFTPServer/8.2.1/WingFTPSoftware.WingFTPServer.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: WingFTPSoftware.WingFTPServer
+PackageVersion: 8.2.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/w/WingFTPSoftware/WingGateway/1.1.2/WingFTPSoftware.WingGateway.installer.yaml
+++ b/manifests/w/WingFTPSoftware/WingGateway/1.1.2/WingFTPSoftware.WingGateway.installer.yaml
@@ -1,0 +1,15 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: WingFTPSoftware.WingGateway
+PackageVersion: 1.1.2
+InstallerType: inno
+Scope: machine
+ElevationRequirement: elevatesSelf
+ReleaseDate: 2023-03-20
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.wftpserver.com/download/WingGateway_Setup.exe
+  InstallerSha256: F867D26C4957FDF0C95E6F4E843386434DC94F8DC4BE8B426D8BBEE1E940B2E1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/WingFTPSoftware/WingGateway/1.1.2/WingFTPSoftware.WingGateway.locale.en-US.yaml
+++ b/manifests/w/WingFTPSoftware/WingGateway/1.1.2/WingFTPSoftware.WingGateway.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: WingFTPSoftware.WingGateway
+PackageVersion: 1.1.2
+PackageLocale: en-US
+Publisher: Wing FTP Software, Inc.
+PublisherUrl: https://www.wftpserver.com/
+PublisherSupportUrl: https://www.wftpserver.com/support.htm
+PackageName: Wing Gateway
+PackageUrl: https://www.wftpserver.com/gateway.htm
+License: Proprietary
+Copyright: © 2003-2026 Wing FTP Software, Inc.
+ShortDescription: A reverse proxy and load balancer for Wing FTP Server, avoiding open inbound ports and supporting failover across multiple nodes.
+Description: |-
+  Wing Gateway is a high performance reverse proxy and load balance module for Wing FTP Server, it avoids opening unnecessary inbound ports and prevents sensitive data from being stored in the DMZ, Wing Gateway can provide reverse proxy function for all the WingFTP supported protocols - FTP/FTPS/SFTP/HTTP/HTTPS, clients transfer files through Wing Gateway will have the same experience as connecting to WingFTP directly. Wing Gateway also supports load balancing to distribute incoming connections to multiple WingFTP server machines, let you easily and dynamically adding or removing WingFTP node without stopping service. To meet the high availability requirement, you can use "Failover" feature for one server node, then if the running node fails or goes down, the failover node will carry on.
+Moniker: winggateway
+Tags:
+- ftp
+- reverse-proxy
+- load-balancer
+- gateway
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/WingFTPSoftware/WingGateway/1.1.2/WingFTPSoftware.WingGateway.yaml
+++ b/manifests/w/WingFTPSoftware/WingGateway/1.1.2/WingFTPSoftware.WingGateway.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: WingFTPSoftware.WingGateway
+PackageVersion: 1.1.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/PCBPiezotronics.G4LDUtility.json
+++ b/shards/json/PCBPiezotronics.G4LDUtility.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://www.larsondavis.com/product-support/software/g4-ld-utility",
+		"regex": "G4Setup_v(?<version>\\d+\\.\\d+\\.\\d+)_x64\\.zip"
+	},
+	"version": { "source": "product" },
+	"urls": [
+		{
+			"url": "https://www.larsondavis.com/ContentStore/mktg/LD_Software/G4Setup_v{version}_x64.zip",
+			"nestedInstallerMatches": ["G4Setup"]
+		}
+	]
+}

--- a/shards/json/WingFTPSoftware.WingFTPServer.json
+++ b/shards/json/WingFTPSoftware.WingFTPServer.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{ "url": "https://www.wftpserver.com/download/WingFtpServer.exe", "architecture": "x64" }
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://www.wftpserver.com/download/WingFtpServer.exe",
+		"header": "etag"
+	},
+	"replace": true
+}

--- a/shards/json/WingFTPSoftware.WingGateway.json
+++ b/shards/json/WingFTPSoftware.WingGateway.json
@@ -1,0 +1,14 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{ "url": "https://www.wftpserver.com/download/WingGateway_Setup.exe", "architecture": "x64" }
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://www.wftpserver.com/download/WingGateway_Setup.exe",
+		"header": "etag"
+	},
+	"replace": true
+}


### PR DESCRIPTION
Adds the three packages requested in #794 (Wing FTP Server, Wing Gateway) and #788 (PCB Piezotronics G4 LD Utility), all of which already had complete details (URLs, versions, publisher info) in the issue and just needed someone with installer access to build the manifest — which this session now has.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Not submitted to winget-pkgs (per the issues); no related upstream PR.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? Not run — no Windows environment available in this session. Checked with this repo's own `bun manifests:check` linter (passes with no warnings) and `bun test scripts` (all green).
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Not run, same reason — relying on this repo's CI `Validate` job.
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? Uses schema 1.12.0, consistent with other recently-added manifests in this repo.

## Details

**WingFTPSoftware.WingFTPServer 8.2.1** and **WingFTPSoftware.WingGateway 1.1.2** — both plain Inno Setup installers downloaded directly from wftpserver.com. Installer hashes and versions were confirmed against the downloaded binaries (PE version resources matched the requester-provided versions exactly). Shards use `strategy: static` with `version: { source: product }`, since both download URLs are unversioned/stable and the real version has to come from the installer's embedded metadata (etag used as the cheap change-detection token, per Anthelion's contributing guide).

**PCBPiezotronics.G4LDUtility 5.6.0.70** — the download is a zip containing a WiX Burn bootstrapper exe (`InstallerType: zip` / `NestedInstallerType: burn`). The vendor's download page only exposes a 3-part marketing version (`5.6.0`) in the URL/filename, but the actual `ProductVersion` embedded in the executable is `5.6.0.70` (matches the version the requester reported). The shard uses `page-match` to discover the versioned URL, then overrides the resolved version with `{ source: product }` so future automated updates stay aligned with the more precise installed version rather than the coarser marketing version.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ARh3p597K2RcGURXkBgUfP)_