### PR TITLE
New package: Dell.CommandUpdate.61R17 version 5.7.1

### DIFF
--- a/manifests/d/Dell/CommandUpdate/61R17/5.7.1/Dell.CommandUpdate.61R17.installer.yaml
+++ b/manifests/d/Dell/CommandUpdate/61R17/5.7.1/Dell.CommandUpdate.61R17.installer.yaml
@@ -1,0 +1,33 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate.61R17
+PackageVersion: 5.7.1
+ReleaseDate: 2026-08-03
+InstallerLocale: en-US
+InstallerType: exe
+Scope: machine
+InstallerSwitches:
+  Silent: /passthrough /S /V/quiet /V/norestart
+  SilentWithProgress: /passthrough /S /V/quiet /V/norestart
+  Interactive: /passthrough
+  InstallLocation: /V"COMMANDUPDATE1=\"<INSTALLPATH>\""
+  Log: /V"/log \"<LOGPATH>\""
+InstallerSuccessCodes:
+- 2
+ExpectedReturnCodes:
+- InstallerReturnCode: 6
+  ReturnResponse: rebootInitiated
+UpgradeBehavior: install
+Dependencies:
+  PackageDependencies:
+    - PackageIdentifier: Microsoft.DotNet.DesktopRuntime.10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://dl.dell.com/FOLDER14847280M/2/Dell-Command-Update-for-Win32_61R17_WIN64_5.7.1_A00.EXE
+  InstallerSha256: 1F7AE4E4A20E7005A894CF9429765E99CF197CC021303F7E105ABAC463114B0C
+ElevationRequirement: elevatesSelf
+ProductCode: '{9F3A7C1E-8B52-4D9F-A6C7-1E2B9D4F5A08}'
+AppsAndFeaturesEntries:
+- ProductCode: '{9F3A7C1E-8B52-4D9F-A6C7-1E2B9D4F5A08}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/Dell/CommandUpdate/61R17/5.7.1/Dell.CommandUpdate.61R17.locale.en-US.yaml
+++ b/manifests/d/Dell/CommandUpdate/61R17/5.7.1/Dell.CommandUpdate.61R17.locale.en-US.yaml
@@ -1,0 +1,47 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate.61R17
+PackageVersion: 5.7.1
+PackageLocale: en-US
+Publisher: Dell Inc.
+PublisherUrl: https://www.dell.com/
+PublisherSupportUrl: https://www.dell.com/support/home/en-us/
+PrivacyUrl: https://www.dell.com/en-us/lp/legal/policies-privacy
+Author: Dell Inc.
+PackageName: "Dell Command | Update (61R17)"
+PackageUrl: https://www.dell.com/support/home/en-sg/drivers/driversdetails?driverid=61R17
+License: Proprietary
+LicenseUrl: https://www.dell.com/en-us/lp/legal/terms-of-sale
+Copyright: © 2020 - 2026 Dell Inc. or its subsidiaries. All rights reserved.
+CopyrightUrl: https://www.dell.com/en-us/lp/legal/trademarks-us
+ShortDescription: A stand-alone application for systems that provides updates for system software that is released by Dell. This application simplifies the BIOS, firmware, driver, and application update experience for Dell client hardware.
+Description: |-
+  Dell Command Update is a standalone application for client systems that provides updates to system software released by Dell. This application simplifies the BIOS, firmware, drivers, and application update experience for Dell client hardware. This update addresses Dell Security Notices (DSAs). A security bulletin is a statement that provides remediation measures when a security vulnerability affects a product.
+
+  For Dell devices that use the «6JGR0» release channels of Dell Command Update instead of «61R17», use the regular Dell.CommandUpdate package instead.
+Moniker: dellcommandupdate61r17
+Tags:
+- dell-command-update-61r17
+- alienware
+- dell-bios
+- dell-firmware
+- dell-devices
+- dell-drivers
+- dell-update
+- inspiron
+- latitude
+- optiplex
+- precision
+- vostro
+- xps
+- dell-core-services
+- dellinstrumentation.inf
+ReleaseNotes: |-
+  Fixes:
+  - This release contains security updates as disclosed in the Dell Security Advisory DSA-2026-309. The DSA details are published on the Security Advisories, Notices, and Resources page, once they are publicly available. For more information about the release schedule, see Dell Client Drivers and Downloads Update Release Schedule.
+
+  Enhancements:
+  - Added the option to bypass the Out of Box Experience (OOBE) through the command line to install the Dell Command Update application.
+  - Improved the performance of the application.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/Dell/CommandUpdate/61R17/5.7.1/Dell.CommandUpdate.61R17.yaml
+++ b/manifests/d/Dell/CommandUpdate/61R17/5.7.1/Dell.CommandUpdate.61R17.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Dell.CommandUpdate.61R17
+PackageVersion: 5.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -4,6 +4,7 @@
 			"manifests/a/AMD/BugReportTool": "selfhosted, drivers.amd.com only serves the installer to requests with an amd.com referer",
 			"manifests/a/ASRock/AppShop": "asrock.com blocks automated requests, and the download URL is the only place the version appears",
 			"manifests/a/AVerMedia/AssistCentral": "discontinued, delisted for Assist Central Pro",
