### PR TITLE
New package: Calibrite.PROFILER version 3.1.0

### DIFF
--- a/manifests/c/Calibrite/PROFILER/3.1.0/Calibrite.PROFILER.installer.yaml
+++ b/manifests/c/Calibrite/PROFILER/3.1.0/Calibrite.PROFILER.installer.yaml
@@ -1,0 +1,19 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Calibrite.PROFILER
+PackageVersion: 3.1.0
+InstallerLocale: en-US
+InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+UpgradeBehavior: install
+ElevationRequirement: elevationRequired
+ReleaseDate: 2026-05-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/LUMESCA/calibrite-profiler-releases/releases/download/v3.1.0/calibrite-PROFILER-Setup-3.1.0.exe
+  InstallerSha256: C875A21A60B289B029DDDC3AF7FC7A305F6ACB5DC0B7D889AD165E384F298773
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Calibrite/PROFILER/3.1.0/Calibrite.PROFILER.locale.en-US.yaml
+++ b/manifests/c/Calibrite/PROFILER/3.1.0/Calibrite.PROFILER.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Calibrite.PROFILER
+PackageVersion: 3.1.0
+PackageLocale: en-US
+Publisher: Calibrite LLC
+PublisherUrl: https://calibrite.com/
+PublisherSupportUrl: https://calibrite.com/calibrite-technical-support/
+PackageName: calibrite PROFILER
+PackageUrl: https://calibrite.com/profiler/
+License: Proprietary
+ShortDescription: Calibration software that ensures consistent, accurate results across your entire workflow.
+Description: |-
+  Calibrite PROFILER is powerful yet easy-to-use calibration software that ensures consistent, accurate results across your entire workflow. With built-in presets for beginners and advanced customization for professionals, it's designed to help you get color right, every time.
+Moniker: calibrite-profiler
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Calibrite/PROFILER/3.1.0/Calibrite.PROFILER.yaml
+++ b/manifests/c/Calibrite/PROFILER/3.1.0/Calibrite.PROFILER.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Calibrite.PROFILER
+PackageVersion: 3.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Calibrite.PROFILER.json
+++ b/shards/json/Calibrite.PROFILER.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": {
+		"owner": "LUMESCA",
+		"repo": "calibrite-profiler-releases"
+	},
+	"urls": [
+		"https://github.com/LUMESCA/calibrite-profiler-releases/releases/download/v{version}/calibrite-PROFILER-Setup-{version}.exe"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#377076

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? (not run in this environment; installer downloaded and inspected manually — NSIS/Nullsoft installer, requires admin elevation, x64 payload)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (no Windows environment available)
- [x] Does your manifest conform to the [1.12 schema](https://github.com/microsoft/winget-pkgs/tree/master/doc/manifest/schema/1.12.0)?

Note: `<path>` is `manifests/c/Calibrite/PROFILER/3.1.0`.

---

Closes #864.

Adds Calibrite.PROFILER 3.1.0 (calibrite PROFILER color calibration software by Calibrite LLC), requested via #864 where the submitter asked for someone else to build the manifest.

- Downloaded the installer from the GitHub release linked in the issue (`LUMESCA/calibrite-profiler-releases` v3.1.0) and verified the SHA256 hash, publisher/product metadata (`Calibrite LLC` / `calibrite PROFILER` / `3.1.0`), and installer type (NSIS/Nullsoft, requires administrator, x64 payload).
- Added `shards/json/Calibrite.PROFILER.json` using the `github-release` strategy against that release repo so future versions are picked up automatically.
- Publisher/support/product URLs sourced from calibrite.com.

---
_Generated by [Claude Code](https://claude.ai/code/session_017ewj8dq6iTs6DAEM6Ns81g)_