### PR TITLE
ci(publish): run rclone in verbose mode

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -138,6 +138,7 @@ jobs:
           DRY_RUN: ${{ github.ref != 'refs/heads/main' }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          RCLONE_VERBOSE: '1'
           RCLONE_CONFIG_R2_TYPE: s3
           RCLONE_CONFIG_R2_PROVIDER: Cloudflare
           RCLONE_CONFIG_R2_ENV_AUTH: 'true'


### PR DESCRIPTION
Enables rclone's verbose mode so it shows what was uploaded/deleted. This would be useful for debugging purposes if something breaks in the future.

https://rclone.org/docs/#v-vv-verbose