### PR TITLE
ci(autofix): move formatting out of parallel step

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -39,11 +39,11 @@ jobs:
             env:
               ZIZMOR_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-          - name: Fix Formatting
-            run: bun fmt
-
           - name: Fix Manifests
             run: bun manifests:fix
+
+      - name: Fix Formatting
+        run: bun fmt
 
       - name: Apply Fixes
         uses: autofix-ci/action@c5b2d67aa2274e7b5a18224e8171550871fc7e4a # v1.3.4


### PR DESCRIPTION
On second thought, it's probably better to run oxlint and oxfmt separately since they run on the same files.