### PR TITLE
New package: worproject.Imager version 2.3.1

### DIFF
--- a/manifests/w/worproject/Imager/2.3.1/worproject.Imager.installer.yaml
+++ b/manifests/w/worproject/Imager/2.3.1/worproject.Imager.installer.yaml
@@ -11,7 +11,7 @@ NestedInstallerFiles:
 ArchiveBinariesDependOnPath: true
 Installers:
 - Architecture: x86
-  InstallerUrl: https://github.com/worproject/dldserv-mirror/releases/download/130.000000020.0000002024/WoR_Release_2.3.1.zip
+  InstallerUrl: https://github.com/worproject/dldserv-mirror/releases/download/13%2F02%2F2024/WoR_Release_2.3.1.zip
   InstallerSha256: FC3F6A98E1744ADAA8C514514C35176805AAC8BB44E16514C2A979683FA0AE1F
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/w/worproject/Imager/2.3.1/worproject.Imager.installer.yaml
+++ b/manifests/w/worproject/Imager/2.3.1/worproject.Imager.installer.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: worproject.Imager
+PackageVersion: 2.3.1
+ReleaseDate: 2024-02-13
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: WoR.exe
+  PortableCommandAlias: wor
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/worproject/dldserv-mirror/releases/download/130.000000020.0000002024/WoR_Release_2.3.1.zip
+  InstallerSha256: FC3F6A98E1744ADAA8C514514C35176805AAC8BB44E16514C2A979683FA0AE1F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/w/worproject/Imager/2.3.1/worproject.Imager.locale.en-US.yaml
+++ b/manifests/w/worproject/Imager/2.3.1/worproject.Imager.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: worproject.Imager
+PackageVersion: 2.3.1
+PackageLocale: en-US
+Publisher: worproject
+PackageName: Windows on Raspberry imager
+PackageUrl: https://worproject.com/downloads
+License: Freeware
+ShortDescription: Imaging tool to install Windows (11 22H2 or earlier) on Raspberry Pi 2 (revision 1.2), 3, 4, and 400.
+Moniker: worimager
+Tags:
+- raspberry-pi-2
+- raspberry-pi-3
+- raspberry-pi-400
+- raspberrypi2
+- raspberrypi3
+- raspberrypi4
+- rasppi2
+- rasppi3
+- rasppi4
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/w/worproject/Imager/2.3.1/worproject.Imager.yaml
+++ b/manifests/w/worproject/Imager/2.3.1/worproject.Imager.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: worproject.Imager
+PackageVersion: 2.3.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/script/worproject.Imager.ts
+++ b/shards/script/worproject.Imager.ts
@@ -1,0 +1,20 @@
+import { defineShard } from 'anthelion';
+import { getLatestRelease } from 'anthelion/github';
+import { match } from 'anthelion/helpers';
+
+// dldserv-mirror tags each release with the mirror's upload date (e.g. 13%2F02%2F2024),
+// not a package version, and a single release bundles assets for several worproject
+// downloads (imager, boot mounter, etc). Find the imager zip by its filename and read
+// the version out of the filename itself, since it's not exposed anywhere else on the
+// release.
+export default defineShard(async () => {
+	const release = await getLatestRelease({ owner: 'worproject', repo: 'dldserv-mirror' });
+	const urls = release.urls().filter((url) => /\/WoR_Release_[^/]+\.zip$/i.test(url));
+	if (urls.length !== 1) throw new Error('Expected exactly one WoR_Release imager asset');
+
+	const {
+		groups: [version],
+	} = match(urls[0]!, /WoR_Release_(\d+(?:\.\d+)+)\.zip$/i);
+
+	return { version, urls: () => urls };
+});


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to https://github.com/microsoft/winget-pkgs/pull/422237.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is `manifests/w/worproject/Imager/2.3.1/`.

---

This adds `worproject.Imager` version 2.3.1 (Windows on Raspberry imager), relating to #1068, which @DandelionSprout opened but couldn't add a shard for, noting:

> Reason for not having been able to make a shard: The InstallerUrl contains tag numbering that differs between versions. For this version, it's `13%2F02%2F2024`.

That's correct — the `worproject/dldserv-mirror` release tag is the date the mirror was uploaded, not a package version, and isn't derivable from the version number. On top of that, a single release bundles assets for several worproject downloads (the imager, the boot mounter, etc.), so a plain `github-release` JSON shard can't select the right file either. I added a script shard (`shards/script/worproject.Imager.ts`) instead: it fetches the latest `dldserv-mirror` release, filters the asset list down to the one matching `WoR_Release_*.zip`, and reads the version back out of that filename.

The manifest content matches what was proposed in #1068 — same version, same installer URL/hash — I re-downloaded the installer myself and recomputed its SHA256 rather than trusting the value already in that PR, and it matched. I also checked worproject's own changelog and downloads page, which both still list 2.3.1 as current.

I don't have a Windows environment here, so I couldn't run `winget validate`/`winget install` against the manifest directly. Instead I verified locally with this repo's own tooling:

```sh
bun manifests:check --deny-warnings
bun test:manifests --deny-warnings
bun fmt --check
```

All three passed. (The real `anthelion` npm dependency can't be installed in this sandbox since it needs GitHub API access to a different org than this token has, so I temporarily swapped it for pinned versions of its own dependencies to run the checks, then restored `package.json`/`bun.lock` before committing — only the manifest and shard files are included in this PR.)

This is not a replacement for #1068 — that PR is DandelionSprout's and I haven't touched it. This is a separate submission that happens to add the shard piece that was missing.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REcvxfrJ4UzqfhY1akgvBN)_