### PR TITLE
New package: Microsoft.UpdateHealthTools.W11-21H2 version 4.71

### DIFF
--- a/manifests/m/Microsoft/UpdateHealthTools/W11-21H2/4.71/Microsoft.UpdateHealthTools.W11-21H2.installer.yaml
+++ b/manifests/m/Microsoft/UpdateHealthTools/W11-21H2/4.71/Microsoft.UpdateHealthTools.W11-21H2.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: Microsoft.UpdateHealthTools.W11-21H2
+PackageVersion: "4.71"
+MinimumOSVersion: 10.0.22000.0
+InstallerType: zip
+NestedInstallerType: msi
+NestedInstallerFiles:
+- RelativeFilePath: 'Expedite_packages\Windows 11 21H2\UpdHealthTools.msi'
+ProductCode: '{843E8BAC-637E-4354-94D7-73D910E2168F}'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://download.microsoft.com/download/d/7/e/d7e9fd79-e6fe-4036-85df-c60254f50d90/Expedite_packages.zip
+  InstallerSha256: ED4DEAD7E64F16C30DA29593EB05015274E9AA9A826DE510B659C7BEE94F4A52
+ElevationRequirement: elevationRequired
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/m/Microsoft/UpdateHealthTools/W11-21H2/4.71/Microsoft.UpdateHealthTools.W11-21H2.locale.en-US.yaml
+++ b/manifests/m/Microsoft/UpdateHealthTools/W11-21H2/4.71/Microsoft.UpdateHealthTools.W11-21H2.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: Microsoft.UpdateHealthTools.W11-21H2
+PackageVersion: "4.71"
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://support.microsoft.com/
+PackageName: Microsoft Update Health Tools (Windows 11 21H2)
+PackageUrl: https://www.microsoft.com/en-us/download/details.aspx?id=103324
+License: Proprietary
+ShortDescription: Enables expediting Windows 10 and Windows 11 quality updates in Microsoft Intune.
+Moniker: muht21h2
+Tags:
+- microsoft-update-health-tools-21h2
+- microsoftupdatehealthtools21h2
+- expediteupdater
+- uhssvc
+- microsoft-intune
+- microsoftintune
+- updhealthtools-windows-11-21h2
+- windows1121h2
+- kb4023057
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/m/Microsoft/UpdateHealthTools/W11-21H2/4.71/Microsoft.UpdateHealthTools.W11-21H2.yaml
+++ b/manifests/m/Microsoft/UpdateHealthTools/W11-21H2/4.71/Microsoft.UpdateHealthTools.W11-21H2.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: Microsoft.UpdateHealthTools.W11-21H2
+PackageVersion: "4.71"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -42,6 +42,7 @@
 			"manifests/m/Microsoft/UI/Xaml/2/2": "discontinued",
 			"manifests/m/Microsoft/UI/Xaml/2/3": "discontinued",
 			"manifests/m/Microsoft/UI/Xaml/2/4": "discontinued",
+			"manifests/m/Microsoft/UpdateHealthTools/W11-21H2": "discontinued, Windows 11 21H2 reached end of servicing and the zip is a static download shared across all supported OS versions with no discoverable per-version URL or page signal",
 			"manifests/m/Microsoft/VCLibs/12": "discontinued",
 			"manifests/m/Microsoft/VCRedist/2012/arm32": "discontinued",
 			"manifests/m/Microsoft/VCRedist/2013/arm32": "discontinued",


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#414290
  - Relates to microsoft/winget-pkgs#416884

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

This replicates #1052 (originally opened by @DandelionSprout) as a standalone PR, with a working automated-update shard added (or, as explained below, an honest justification for why one isn't feasible).

### What this does

- Adds the manifest for `Microsoft.UpdateHealthTools.W11-21H2` version `4.71` (Microsoft Update Health Tools for Windows 11 21H2), matching the manifest content DandelionSprout proposed in #1052, adjusted to this repo's current conventions (schema 1.28.0, `en-US` locale filename/`PackageLocale`).
- Adds a `repository/shard-coverage` ignore entry in `scripts/manifest-linter/config.json` for this manifest, since no automated-update shard is feasible here (see below) — mirroring what DandelionSprout attempted in #1052's review comments ("I'll see if I can set its shard to 'Discontinued' status").

### Verification performed (no Windows environment available here)

I could not run actual Windows `winget validate` / `winget install`, so I verified with this repo's own tooling instead:

- Downloaded `https://download.microsoft.com/download/d/7/e/d7e9fd79-e6fe-4036-85df-c60254f50d90/Expedite_packages.zip` myself with `curl` (still resolves, HTTP 200, 2,677,780 bytes) and computed `sha256sum` on the raw bytes — it matches the `InstallerSha256` in the manifest (`ed4dead7e64f16c30da29593eb05015274e9aa9a826de510b659c7bee94f4a52`), so I did not just trust the hash quoted in #1052.
- Unzipped the archive and confirmed `Expedite_packages\Windows 11 21H2\UpdHealthTools.msi` exists at that exact relative path, and that the literal `ProductCode` GUID `843E8BAC-637E-4354-94D7-73D910E2168F` appears inside that MSI's raw bytes.
- Ran this repo's linter/tests against a temporarily-patched `package.json` (pinned `@unownplain/anthelion-komac` + friends in place of the private `anthelion` GitHub dependency, which isn't installable from this sandbox), then restored `package.json`/`bun.lock` to their original committed state before committing anything:
  - `bun manifests:check --deny-warnings` → `Manifests OK (2208 files)`
  - `bun test:manifests --deny-warnings` → `89 pass, 0 fail`
  - `bun fmt --check` → clean (only the temporary `package.json` edit itself, which was reverted and not committed, showed a diff)

### Why no shard

I looked for a viable `shards/json` / `shards/script` strategy first (checked existing Microsoft.* shards for a Microsoft Update Catalog/KB pattern — none exist in this repo) but concluded one genuinely isn't feasible, matching what DandelionSprout ran into in #1052:

- The installer URL (`download.microsoft.com/.../Expedite_packages.zip`) is a single static, opaque GUID-keyed blob — not a predictable/versioned path.
- The Download Center details page (`microsoft.com/en-us/download/details.aspx?id=103324`) shows a page-level "Version 1.1", which is unrelated to and does not track the MSI's actual `ProductVersion` (4.71) — so `page-match`/`sort-versions` against that page would extract the wrong, unchanging number, not a genuine version signal.
- The same zip bundles installers for Windows 10, Windows 11 21H2, and Windows 11 22H2+ together under one URL with no per-OS-version or per-release versioning exposed anywhere upstream.
- Windows 11 21H2 itself reached end of servicing in October 2023, so this OS-pinned manifest variant specifically is not expected to receive further updates going forward even if the shared zip changes for other OS versions.

Given that, I added the `repository/shard-coverage` ignore entry (reason: `"discontinued, Windows 11 21H2 reached end of servicing and the zip is a static download shared across all supported OS versions with no discoverable per-version URL or page signal"`) rather than fabricate a shard that wouldn't actually detect real updates.

Note: this PR does not touch, comment on, or close #1052 — it stands on its own.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REcvxfrJ4UzqfhY1akgvBN)_