### PR TITLE
feat(linter): accept localized values of Proprietary and Freeware

### DIFF
--- a/manifests/s/SichboPVR/SichboPVR/3/3.1.105/SichboPVR.SichboPVR.3.locale.da.yaml
+++ b/manifests/s/SichboPVR/SichboPVR/3/3.1.105/SichboPVR.SichboPVR.3.locale.da.yaml
@@ -3,6 +3,7 @@
 PackageIdentifier: SichboPVR.SichboPVR.3
 PackageVersion: 3.1.105
 PackageLocale: da
+License: Gratis
 ShortDescription: Den gamle og noget særegne version 3 af SichboPVR.
 Tags:
 - danmarks-radio

--- a/manifests/s/SichboPVR/SichboPVR/3/3.1.105/SichboPVR.SichboPVR.3.locale.nb.yaml
+++ b/manifests/s/SichboPVR/SichboPVR/3/3.1.105/SichboPVR.SichboPVR.3.locale.nb.yaml
@@ -3,6 +3,7 @@
 PackageIdentifier: SichboPVR.SichboPVR.3
 PackageVersion: 3.1.105
 PackageLocale: nb
+License: Gratis
 ShortDescription: Den gamle og underfundige versjon 3 av SichboPVR.
 Tags:
 - digital-antenne-tv

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -1,9 +1,5 @@
 {
 	"ignore": {
-		"repository/license-spdx": {
-			"manifests/l/Linkly/Linkly/*/Linkly.Linkly.locale.zh-CN.yaml": "localized Proprietary license value",
-			"manifests/m/Microsoft/Outlook/*/Microsoft.Outlook.locale.{da,nb,nn}.yaml": "localized Proprietary license value"
-		},
 		"repository/shard-coverage": {
 			"manifests/a/AMD/BugReportTool": "selfhosted, drivers.amd.com only serves the installer to requests with an amd.com referer",
 			"manifests/a/ASRock/AppShop": "asrock.com blocks automated requests, and the download URL is the only place the version appears",

--- a/scripts/manifest-linter/rules/repository/license-spdx.test.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.test.ts
@@ -34,13 +34,21 @@ async function checkLicense(license: string | undefined, response?: Response | E
 }
 
 describe('license spdx rule', () => {
-	test('accepts published identifiers, expressions and the house values', async () => {
+	test('accepts published identifiers, expressions and translated house values', async () => {
 		for (const license of [
 			'MIT',
 			'MIT OR Apache-2.0',
 			'GPL-3.0-only WITH Autoconf-exception-3.0',
 			'Proprietary',
 			'Freeware',
+			'Propietario',
+			'Proprietær',
+			'专有软件',
+			'免费软件',
+			'Проприетарное',
+			'मुफ़्त',
+			'Besplatni',
+			'Gratis',
 			'  ',
 			undefined,
 		]) {
@@ -57,7 +65,7 @@ describe('license spdx rule', () => {
 		expect(issues[0]?.level).toBe('warning');
 		expect(issues[0]?.search).toBe('License');
 		expect(issues[0]?.hints).toEqual([
-			'use an identifier from https://spdx.org/licenses/, or Proprietary or Freeware for a license SPDX does not list',
+			'use an identifier from https://spdx.org/licenses/, or Proprietary, Freeware, or one of their localized translations for a license SPDX does not list',
 		]);
 
 		expect(messages((await checkLicense('GPLv3')).issues)).toEqual([

--- a/scripts/manifest-linter/rules/repository/license-spdx.ts
+++ b/scripts/manifest-linter/rules/repository/license-spdx.ts
@@ -2,12 +2,60 @@ import { defineRule } from '@/scripts/manifest-linter/rules/helpers';
 
 const LICENSE_LIST_URL = 'https://spdx.org/licenses/licenses.json';
 
-/**
- * How this repository spells a license SPDX does not publish. Most closed source
- * packages have no identifier to reach for, so they standardise on these two
- * rather than on a phrase per package.
- */
-const HOUSE_IDENTIFIERS = new Set(['Proprietary', 'Freeware']);
+const LICENSE_TRANSLATIONS = {
+	en: ['Proprietary', 'Freeware'],
+	es: ['Propietario', 'Gratuito'],
+	de: ['Proprietär', 'Kostenlos'],
+	ja: ['プロプライエタリ', 'フリーウェア'],
+	fr: ['Propriétaire', 'Gratuiciel'],
+	pt: ['Proprietário', 'Gratuito'],
+	ru: ['Проприетарное', 'Бесплатное'],
+	it: ['Proprietario', 'Gratuito'],
+	nl: ['Proprietair', 'Gratis'],
+	pl: ['Zamknięte', 'Darmowe'],
+	tr: ['Kapalı kaynak', 'Ücretsiz'],
+	zh: ['专有软件', '免费软件', '專有軟件', '免費軟體'],
+	id: ['Milik perorangan', 'Gratis'],
+	cs: ['Proprietární', 'Bezplatný'],
+	fa: ['اختصاصی', 'رایگان'],
+	vi: ['Độc quyền', 'Miễn phí'],
+	ko: ['사유 소프트웨어', '프리웨어'],
+	uk: ['Пропрієтарне', 'Безкоштовне'],
+	ar: ['امتلاكية', 'مجانية'],
+	hu: ['Zárt forráskódú', 'Ingyenes'],
+	sv: ['Proprietär', 'Gratis'],
+	ro: ['Proprietar', 'Gratuit'],
+	el: ['Ιδιόκτητο', 'Δωρεάν'],
+	da: ['Proprietær', 'Gratis'],
+	fi: ['Omisteinen', 'Ilmainen'],
+	he: ['קניינית', 'חינמית'],
+	sk: ['Proprietárny', 'Bezplatný'],
+	th: ['จำกัดสิทธิ์', 'ฟรี'],
+	bg: ['Собствен', 'Безплатен'],
+	hr: ['Vlasnički', 'Besplatni'],
+	sr: ['Власнички', 'Бесплатан'],
+	nb: ['Proprietær', 'Gratis'],
+	lt: ['Uždaras kodas', 'Nemokama'],
+	sl: ['Lastniška', 'Brezplačna'],
+	ca: ['Propietari', 'Gratuït'],
+	et: ['Omanduslik', 'Priivara'],
+	no: ['Proprietær', 'Gratis'],
+	lv: ['Slēgtais kods', 'Bezmaksas'],
+	bn: ['মালিকানাধীন', 'বিনামূল্যের'],
+	hi: ['मालिकाना', 'मुफ़्त'],
+	bs: ['Vlasnički', 'Besplatni'],
+	az: ['Özəl', 'Pulsuz'],
+	ka: ['კერძო', 'უფასო'],
+	is: ['Séreignarhugbúnaður', 'Ókeypis'],
+	uz: ['Proprietar', 'Bepul'],
+	ms: ['Hak milik', 'Percuma'],
+	mk: ['Сопственичка', 'Бесплатна'],
+	kk: ['Меншікті', 'Тегін'],
+	sq: ['Pronësor', 'Falas'],
+	hy: ['Սեփականատիրական', 'Անվճար'],
+} as const;
+
+const CUSTOM_IDENTIFIERS = new Set<string>(Object.values(LICENSE_TRANSLATIONS).flat());
 
 type SpdxLicense = { licenseId: string; isDeprecatedLicenseId?: boolean };
 
@@ -48,7 +96,7 @@ function identifiers(value: string): string[] | undefined {
 
 function accepted(id: string, licenses: Map<string, SpdxLicense>): boolean {
 	const license = licenses.get(id);
-	return HOUSE_IDENTIFIERS.has(id) || (license !== undefined && !license.isDeprecatedLicenseId);
+	return CUSTOM_IDENTIFIERS.has(id) || (license !== undefined && !license.isDeprecatedLicenseId);
 }
 
 export const licenseSpdxRule = defineRule({
@@ -67,6 +115,7 @@ export const licenseSpdxRule = defineRule({
 			if (manifest.ManifestType !== 'locale' && manifest.ManifestType !== 'defaultLocale') continue;
 			const value = manifest.License?.trim();
 			if (!value) continue;
+			if (CUSTOM_IDENTIFIERS.has(value)) continue;
 
 			const unknown = identifiers(value)?.filter((id) => !accepted(id, licenses));
 			if (unknown && unknown.length === 0) continue;
@@ -83,7 +132,7 @@ export const licenseSpdxRule = defineRule({
 					hints: [
 						deprecated
 							? `see https://spdx.org/licenses/${id}.html for its replacement`
-							: 'use an identifier from https://spdx.org/licenses/, or Proprietary or Freeware for a license SPDX does not list',
+							: 'use an identifier from https://spdx.org/licenses/, or Proprietary, Freeware, or one of their localized translations for a license SPDX does not list',
 					],
 				});
 			}


### PR DESCRIPTION
This adds translations for Proprietary and Freeware to the linter for the [50 most common languages](https://en.wikipedia.org/wiki/Languages_used_on_the_Internet) used on in the internet. Most the of translations were pulled from the [Wikidata](https://www.wikidata.org/wiki/Q218616) [pages](https://www.wikidata.org/wiki/Q178285) and the rest were from Google Translate with some minor changes by Codex.

I think this is the best compromise for https://github.com/pl4nty/winget-extras/pull/902#issuecomment-5306324398.