### PR TITLE
New package: LZ4.LZ4 version 1.10.0

### DIFF
--- a/manifests/l/LZ4/LZ4/1.10.0/LZ4.LZ4.installer.yaml
+++ b/manifests/l/LZ4/LZ4/1.10.0/LZ4.LZ4.installer.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: LZ4.LZ4
+PackageVersion: 1.10.0
+ReleaseDate: 2024-08-03
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: lz4.exe
+  PortableCommandAlias: lz4
+UpgradeBehavior: install
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/lz4/lz4/releases/download/v1.10.0/lz4_win64_v1_10_0.zip
+  InstallerSha256: 8CB562A53189DFC8A53EC12469B91F1B51A5075036061A86B55738183BF4AB74
+- Architecture: x86
+  InstallerUrl: https://github.com/lz4/lz4/releases/download/v1.10.0/lz4_win32_v1_10_0.zip
+  InstallerSha256: AB0CC3153D647605D37E031BAA875228DDA222FB9319420BEB8D2AD075840A4E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LZ4/LZ4/1.10.0/LZ4.LZ4.locale.en-US.yaml
+++ b/manifests/l/LZ4/LZ4/1.10.0/LZ4.LZ4.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: LZ4.LZ4
+PackageVersion: 1.10.0
+PackageLocale: en-US
+Publisher: LZ4
+PackageUrl: https://github.com/lz4/lz4
+PackageName: LZ4
+License: GPL-2.0-or-later AND BSD-2-Clause
+LicenseUrl: https://github.com/lz4/lz4/blob/dev/LICENSE
+ShortDescription: A lossless compression algorithm, providing compression speed >500 MB/s per core, scalable with multi-cores CPU.
+Description: |-
+  A lossless compression algorithm, providing compression speed >500 MB/s per core, scalable with multi-cores CPU. It features an extremely fast decoder, with speed in multiple GB/s per core, typically reaching RAM speed limits on multi-core systems.
+Moniker: lz4
+Tags:
+- compression
+- compression-algorithm
+- portable
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LZ4/LZ4/1.10.0/LZ4.LZ4.yaml
+++ b/manifests/l/LZ4/LZ4/1.10.0/LZ4.LZ4.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: LZ4.LZ4
+PackageVersion: 1.10.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/LZ4.LZ4.json
+++ b/shards/json/LZ4.LZ4.json
@@ -1,0 +1,15 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "lz4", "repo": "lz4" },
+	"urls": [
+		{
+			"url": "https://github.com/lz4/lz4/releases/download/v{version}/lz4_win64_v{version|.|_}.zip",
+			"architecture": "x64"
+		},
+		{
+			"url": "https://github.com/lz4/lz4/releases/download/v{version}/lz4_win32_v{version|.|_}.zip",
+			"architecture": "x86"
+		}
+	]
+}

--- a/shards/json/LZ4.LZ4.json
+++ b/shards/json/LZ4.LZ4.json
@@ -3,13 +3,7 @@
 	"strategy": "github-release",
 	"github": { "owner": "lz4", "repo": "lz4" },
 	"urls": [
-		{
-			"url": "https://github.com/lz4/lz4/releases/download/v{version}/lz4_win64_v{version|.|_}.zip",
-			"architecture": "x64"
-		},
-		{
-			"url": "https://github.com/lz4/lz4/releases/download/v{version}/lz4_win32_v{version|.|_}.zip",
-			"architecture": "x86"
-		}
+		"https://github.com/lz4/lz4/releases/download/v{version}/lz4_win32_v{version|.|_}.zip",
+		"https://github.com/lz4/lz4/releases/download/v{version}/lz4_win64_v{version|.|_}.zip"
 	]
 }


### PR DESCRIPTION
Adds a manifest for [LZ4](https://github.com/lz4/lz4), a lossless compression algorithm, in response to #1116.

The Windows build is distributed as a zip on GitHub releases containing a portable `lz4.exe`, so this is packaged as `InstallerType: zip` / `NestedInstallerType: portable` (x64 and x86), similar to the existing `NirSoft.NirCmd` and `Git.PortableGit` manifests. A `shards/json/LZ4.LZ4.json` shard is included for automated version updates via the `github-release` strategy.

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#426292

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? (no Windows environment available here; ran this repo's own `bun manifests:check`, `bun test:manifests`, `bun fmt --check`, and `bun lint` instead, all passing)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (no Windows environment available here)
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? (uses the 1.12.0 manifest schema, matching other recent additions in this repo)

Note: `manifests/l/LZ4/LZ4/1.10.0`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NhCpMWVW73mpYqvW1TNa8H

---
_Generated by [Claude Code](https://claude.ai/code/session_01NhCpMWVW73mpYqvW1TNa8H)_