### PR TITLE
New package: Microsoft.365CompanionApps version 2.2604.28000.0

### DIFF
--- a/manifests/m/Microsoft/365CompanionApps/2.2604.28000.0/Microsoft.365CompanionApps.installer.yaml
+++ b/manifests/m/Microsoft/365CompanionApps/2.2604.28000.0/Microsoft.365CompanionApps.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.365CompanionApps
+PackageVersion: 2.2604.28000.0
+ReleaseDate: 2026-04-28
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.22000.0
+InstallerType: msix
+PackageFamilyName: Microsoft.M365Companions_8wekyb3d8bbwe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://res.public.onecdn.static.microsoft/m365companion/5mttl/prod/2.2604.28000.0/Microsoft.M365Companions_x64.msix
+  InstallerSha256: 77784438392EA9A118CB8A698672E8808CC6B266AF71878BF1EDC930A7DBB3A8
+  SignatureSha256: 15D093FC0426D6F52988CC2BFBF73A6E11914323CC9997A2352D6D0CD8C59904
+- Architecture: arm64
+  InstallerUrl: https://res.public.onecdn.static.microsoft/m365companion/5mttl/prod/2.2604.28000.0/Microsoft.M365Companions_arm64.msix
+  InstallerSha256: 27BC31559BB22F3C045D4E75DB40BADE492013B333BC73DCF9C3006487DCCA2B
+  SignatureSha256: 5A4215BD18404E574997AE8A539A5831199DE4CBE46AB3B7B16C85A092FD37ED
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/365CompanionApps/2.2604.28000.0/Microsoft.365CompanionApps.locale.en-US.yaml
+++ b/manifests/m/Microsoft/365CompanionApps/2.2604.28000.0/Microsoft.365CompanionApps.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.365CompanionApps
+PackageVersion: 2.2604.28000.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://support.microsoft.com/office/get-started-with-microsoft-365-companions-a27df74a-cc41-4e74-8216-51091dc30194
+Author: Microsoft Corporation
+PackageName: Microsoft 365 Companion Apps
+PackageUrl: https://learn.microsoft.com/en-us/microsoft-365-apps/companions/overview
+License: Proprietary
+Copyright: © Microsoft Corporation. All rights reserved.
+ShortDescription: Suite of companion apps for people, files, and calendar, powered by Microsoft Graph and pinned to the Windows 11 taskbar.
+Moniker: m365-companion-apps
+Tags:
+- microsoft-365-companion-apps
+- companions
+- people
+- files
+- calendar
+- m365
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/365CompanionApps/2.2604.28000.0/Microsoft.365CompanionApps.yaml
+++ b/manifests/m/Microsoft/365CompanionApps/2.2604.28000.0/Microsoft.365CompanionApps.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.365CompanionApps
+PackageVersion: 2.2604.28000.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -13,7 +13,6 @@
 			"manifests/g/GameJolt/GameJolt": "selfhosted, download.gamejolt.net only serves signed URLs that expire after 24h",
 			"manifests/h/HOIC/HOIC": "discontinued",
 			"manifests/m/MSI/TrueColor": "msi.com blocks automated requests, and download filenames carry an opaque hash",
-			"manifests/m/Microsoft/365CompanionApps": "selfhosted, the versioned CDN path is only discoverable by intercepting the M365 Apps update process, no public version API or directory listing exists",
 			"manifests/m/Microsoft/ConfigMgr/CMPivot": "selfhosted, shipped inside the Configuration Manager install",
 			"manifests/m/Microsoft/ConfigMgr/CMTrace": "selfhosted, shipped inside the Configuration Manager install",
 			"manifests/m/Microsoft/ConfigMgr/ClientSpy": "selfhosted, shipped inside the Configuration Manager install",

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -13,6 +13,7 @@
 			"manifests/g/GameJolt/GameJolt": "selfhosted, download.gamejolt.net only serves signed URLs that expire after 24h",
 			"manifests/h/HOIC/HOIC": "discontinued",
 			"manifests/m/MSI/TrueColor": "msi.com blocks automated requests, and download filenames carry an opaque hash",
+			"manifests/m/Microsoft/365CompanionApps": "selfhosted, the versioned CDN path is only discoverable by intercepting the M365 Apps update process, no public version API or directory listing exists",
 			"manifests/m/Microsoft/ConfigMgr/CMPivot": "selfhosted, shipped inside the Configuration Manager install",
 			"manifests/m/Microsoft/ConfigMgr/CMTrace": "selfhosted, shipped inside the Configuration Manager install",
 			"manifests/m/Microsoft/ConfigMgr/ClientSpy": "selfhosted, shipped inside the Configuration Manager install",

--- a/shards/json/Microsoft.365CompanionApps.json
+++ b/shards/json/Microsoft.365CompanionApps.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://res.public.onecdn.static.microsoft/m365companion/5mttl/prod/Microsoft.M365Companions_x64.appinstaller",
+		"regex": "Version=\"(\\d+(?:\\.\\d+)+)\""
+	},
+	"urls": [
+		"https://res.public.onecdn.static.microsoft/m365companion/5mttl/prod/{version}/Microsoft.M365Companions_x64.msix",
+		"https://res.public.onecdn.static.microsoft/m365companion/5mttl/prod/{version}/Microsoft.M365Companions_arm64.msix"
+	]
+}

--- a/shards/json/Microsoft.365CompanionApps.json
+++ b/shards/json/Microsoft.365CompanionApps.json
@@ -3,7 +3,7 @@
 	"strategy": "page-match",
 	"pageMatch": {
 		"url": "https://res.public.onecdn.static.microsoft/m365companion/5mttl/prod/Microsoft.M365Companions_x64.appinstaller",
-		"regex": "Version=\"(\\d+(?:\\.\\d+)+)\""
+		"regex": "MainPackage[\\s\\S]*?Version=\"(\\d+(?:\\.\\d+)+)\""
 	},
 	"urls": [
 		"https://res.public.onecdn.static.microsoft/m365companion/5mttl/prod/{version}/Microsoft.M365Companions_x64.msix",


### PR DESCRIPTION
Closes #1078

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - The issue links microsoft/winget-pkgs#414290, but that PR is actually for an unrelated package (`Microsoft.UpdateHealthTools.W11-21H2`), so it isn't referenced here.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally with `bun manifests:check --deny-warnings`? (`winget validate`/`winget install` aren't available on Linux, so this and a manual read of the AppX manifest/signature stood in for them.)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Not possible in this environment (Linux, no winget). Please test on Windows before merging. The real install was validated in this PR's own `Installation Validation` CI (winget log shows `Successfully installed`).
- [x] Does your manifest conform to the 1.12.0 schema?

### Summary

- Adds `Microsoft.365CompanionApps` (People/Files/Calendar companion apps for Windows 11 taskbar), distributed by Microsoft as a signed msix rather than through the Store.
- `InstallerUrl`s, `PackageFamilyName` (`Microsoft.M365Companions_8wekyb3d8bbwe`), and hashes were derived directly from the x64/arm64 msix packages at the CDN URLs Microsoft serves (confirmed against the extracted `AppxManifest.xml`/`AppxSignature.p7x`).
- Added `shards/json/Microsoft.365CompanionApps.json` using the `page-match` strategy against the unversioned `.appinstaller` endpoint (`.../prod/Microsoft.M365Companions_x64.appinstaller`), per [review feedback](https://github.com/pl4nty/winget-extras/pull/1079#discussion_r3877525984) — it always reflects the current version and source msix URL.

🤖 Generated with [Claude Code](https://claude.ai/code)
