### PR TITLE
Add shard for XnSoft.XnRetro

### DIFF
--- a/shards/json/XnSoft.XnRetro.json
+++ b/shards/json/XnSoft.XnRetro.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://www.xnview.com/en/xnretro/",
+		"regex": "Version (\\d+(?:\\.\\d+)+) \\(Windows"
+	},
+	"urls": ["https://download.xnview.com/old_versions/XnRetro/XnRetro-{version}-win-x64.zip"]
+}


### PR DESCRIPTION
Adds `shards/json/XnSoft.XnRetro.json` so XnRetro picks up new versions automatically.

Uses the `page-match` strategy against the official product page, which advertises the current release as `Version 1.30 (Windows/macOS/Linux)`. The advertised download link (`https://download.xnview.com/XnRetro-win-x64.zip`) is unversioned, so the shard instead templates the immutable versioned archive under `old_versions/`, which is where XnSoft publishes every release (and which the existing 1.30 manifest already points at).

Verified manually (the `anthelion` dependency can't be installed in this environment, so `bun test:shard --dry-run` wasn't available):

- The regex matches the live page and captures `1.30`, the current manifest version.
- The templated URL resolves to `https://download.xnview.com/old_versions/XnRetro/XnRetro-1.30-win-x64.zip`, whose SHA256 is `D51B03BCFAD75B477E713AEBB24757661F3D8490D8AA4D052ABB27132238A2E1` — identical to the `InstallerSha256` in `manifests/x/XnSoft/XnRetro/1.30/XnSoft.XnRetro.installer.yaml`.

Only the x64 archive is templated, matching the existing manifest. `NestedInstallerFiles` is carried over from the previous manifest, as with the other portable-zip shards in the repo.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - No related winget-pkgs issue.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? — n/a, no manifest changes; this PR only adds a shard.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — n/a, no manifest changes.
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? — existing 1.28 manifests are unchanged.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0176Fo4wJAT1FxG6zbMHqffj

---
_Generated by [Claude Code](https://claude.ai/code/session_0176Fo4wJAT1FxG6zbMHqffj)_