### PR TITLE
Ignore .claude/ scratch directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /.env
+/.claude


### PR DESCRIPTION
Claude Code creates `.claude/worktrees/` for isolated background-agent work (each worktree is a full checkout of the repo). It should never be tracked, similar to `/node_modules`.

No manifest/package changes in this PR — just the `.gitignore` addition.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REcvxfrJ4UzqfhY1akgvBN)_