### PR TITLE
Purslane.RustDesk: add IconSha256 so icons render

### DIFF
--- a/manifests/p/Purslane/RustDesk/1.4.6/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.6/Purslane.RustDesk.locale.en-US.yaml
@@ -77,5 +77,6 @@ ReleaseNotesUrl: https://github.com/rustdesk/rustdesk/releases/tag/1.4.6
 Icons:
 - IconUrl: https://raw.githubusercontent.com/rustdesk/rustdesk/14a4b197adc8b80fc954ad11fde50d443305a176/res/128x128%402x.png
   IconFileType: png
+  IconSha256: d1f9e63be757f345cfa3b3a0592ab02897935074e3876419f70fb554cef5872f
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/p/Purslane/RustDesk/1.4.8/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.8/Purslane.RustDesk.locale.en-US.yaml
@@ -62,5 +62,6 @@ ReleaseNotesUrl: https://github.com/rustdesk/rustdesk/releases/tag/1.4.8
 Icons:
 - IconUrl: https://raw.githubusercontent.com/rustdesk/rustdesk/14a4b197adc8b80fc954ad11fde50d443305a176/res/128x128%402x.png
   IconFileType: png
+  IconSha256: d1f9e63be757f345cfa3b3a0592ab02897935074e3876419f70fb554cef5872f
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/p/Purslane/RustDesk/1.4.9/Purslane.RustDesk.locale.en-US.yaml
+++ b/manifests/p/Purslane/RustDesk/1.4.9/Purslane.RustDesk.locale.en-US.yaml
@@ -78,5 +78,6 @@ ReleaseNotesUrl: https://github.com/rustdesk/rustdesk/releases/tag/1.4.9
 Icons:
 - IconUrl: https://raw.githubusercontent.com/rustdesk/rustdesk/14a4b197adc8b80fc954ad11fde50d443305a176/res/128x128%402x.png
   IconFileType: png
+  IconSha256: d1f9e63be757f345cfa3b3a0592ab02897935074e3876419f70fb554cef5872f
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0


### PR DESCRIPTION
Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to #920 (follow-up: the icons added there don't render)

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? (edited on Linux; only adds an `IconSha256` field to existing valid manifests)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

#920 added `IconUrl`/`IconFileType` without `IconSha256`, and the icons never rendered on endpoints. winget uses the icon hash as the file-cache key and integrity check (`Caching::FileCache{ Type::Icon, SHA256::ConvertToString(bestFitIcon->Sha256), ... }` in `WorkflowBase.cpp`); with no hash, `ConvertToHexString` throws `80070057` ("ConvertToHexString: Invalid buffer size") and the icon is silently skipped under `CATCH_LOG()`:

```
<E> [FAIL] ...AppInstallerStrings.cpp(886)... Msg:[ConvertToHexString: Invalid buffer size]
```

This adds `IconSha256: d1f9e63be757f345cfa3b3a0592ab02897935074e3876419f70fb554cef5872f` to the RustDesk 1.4.6/1.4.8/1.4.9 locale manifests — the verified SHA-256 of the PNG at the pinned `IconUrl`.

---
_Generated by [Claude Code](https://claude.ai/code/session_012ANuyFFUa5eoh9UAaytBxx)_