### PR TITLE
New package: GyulyVGC.sniffnet version 1.5.1

### DIFF
--- a/manifests/g/GyulyVGC/sniffnet/1.5.1/GyulyVGC.sniffnet.installer.yaml
+++ b/manifests/g/GyulyVGC/sniffnet/1.5.1/GyulyVGC.sniffnet.installer.yaml
@@ -1,0 +1,45 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: GyulyVGC.sniffnet
+PackageVersion: 1.5.1
+InstallerLocale: en-US
+InstallerType: wix
+Scope: machine
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Insecure.Npcap
+ReleaseDate: 2026-07-22
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/GyulyVGC/sniffnet/releases/download/v1.5.1/Sniffnet_Windows_x64.msi
+  InstallerSha256: 3F4DACF273B0E5270D4055A6561C5B0E1E0747EF6530F984CC42389EBC401700
+  ProductCode: '{03272003-B238-460D-88E8-B9922E0A4700}'
+  AppsAndFeaturesEntries:
+  - Publisher: Giuliano Bellini
+    ProductCode: '{03272003-B238-460D-88E8-B9922E0A4700}'
+    UpgradeCode: '{352ADDB7-26A5-46BB-B25B-94E379BC2408}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\Sniffnet'
+- Architecture: x86
+  InstallerUrl: https://github.com/GyulyVGC/sniffnet/releases/download/v1.5.1/Sniffnet_Windows_x86.msi
+  InstallerSha256: EEE53CBD9AAA80D8E046363C5A8881839A057618BB58B5CE942E562580CED234
+  ProductCode: '{6915E6E1-0AA6-4738-9F91-C5A90EE81FBD}'
+  AppsAndFeaturesEntries:
+  - Publisher: Giuliano Bellini
+    ProductCode: '{6915E6E1-0AA6-4738-9F91-C5A90EE81FBD}'
+    UpgradeCode: '{352ADDB7-26A5-46BB-B25B-94E379BC2408}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles(x86)%\Sniffnet'
+- Architecture: arm64
+  InstallerUrl: https://github.com/GyulyVGC/sniffnet/releases/download/v1.5.1/Sniffnet_Windows_arm64.msi
+  InstallerSha256: 54B52B1CE8BFD9E0D6D727DA8DB988BC6B6A843492C7CE4AFC4709E8378EEC9A
+  ProductCode: '{EF291603-2255-47DD-AC26-5B462B5B8BA6}'
+  AppsAndFeaturesEntries:
+  - Publisher: Giuliano Bellini
+    ProductCode: '{EF291603-2255-47DD-AC26-5B462B5B8BA6}'
+    UpgradeCode: '{352ADDB7-26A5-46BB-B25B-94E379BC2408}'
+  InstallationMetadata:
+    DefaultInstallLocation: '%ProgramFiles%\Sniffnet'
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/g/GyulyVGC/sniffnet/1.5.1/GyulyVGC.sniffnet.locale.en-US.yaml
+++ b/manifests/g/GyulyVGC/sniffnet/1.5.1/GyulyVGC.sniffnet.locale.en-US.yaml
@@ -1,0 +1,36 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: GyulyVGC.sniffnet
+PackageVersion: 1.5.1
+PackageLocale: en-US
+Publisher: GyulyVGC
+PublisherUrl: https://github.com/GyulyVGC
+PublisherSupportUrl: https://github.com/GyulyVGC/sniffnet/issues
+Author: Giuliano Bellini
+PackageName: Sniffnet
+PackageUrl: https://sniffnet.app/
+License: MIT OR Apache-2.0
+LicenseUrl: https://github.com/GyulyVGC/sniffnet/blob/main/LICENSE-MIT
+Copyright: © 2022 - Bellini Giuliano.
+ShortDescription: Application to comfortably monitor your network traffic.
+Description: |-
+  Sniffnet is a network monitoring tool to help you easily keep track of your Internet traffic. Cross-platform, intuitive, and reliable, it lets you choose a network adapter to inspect, apply filters, view real-time charts and statistics, identify domains and hosts, set custom notifications, and export capture reports.
+  Sniffnet requires the Npcap packet capture driver, which is installed as a dependency of this package.
+Moniker: sniffnet
+Tags:
+- monitoring
+- network
+- network-analyzer
+- network-monitoring
+- networking
+- packet-capture
+- packet-sniffer
+- pcap
+- sniffer
+- traffic
+ReleaseNotesUrl: https://github.com/GyulyVGC/sniffnet/releases/tag/v1.5.1
+Documentations:
+- DocumentLabel: Wiki
+  DocumentUrl: https://github.com/GyulyVGC/sniffnet/wiki
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/g/GyulyVGC/sniffnet/1.5.1/GyulyVGC.sniffnet.yaml
+++ b/manifests/g/GyulyVGC/sniffnet/1.5.1/GyulyVGC.sniffnet.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: GyulyVGC.sniffnet
+PackageVersion: 1.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0

--- a/shards/json/GyulyVGC.sniffnet.json
+++ b/shards/json/GyulyVGC.sniffnet.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "GyulyVGC", "repo": "sniffnet" },
+	"urls": [
+		"https://github.com/GyulyVGC/sniffnet/releases/download/v{version}/Sniffnet_Windows_x64.msi",
+		"https://github.com/GyulyVGC/sniffnet/releases/download/v{version}/Sniffnet_Windows_x86.msi",
+		"https://github.com/GyulyVGC/sniffnet/releases/download/v{version}/Sniffnet_Windows_arm64.msi"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#361406

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: authored in a Linux environment, so `winget validate`/`winget install` weren't run locally — relying on this repo's manifest linter (`bun run manifests:check` passes) and CI sandbox validation instead.

---

Adds Sniffnet 1.5.1, a network traffic monitor, per the winget-pkgs package request above. It can't be added upstream because it requires the Npcap driver, whose winget package is stuck on an outdated version — so this manifest declares a dependency on this source's own `Insecure.Npcap` package instead.

- All three Windows MSIs (x64, x86, arm64) with SHA256 hashes computed from the downloaded installers, and ProductCode/UpgradeCode extracted from the MSI property tables (`ALLUSERS=1`, so `Scope: machine`)
- The MSI doesn't bundle Npcap; it only shows an exit-dialog reminder, so silent install works
- `github-release` shard for automated updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0164i3Sd7WHX7yDC7oESW3FE

---
_Generated by [Claude Code](https://claude.ai/code/session_0164i3Sd7WHX7yDC7oESW3FE)_