### PR TITLE
ci: add autofix workflow

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -1,0 +1,49 @@
+name: autofix.ci
+
+on:
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  autofix:
+    name: Autofix
+    runs-on: ubuntu-26.04-arm
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Environment
+        uses: jdx/mise-action@3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518 # v4.2.5
+        with:
+          version: 2026.8.10
+          install_args: bun zizmor
+
+      - name: Install Dependencies
+        run: bun ci
+
+      - parallel:
+          - name: Fix Linting
+            run: bun lint --fix
+
+          - name: Fix Actions
+            run: |
+              zizmor . --pedantic --fix=safe --color=always
+            env:
+              ZIZMOR_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+          - name: Fix Formatting
+            run: bun fmt
+
+          - name: Fix Manifests
+            run: bun manifests:fix
+
+      - name: Apply Fixes
+        uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
See https://autofix.ci/ and https://autofix.ci/security for how this works.
The GitHub app must be installed for this to work: https://github.com/marketplace/autofix-ci

Resolves #854