### PR TITLE
chore: add .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+shards/script/*.disabled linguist-language=TypeScript
+shards/json/*.disabled linguist-language=JSON


### PR DESCRIPTION
Adds syntax highlighting for disabled shards on GitHub.