+			"manifests/d/Dell/CommandUpdate/61R17": "dell.com/support and dl.dell.com both terminate plain HTTP clients at the TLS/connection level (Bun's fetch gets ECONNRESET on both, curl needs a full browser header set including sec-fetch-* to get past dell.com's Akamai bot check), so a page-match, redirect-match, or json shard can't reliably run in Anthelion's own bun/ky runtime; the driver page has no separate machine-readable API",
 			"fonts/a/AndreBerg/MesloLG/DZ": "discontinued",
 			"fonts/a/AndreBerg/MesloLG": "discontinued",
 			"fonts/b/BrailleInstitute/AtkinsonHyperlegible": "discontinued",


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to https://github.com/microsoft/winget-pkgs/pull/419518.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is `manifests/d/Dell/CommandUpdate/61R17/5.7.1/`.

---

### Context

This relates to #1063, originally opened by @DandelionSprout, who proposed the same manifest but explicitly didn't attempt a shard ("I have/had little to no experience with Dell utilities... I won't create a shard for this if it was a matter of life and death"). This PR is a separate, independent submission with the same package content plus a shard attempt — #1063 itself is untouched.

### What I verified

- Downloaded `https://dl.dell.com/FOLDER14847280M/2/Dell-Command-Update-for-Win32_61R17_WIN64_5.7.1_A00.EXE` myself with `curl` and computed `sha256sum` directly (not trusted from the original PR). It matches: `1F7AE4E4A20E7005A894CF9429765E99CF197CC021303F7E105ABAC463114B0C`.
- Confirmed 5.7.1 (A00), released 2026-08-03, is still the current build listed on Dell's driver page for driverid 61R17.

### No windows environment here

I don't have a Windows environment to run `winget validate`/`winget install` locally, so instead I verified with this repo's own tooling (see `README.md` "Automated updates"/"Validation" sections):

```sh
bun manifests:check --deny-warnings
bun test:manifests --deny-warnings
bun fmt --check
```

All pass. (`anthelion` itself can't install in this sandbox since it needs GitHub API access this token doesn't have, so I temporarily swapped it for its pinned direct dependencies to run the linter/tests, then restored `package.json`/`bun.lock` before committing — only the manifest and `scripts/manifest-linter/config.json` changes are in this PR.) The real install-validation job (`validate.yml`, Windows runner) will still need to run in CI.

### About the shard

I made a real attempt at a `page-match` shard against Dell's driver page (`driverid=61R17`), which does embed the version and exact download URL server-side (`DellDndDrawer.FileDetails[...].FileLocation`). However, both `dell.com/support/...` and `dl.dell.com` sit behind Akamai bot protection that a plain HTTP client fails against:

- `curl` with no headers, or with just a normal browser `User-Agent`, gets HTTP 403 from `dell.com/support/home/.../driversdetails`. It only succeeds with a full browser-like header set (`sec-fetch-mode`, `sec-fetch-site`, `sec-fetch-dest`, `upgrade-insecure-requests`, etc.), which `page-match`/`redirect-match`/`json` shards have no way to configure (checked `pageMatch`'s JSON schema — it only takes `url` and `regex`).
- Bun's own `fetch()` (what Anthelion's `ky`-based strategies use under the hood, per `src/strategies.ts`) gets `ECONNRESET` against both `dell.com/support/...` and `dl.dell.com` outright — not even a 403, the connection is dropped.

So no declarative or script shard can reliably run against this upstream from Anthelion's runtime, and there's no separate machine-readable API for this driver page. This mirrors existing entries in `scripts/manifest-linter/config.json`'s `repository/shard-coverage` ignore list (e.g. ASRock AppShop, MSI TrueColor: "blocks automated requests"). I added `manifests/d/Dell/CommandUpdate/61R17` to that list with the specific behavior I observed, rather than fabricate a shard that would just fail in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01REcvxfrJ4UzqfhY1akgvBN)_