### PR TITLE
New package: Nvidia.Driver.GeForceGameReady.6x0 version 475.14

### DIFF
--- a/manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/Nvidia.Driver.GeForceGameReady.6x0.installer.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/Nvidia.Driver.GeForceGameReady.6x0.installer.yaml
@@ -15,7 +15,7 @@ Installers:
 InstallerSuccessCodes:
 - 1
 ExpectedReturnCodes:
-- InstallerReturnCode: 3858759936
+- InstallerReturnCode: 3858759938
   ReturnResponse: systemNotSupported
 ElevationRequirement: elevationRequired
 ManifestType: installer

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/Nvidia.Driver.GeForceGameReady.6x0.installer.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/Nvidia.Driver.GeForceGameReady.6x0.installer.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.Driver.GeForceGameReady.6x0
+PackageVersion: "475.14"
+ReleaseDate: 2024-07-09
+InstallerType: exe
+InstallerSwitches:
+  Silent: -s -n Display.Driver HDAudio.Driver
+  SilentWithProgress: -s -n Display.Driver HDAudio.Driver
+  Log: -log:"<LOGPATH>"
+Installers:
+- Architecture: x64
+  InstallerUrl: https://uk.download.nvidia.com/Windows/475.14/475.14-desktop-win10-win11-64bit-international-dch-whql.exe
+  InstallerSha256: d602d0a5635ed492261dd8df34f4d159b36289cbdcb1c88b9f3b0c7947184ff5
+InstallerSuccessCodes:
+- 1
+ExpectedReturnCodes:
+- InstallerReturnCode: 3858759936
+  ReturnResponse: systemNotSupported
+ElevationRequirement: elevationRequired
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/Nvidia.Driver.GeForceGameReady.6x0.locale.en.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/Nvidia.Driver.GeForceGameReady.6x0.locale.en.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.Driver.GeForceGameReady.6x0
+PackageVersion: "475.14"
+PackageLocale: en
+Publisher: NVIDIA Corporation
+PackageName: NVIDIA GeForce Game Ready Driver (6x0 and most 7x0 cards)
+PackageUrl: https://www.nvidia.com/en-gb/drivers/details/229812/
+License: Freeware
+Copyright: © 2011-2024 NVIDIA Corporation.
+ShortDescription: Drivers for NVIDIA series 7x0 (except 750 Ti, 750, and 745) and 6x0 graphics cards.
+Description: |-
+  Graphics and audio drivers for NVIDIA series 7x0 (except 750 Ti, 750, and 745) and 6x0 graphics cards.
+
+  As with the regular NVIDIA driver installer, the screens will flicker once when the installation is complete.
+Moniker: nvidiadriver6x0
+Tags:
+- nvidia-display-driver
+- nvidiadisplaydriver
+- nvidia-graphics-card-driver
+- nvidiagraphicscarddriver
+- nvidia-gpus
+- nvidiagpus
+- nvidia-geforce-game-ready-driver
+- nvidiageforcegamereadydriver
+- nvidia-hd-audio-driver
+- nvidiahdaudiodriver
+- nvidia-driver
+- nvidiadriver
+- nv_dispi.inf
+- nvhda.inf
+Documentations:
+- DocumentLabel: Info on parameters
+  DocumentUrl: https://docs.nvidia.com/datacenter/tesla/driver-installation-guide/windows.html
+Agreements:
+- Agreement: "This package is untested, as no test environment was available. Please report any issues here: https://github.com/pl4nty/winget-extras/issues/new?template=package_issue.yml"
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/Nvidia.Driver.GeForceGameReady.6x0.yaml
+++ b/manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/Nvidia.Driver.GeForceGameReady.6x0.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.Driver.GeForceGameReady.6x0
+PackageVersion: "475.14"
+DefaultLocale: en
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Nvidia.Driver.GeForceGameReady.6x0.json
+++ b/shards/json/Nvidia.Driver.GeForceGameReady.6x0.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "json",
+	"json": {
+		"url": "https://gfwsl.geforce.com/services_toolkit/services/com/nvidia/services/AjaxDriverService.php?func=DriverManualLookup&psid=85&pfid=660&osID=135&languageCode=1033&dch=1&upCRD=0&qnf=0&sort1=0&numberOfResults=1",
+		"path": "IDS.0.downloadInfo.Version"
+	},
+	"urls": [
+		"https://uk.download.nvidia.com/Windows/{version}/{version}-desktop-win10-win11-64bit-international-dch-whql.exe"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - None found.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? (written against the repo's currently-adopted 1.12.0 schema, which this manifest matches)

Note: `<path>` is `manifests/n/Nvidia/Driver/GeForceGameReady/6x0/475.14/`.

---

### Context

This replicates #930 ("New package: Nvidia.Driver.GeForceGameReady.6x0 version 475.14", opened by @DandelionSprout, who could not test on real hardware and didn't have a shard strategy for it) as a fresh PR with a working automated-update shard added. #930 itself is untouched.

### What I verified myself

- **Version currency**: queried NVIDIA's driver lookup API directly for a representative card in this series (GeForce GTX 660, `psid=85&pfid=660`) against `gfwsl.geforce.com/.../AjaxDriverService.php?func=DriverManualLookup`. It returns `475.14`, dated `Tue Jul 09, 2024` — the same version #930 proposed. This confirms 475.14 genuinely is still the latest driver on this legacy ("Kepler desktop") maintenance channel; NVIDIA's own release notes for this driver state it's a security-only update for GPUs no longer covered by Game Ready Drivers.
- **Installer hash**: downloaded `https://uk.download.nvidia.com/Windows/475.14/475.14-desktop-win10-win11-64bit-international-dch-whql.exe` myself (740,751,984 bytes) and computed SHA-256 independently — `d602d0a5635ed492261dd8df34f4d159b36289cbdcb1c88b9f3b0c7947184ff5`, matching the value #930 quoted and matching the driver-lookup API's own file listing.
- **Manifest format**: modelled on the sibling `Nvidia.Driver.GeForceGameReady.10x0` package (same vendor/versioning scheme, different card-series branch), including its `Freeware` license, elevation/return-code handling, and CRLF/schema-1.12.0 conventions, rather than #930's proposed 1.28.0-schema manifest (this repo hasn't adopted 1.28.0 yet).
- **Shard**: added `shards/json/Nvidia.Driver.GeForceGameReady.6x0.json` using the same `json` strategy as the 10x0 sibling shard, pointed at `psid=85&pfid=660` (GeForce 600 series / GTX 660) instead of leaving it `.disabled` as #930 did. Since this maintenance channel is discontinued, the shard is expected to keep reporting "already up to date" indefinitely — that's the correct behavior, not a bug, per the task brief ("the shard just needs to be correct, not find something new every time").
- Since this driver only installs on specific legacy NVIDIA hardware I don't have, I kept #930's "untested" `Agreements` disclaimer on the locale manifest, matching the convention already used elsewhere in this repo (e.g. `AMD.BugReportTool`, `MSI.TrueColor`) for hardware-gated packages.

### Local verification (no Windows environment available here)

Real `winget validate`/`winget install` couldn't be run (no Windows environment in this sandbox). Verified instead with this repo's own tooling:

```sh
bun manifests:check --deny-warnings   # Manifests OK (2208 files)
bun test:manifests --deny-warnings    # 89 pass, 0 fail
bun fmt --check                       # no issues in the new manifest/shard files
```

(`anthelion`'s GitHub dependency can't install in this sandbox since it needs API access to a different org, so `package.json`/`bun.lock` were temporarily swapped to pinned published equivalents for local testing only, then reverted — no dependency changes are part of this PR.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01REcvxfrJ4UzqfhY1akgvBN)_