### PR TITLE
New package: Git.PortableGit version 2.55.0.5

### DIFF
--- a/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.installer.yaml
+++ b/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.installer.yaml
@@ -1,0 +1,24 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Git.PortableGit
+PackageVersion: 2.55.0.5
+ReleaseDate: 2026-08-20
+InstallerType: exe
+InstallerSwitches:
+  Silent: -y
+  SilentWithProgress: -y
+  InstallLocation: -o"<INSTALLPATH>"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.5/PortableGit-2.55.0.5-64-bit.7z.exe
+  InstallerSha256: 5AA8A20F6E9ABB2C755F0E73C91C687701A46B309AD84A0CA6509380FA4AE290
+- Architecture: arm64
+  InstallerUrl: https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.5/PortableGit-2.55.0.5-arm64.7z.exe
+  InstallerSha256: 49D1DD3158017FA9805D07268433DBAB7021B2EC1C1CC3FBABAF8B8255764DD0
+  ElevationRequirement: elevationRequired
+  Dependencies:
+    PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.Framework.Runtime
+InstallLocationRequired: true
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.installer.yaml
+++ b/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.installer.yaml
@@ -19,6 +19,5 @@ Installers:
   Dependencies:
     PackageDependencies:
     - PackageIdentifier: Microsoft.DotNet.Framework.Runtime
-InstallLocationRequired: true
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.installer.yaml
+++ b/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.installer.yaml
@@ -16,8 +16,5 @@ Installers:
   InstallerUrl: https://github.com/git-for-windows/git/releases/download/v2.55.0.windows.5/PortableGit-2.55.0.5-arm64.7z.exe
   InstallerSha256: 49D1DD3158017FA9805D07268433DBAB7021B2EC1C1CC3FBABAF8B8255764DD0
   ElevationRequirement: elevationRequired
-  Dependencies:
-    PackageDependencies:
-    - PackageIdentifier: Microsoft.DotNet.Framework.Runtime
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.locale.en-US.yaml
+++ b/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Git.PortableGit
+PackageVersion: 2.55.0.5
+PackageLocale: en-US
+Publisher: The Git Development Community
+PackageName: PortableGit
+PackageUrl: https://github.com/git-for-windows/git
+License: GPL-2.0-only
+ShortDescription: Portable version of Git for Windows.
+Description: |-
+  Portable version of Git for Windows.
+
+  Note that due to limitations in the workaround this Winget package uses to treat a 7-Zip self-extraction as a successful install, this package does not add PortableGit to PATH or to the Start menu. It also does not write to registry, and therefore does not show up among the PC's installed apps, and is unable to be easily checked for updates with «winget update» either.
+Moniker: portablegit
+Tags:
+- portable-git
+- git-for-windows
+- gitforwindows
+- git-portable
+- gitportable
+- git-bash
+- git-cmd
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.yaml
+++ b/manifests/g/Git/PortableGit/2.55.0.5/Git.PortableGit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Git.PortableGit
+PackageVersion: 2.55.0.5
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/script/Git.PortableGit.ts
+++ b/shards/script/Git.PortableGit.ts
@@ -1,0 +1,24 @@
+import { defineShard } from 'anthelion';
+import { getLatestRelease } from 'anthelion/github';
+import { match } from 'anthelion/helpers';
+
+// Git for Windows tags releases as 2.55.0.windows.5, but the package version
+// is 2.55.0.5. Later rebuilds, such as .windows.2, become 2.55.0.2.
+export default defineShard(async () => {
+	const release = await getLatestRelease({
+		owner: 'git-for-windows',
+		repo: 'git',
+	});
+
+	const {
+		groups: [baseVersion, buildNumber],
+	} = match(release.tag, /^(\d+(?:\.\d+)+)\.windows\.(\d+)$/);
+	const version = buildNumber === '1' ? baseVersion : `${baseVersion}.${buildNumber}`;
+
+	const urls = () => release.urls().filter((url) => /\/PortableGit-[^/]+\.7z\.exe$/.test(url));
+
+	return {
+		version,
+		urls,
+	};
+});


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#420919

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change? Yes — #1060 is open for the same package/version, requested via #1080. Its author noted they couldn't get a shard working because the release tag (`2.55.0.windows.5`) and package version (`2.55.0.5`) diverge. This PR adds a script shard (`shards/script/Git.PortableGit.ts`) that derives the version from the tag, following the pattern documented in [Anthelion's CONTRIBUTING.md](https://github.com/UnownPlain/anthelion/blob/main/CONTRIBUTING.md#writing-a-script-shard) (which uses this same git-for-windows/git repo as its worked example, for the sibling MinGit package).
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? Not run — no Windows environment available here. Verified instead with this repo's own tooling: `bun manifests:check --deny-warnings`, `bun test:manifests --deny-warnings`, and `bun fmt --check` all pass for the new files.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Not run, same reason as above. The installer URLs and SHA256 hashes were verified by downloading both assets directly.
- [x] Does your manifest conform to the schema? Yes, using this repo's current `1.12.0` schema/manifest version (consistent with recently merged manifests).

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Adds `Git.PortableGit` 2.55.0.5 (x64 and arm64), mirroring the installer/locale content already reviewed in microsoft/winget-pkgs#420919, updated to the current release. Closes #1080.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REcvxfrJ4UzqfhY1akgvBN)_