### PR TITLE
New package: Winitor.pestudio version 9.61

### DIFF
--- a/manifests/w/Winitor/pestudio/9.61/Winitor.pestudio.installer.yaml
+++ b/manifests/w/Winitor/pestudio/9.61/Winitor.pestudio.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+PackageIdentifier: Winitor.pestudio
+PackageVersion: "9.61"
+ReleaseDate: 2025-03-28
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: pestudio\pestudio.exe
+  PortableCommandAlias: pestudio
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.winitor.com/tools/pestudio/current/pestudio.zip
+  InstallerSha256: C1E2D0C1FBF5951486CF3D850CC24B11B66E25E0A5B77A623E2EB13FFAD9DDD9
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/w/Winitor/pestudio/9.61/Winitor.pestudio.locale.en.yaml
+++ b/manifests/w/Winitor/pestudio/9.61/Winitor.pestudio.locale.en.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+PackageIdentifier: Winitor.pestudio
+PackageVersion: "9.61"
+PackageLocale: en
+Publisher: Winitor
+PublisherUrl: https://www.winitor.com/
+Author: Marc Ochsenmeier
+PackageName: pestudio
+PackageUrl: https://www.winitor.com/download
+License: Proprietary
+Copyright: © 2009-2025 Marc Ochsenmeier.
+ShortDescription: Accelerate your malware assessment workflow by quickly identifying key indicators of Windows executable files.
+Moniker: pestudio
+Tags:
+- dfir
+- executable
+- malware
+- malware-analysis
+- pe
+- portable-executable
+- reverse-engineering
+- static-analysis
+ReleaseNotesUrl: https://www.winitor.com/tools/pestudio/changes.log
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/w/Winitor/pestudio/9.61/Winitor.pestudio.yaml
+++ b/manifests/w/Winitor/pestudio/9.61/Winitor.pestudio.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+PackageIdentifier: Winitor.pestudio
+PackageVersion: "9.61"
+DefaultLocale: en
+ManifestType: version
+ManifestVersion: 1.28.0

--- a/shards/json/Winitor.pestudio.json
+++ b/shards/json/Winitor.pestudio.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "sort-versions",
+	"sortVersions": {
+		"url": "https://www.winitor.com/tools/pestudio/changes.log",
+		"regex": "(?:Version|to) (\\d+(?:\\.\\d+)+)"
+	},
+	"urls": [
+		{
+			"url": "https://www.winitor.com/tools/pestudio/current/pestudio.zip",
+			"architecture": "x64",
+			"nestedInstallerMatches": ["pestudio/pestudio.exe"]
+		}
+	],
+	"replace": true
+}


### PR DESCRIPTION
Adds pestudio, with a shard that reads the version from upstream's `changes.log`.

The `static` strategy with `version.source: product` can't work here — the download is a zip, and an archive has no version resource to read. `sort-versions` over https://www.winitor.com/tools/pestudio/changes.log resolves `9.61` instead, verified with a dry run:

```
==> Running Winitor.pestudio.json
Version: 9.61
URLs: https://www.winitor.com/tools/pestudio/current/pestudio.zip
```

The regex matches both shapes the log uses for its headings — `Version 9.61` for the newest entry and `Version 9.56 to 9.60` once entries are folded into a range — and sorting means the newest wins regardless of where it sits in the file. `state` is dropped: the version now moves on its own, so an etag is no longer what tells an update apart. `replace` stays, since `current/pestudio.zip` only ever serves the newest build.

The nested installer match uses a forward slash (`pestudio/pestudio.exe`), matching the archive's entry paths.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - No related issue. pestudio is not in winget-pkgs — the community source returns no results for it.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? — no Windows in this environment; `bun manifests:check` passes across all 1898 files
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — same, needs validation on Windows
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Manifest details, all read from the shipped build: `9.61` and its 2025-03-28 release date from the archive, x64 and the `pestudio\pestudio.exe` nested path from the executable itself. `ArchiveBinariesDependOnPath` is set because pestudio loads `peparser.dll` and its `xml/` directory from alongside the binary.

The manifest is hand-authored rather than komac-generated, since komac's manifest fetch is blocked in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mwk56QFDWYPAe8LhBEVwFv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mwk56QFDWYPAe8LhBEVwFv)_