### PR TITLE
fix: Adonthell.WastesEdge shard

### DIFF
--- a/shards/json/Adonthell.WastesEdge.json
+++ b/shards/json/Adonthell.WastesEdge.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
-	"strategy": "page-match",
-	"pageMatch": {
+	"strategy": "sort-versions",
+	"sortVersions": {
 		"url": "https://download.savannah.gnu.org/releases/adonthell/",
 		"regex": "wastesedge-(\\d+(?:\\.\\d+)+)-x64\\.msi\""
 	},


### PR DESCRIPTION
#893 proposed Adonthell.WastesEdge 0.3.6, an older version than the 0.3.7 already in the source (#885).

The Savannah release directory lists every release side by side:

```
wastesedge-0.3.6-x64.msi
wastesedge-0.3.6-x86.msi
wastesedge-0.3.7-x64.msi
wastesedge-0.3.7-x86.msi
```

`page-match` resolves the first regex hit, which is 0.3.6. Switched the shard to `sort-versions` (same URL and regex) so the highest matching version wins, matching how other directory-listing shards like `Bitstream.Vera.Font` are configured.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - N/A — shard-only change, no winget-pkgs counterpart.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? — no manifest changed.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — no manifest changed.
- [ ] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? — no manifest changed.

The shard was validated against the Anthelion schema with ajv (`bun run test:shard` couldn't run here — the `anthelion` dependency isn't fetchable from this environment).

---
_Generated by [Claude Code](https://claude.ai/code/session_0138R31aVqzKex844ecebmCU)_