### PR TITLE
New package: irixxxx.PicoDrive version 2.05

### DIFF
--- a/manifests/i/irixxxx/PicoDrive/2.05/irixxxx.PicoDrive.installer.yaml
+++ b/manifests/i/irixxxx/PicoDrive/2.05/irixxxx.PicoDrive.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: irixxxx.PicoDrive
+PackageVersion: "2.05"
+ReleaseDate: 2025-05-31
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: PicoDrive.exe
+  PortableCommandAlias: picodrive
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/irixxxx/picodrive/releases/download/v2.05/PicoDrive-win32-2.05-7cbcd41.zip
+  InstallerSha256: be7fc401666040f9f165a7c44897264bb103cb0afc4d9844125b754aa553efee
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/irixxxx/PicoDrive/2.05/irixxxx.PicoDrive.locale.en-US.yaml
+++ b/manifests/i/irixxxx/PicoDrive/2.05/irixxxx.PicoDrive.locale.en-US.yaml
@@ -1,0 +1,31 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: irixxxx.PicoDrive
+PackageLocale: en-US
+PackageVersion: "2.05"
+PackageName: PicoDrive
+Publisher: irixxxx
+PackageUrl: https://github.com/irixxxx/picodrive
+License: BSD-3-Clause
+LicenseUrl: https://raw.githubusercontent.com/irixxxx/picodrive/refs/heads/master/COPYING
+ShortDescription: It can run games developed for most consumer hardware released by SEGA, up to and including the 32X.
+Moniker: picodrive
+Tags:
+- pico-drive
+- emulator
+- sega-mega-drive
+- segamegadrive
+- sega-genesis
+- sega-mega-cd
+- sega-cd
+- sega-32x
+- sega32x
+- sega-pico
+- sega-sg-1000
+- sega-sc-3000
+- sega-game-gear
+- sega-master-system
+- segamastersystem
+- sega-mark-iii
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/irixxxx/PicoDrive/2.05/irixxxx.PicoDrive.yaml
+++ b/manifests/i/irixxxx/PicoDrive/2.05/irixxxx.PicoDrive.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: irixxxx.PicoDrive
+DefaultLocale: en-US
+PackageVersion: "2.05"
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/script/irixxxx.PicoDrive.ts
+++ b/shards/script/irixxxx.PicoDrive.ts
@@ -1,0 +1,15 @@
+import { defineShard } from 'anthelion';
+import { getLatestRelease } from 'anthelion/github';
+
+// Each build's filename embeds a short commit hash that changes unpredictably
+// between releases (e.g. PicoDrive-win32-2.05-7cbcd41.zip), so filter
+// release.urls() for the win32 zip instead of templating the URL.
+export default defineShard(async () => {
+	const release = await getLatestRelease({ owner: 'irixxxx', repo: 'picodrive' });
+	const urls = release
+		.urls()
+		.filter((url) => /\/PicoDrive-win32-[\d.]+-[0-9a-f]{7}\.zip$/.test(url));
+	if (urls.length !== 1) throw new Error('Expected exactly one Windows win32 zip asset');
+
+	return { version: release.version, urls: () => urls };
+});


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to https://github.com/microsoft/winget-pkgs/pull/420833.
  - Relates to #1076, originally opened by @DandelionSprout for the same package. That PR couldn't add an automated-update shard because the Windows zip filename embeds a short commit hash that changes unpredictably between releases (e.g. `PicoDrive-win32-2.05-7cbcd41.zip`). This PR is a separate submission that adds a working shard for it. #1076 itself has not been touched.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is `manifests/i/irixxxx/PicoDrive/2.05`.

---

This environment has no Windows install, so `winget validate`/`winget install` could not be run directly. Instead I verified with this repo's own tooling:

- `bun --experimental-http2-fetch scripts/manifest-linter --deny-warnings` → `Manifests OK (2208 files)`
- `bun test scripts --deny-warnings` → `89 pass, 0 fail`
- `bun --bun oxfmt --check` → shard file (`shards/script/irixxxx.PicoDrive.ts`) formatted correctly

The real `anthelion` dependency (`github:UnownPlain/anthelion-external`) can't install in this sandbox (it needs GitHub API access to an org this token doesn't have), so for the above I temporarily swapped it in `package.json` for its pinned transitive packages, ran the checks, then restored `package.json`/`bun.lock` to their original committed state before committing — only the manifest and shard files are part of this PR.

**Installer verification**: downloaded `PicoDrive-win32-2.05-7cbcd41.zip` from the `v2.05` GitHub release myself and computed its SHA256 independently (`be7fc401666040f9f165a7c44897264bb103cb0afc4d9844125b754aa553efee`), rather than trusting the hash quoted in #1076. It matches.

**Shard**: `shards/script/irixxxx.PicoDrive.ts` uses `getLatestRelease` (from `anthelion/github`) against `irixxxx/picodrive`, then filters `release.urls()` with `/\/PicoDrive-win32-[\d.]+-[0-9a-f]{7}\.zip$/` to pick out the win32 build regardless of its embedded commit hash, and uses `release.version` (the release tag with its `v` prefix already stripped) as the package version. This follows the same pattern as `shards/script/opengribs.XyGrib.ts` and `shards/script/Adobe.SourceCodePro.Font.ts` in this repo, both of which filter `release.urls()` by regex for an upstream that can't be expressed with a declarative JSON/YAML shard. I checked releases back to `v2.00` and the `PicoDrive-win32-<version>-<7charhash>.zip` naming and hash unpredictability is consistent, so a declarative `github-release` shard with a URL template isn't viable here — a script shard is the correct choice per the strategy preference order in anthelion's CONTRIBUTING.md.

**License**: upstream's `COPYING` is a BSD-3-Clause-derived text with an added non-commercial redistribution clause; there's no exact SPDX identifier for that variant, so I kept `BSD-3-Clause` (the closest standard identifier, matching the choice made in #1076) with `LicenseUrl` pointing at the actual license text so users can review the non-commercial term themselves.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REcvxfrJ4UzqfhY1akgvBN)_