### PR TITLE
New package: Buypass.Javafri version 1.4.1.16

### DIFF
--- a/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.installer.yaml
+++ b/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.installer.yaml
@@ -1,0 +1,20 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Buypass.Javafri
+PackageVersion: 1.4.1.16
+Installers:
+- Architecture: x86
+  InstallerType: msi
+  ProductCode: '{F1C74CB2-8DF7-4C0E-BBCF-3A4116C0575A}'
+  InstallerUrl: https://www.buypass.no/hjelp/buypass-id/smartkort/javafri/_/attachment/download/93481aea-ffea-466c-9c06-b8d0b559d712:ca1961d47ac9de15265e67da2ae149282e3eb94e/Buypass.SCProxy.Setup_1_4_1.msi
+  InstallerSha256: 35EAF01EECFED1A25A628B7F47C83162E9C059E5DC6822B26B987FC2FB17556A
+- Architecture: x86
+  InstallerType: burn
+  InstallerUrl: https://www.buypass.no/hjelp/buypass-id/smartkort/javafri/_/attachment/download/413efde4-1981-417c-8418-a3db0d0acee4:a710386d5c89fab06f050fd18d1f2b453ed5ce15/Buypass.Javafri.Setup_1_4_1.exe
+  InstallerSha256: B60E73AB083D8268E8F7A7D09CC62EBBD017D1F2A935CC17084FF3C19C8C3EA0
+  ProductCode: '{64f4f023-45cd-4e30-82bd-3f8606654751}'
+  AppsAndFeaturesEntries:
+  - ProductCode: '{64f4f023-45cd-4e30-82bd-3f8606654751}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.locale.en-US.yaml
+++ b/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: Buypass.Javafri
+PackageVersion: 1.4.1.16
+PackageLocale: en-US
+PackageUrl: https://www.buypass.com/help/buypass-id/smartcard/javafri
+License: Proprietary
+ShortDescription: A software solution that enables secure communication between your web browser and a Buypass smart card. It is used by a number of Buypass customer sites as well as Buypass' own authentication services.
+Tags:
+- buypass-javafri
+- buypassjavafri
+- buypass-smart-card
+- buypasssmartcard
+- buypass-id
+- buypass-scproxy
+- id-porten
+- idporten
+- norway
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.locale.nb.yaml
+++ b/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.locale.nb.yaml
@@ -1,0 +1,24 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Buypass.Javafri
+PackageVersion: 1.4.1.16
+PackageLocale: nb
+Publisher: Buypass
+PackageName: Buypass Javafri
+PackageUrl: https://www.buypass.no/hjelp/buypass-id/smartkort/javafri
+License: Proprietær
+ShortDescription: En programvareløsning som muliggjør sikker kommunikasjon mellom nettleseren og Buypass Smartkort. Løsningen benyttes av en rekke av Buypass sine brukersteder samt i Buypass sine autentiseringstjenester.
+Moniker: buypass
+Tags:
+- buypass-javafri
+- buypassjavafri
+- buypass-smartkort
+- buypasssmartkort
+- buypass-id
+- buypass-scproxy
+- id-porten
+- idporten
+- norge
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.yaml
+++ b/manifests/b/Buypass/Javafri/1.4.1.16/Buypass.Javafri.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Buypass.Javafri
+PackageVersion: 1.4.1.16
+DefaultLocale: nb
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Buypass.Javafri.json
+++ b/shards/json/Buypass.Javafri.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://www.buypass.no/hjelp/buypass-id/smartkort/javafri",
+		"regex": "href=\"(?<exeUrl>/hjelp/buypass-id/smartkort/javafri/_/attachment/download/[^\"]+/Buypass\\.Javafri\\.Setup_(?<version>\\d[\\d_]*)\\.exe)\"[\\s\\S]{0,3000}?href=\"(?<msiUrl>/hjelp/buypass-id/smartkort/javafri/_/attachment/download/[^\"]+/Buypass\\.SCProxy\\.Setup_\\d[\\d_]*\\.msi)\""
+	},
+	"version": { "source": "product" },
+	"state": { "source": "value", "value": "{version}" },
+	"urls": ["https://www.buypass.no{captures.msiUrl}", "https://www.buypass.no{captures.exeUrl}"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#350616
  - Relates to microsoft/winget-pkgs#350044

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? (manifests use the 1.12.0 schema version, consistent with other manifests already in this repo)

Note: `<path>` is `manifests/b/Buypass/Javafri/1.4.1.16/`.

I don't have a Windows environment in this session, so I could not run actual `winget validate`/`winget install`. Instead I verified with this repo's own tooling:

```sh
bun manifests:check --deny-warnings
bun test:manifests --deny-warnings
bun fmt --check
```

All three pass clean against these new files (2209 manifests, 89 tests).

---

### What this is

This relates to/replicates #1012 ("New package: Buypass.Javafri version 1.4.1.16"), originally opened by @DandelionSprout, who could not get an automated-update shard working because "the InstallerUrl is non-GitHub." I have **not** touched, commented on, or closed #1012 — this is a separate PR of my own that adds the same package plus a working shard.

Buypass is one of Norway's officially permitted electronic ID systems (alongside BankID etc.), used for things like logging into government services (e.g. `login.idporten.no`). Javafri/SCProxy is the smart-card-reader helper that browsers talk to when authenticating with a physical Buypass smart card.

### Manifest

- `manifests/b/Buypass/Javafri/1.4.1.16/` — msi (x86) + burn/exe (x86) installers, `en-US` and `nb` (default) locales.
- I independently downloaded both installers from `buypass.no` and computed SHA256 myself rather than trusting the hashes quoted in #1012 — they matched byte-for-byte:
  - `Buypass.SCProxy.Setup_1_4_1.msi`: `35EAF01EECFED1A25A628B7F47C83162E9C059E5DC6822B26B987FC2FB17556A`
  - `Buypass.Javafri.Setup_1_4_1.exe`: `B60E73AB083D8268E8F7A7D09CC62EBBD017D1F2A935CC17084FF3C19C8C3EA0`
- Also confirmed via `exiftool`/`msiinfo` that both installers' `ProductVersion` is `1.4.1.16`, matching the MSI's `ProductCode` used in the manifest, and that 1.4.1.16 is still the current version live on the vendor's download page today.

### Shard

`shards/json/Buypass.Javafri.json` uses the `page-match` strategy against `https://www.buypass.no/hjelp/buypass-id/smartkort/javafri`. The download URLs on that page look like:

```
/hjelp/buypass-id/smartkort/javafri/_/attachment/download/<uuid>:<hash>/Buypass.SCProxy.Setup_1_4_1.msi
```

The `<uuid>:<hash>` segment is a per-attachment ID unrelated to the package version (it's a Liferay-style CMS asset store), so it can't be reconstructed from a version number template the way most `page-match` shards work — this is likely why #1012 couldn't get a shard working with a template-based URL. Instead this shard captures the *entire* href for both the exe and msi links as named regex groups (`exeUrl`/`msiUrl`) and builds the download URLs from those captures directly, so it keeps working even when the vendor re-uploads the file under a new hash. The version used for the manifest comes from `"version": { "source": "product" }` (the downloaded installer's own `ProductVersion`), since the URL only encodes a truncated `1_4_1` rather than the full `1.4.1.16`.

I validated the regex against a real fetch of the live page (saved locally and matched with Python, mirroring the JS regex semantics) before writing the shard, but couldn't run `bun test:shard Buypass.Javafri --dry-run` itself since the real `anthelion` npm dependency needs GitHub API access this sandboxed token doesn't have.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REcvxfrJ4UzqfhY1akgvBN)_