### PR TITLE
Add Microsoft.UI.Xaml.2.7

### DIFF
--- a/manifests/m/Microsoft/UI/Xaml/2/7/7.2208.15002/Microsoft.UI.Xaml.2.7.installer.yaml
+++ b/manifests/m/Microsoft/UI/Xaml/2/7/7.2208.15002/Microsoft.UI.Xaml.2.7.installer.yaml
@@ -1,0 +1,37 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.UI.Xaml.2.7
+PackageVersion: 7.2208.15002
+ReleaseDate: 2022-08-16
+Platform:
+- Windows.Universal
+PackageFamilyName: Microsoft.UI.Xaml.2.7_8wekyb3d8bbwe
+InstallerType: zip # A .nupkg archive with .appx files inside it.
+NestedInstallerType: appx
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx
+  InstallerUrl: https://globalcdn.nuget.org/packages/microsoft.ui.xaml.2.7.3.nupkg
+  InstallerSha256: 9EF3C54AA8C185603BA87D61673EFB527062054ADC736E27F2C4A033B5F797A8
+  SignatureSha256: CAA70305EC0BE6C89B3CF885AF8AB387E7E9B66C9552E31E0B183EE662B1E16A
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: tools\AppX\x86\Release\Microsoft.UI.Xaml.2.7.appx
+  InstallerUrl: https://globalcdn.nuget.org/packages/microsoft.ui.xaml.2.7.3.nupkg
+  InstallerSha256: 9EF3C54AA8C185603BA87D61673EFB527062054ADC736E27F2C4A033B5F797A8
+  SignatureSha256: 78B43B66446953D1648D5C2BC9C315AFD7E545C5E91D9641A64B0291BAD85F7E
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: tools\AppX\arm64\Release\Microsoft.UI.Xaml.2.7.appx
+  InstallerUrl: https://globalcdn.nuget.org/packages/microsoft.ui.xaml.2.7.3.nupkg
+  InstallerSha256: 9EF3C54AA8C185603BA87D61673EFB527062054ADC736E27F2C4A033B5F797A8
+  SignatureSha256: E8021DB2A89186D6E87F79331DDE332A3F00AE5D5C30F5D3C80145894B68F8F4
+- Architecture: arm
+  NestedInstallerFiles:
+  - RelativeFilePath: tools\AppX\arm\Release\Microsoft.UI.Xaml.2.7.appx
+  InstallerUrl: https://globalcdn.nuget.org/packages/microsoft.ui.xaml.2.7.3.nupkg
+  InstallerSha256: 9EF3C54AA8C185603BA87D61673EFB527062054ADC736E27F2C4A033B5F797A8
+  SignatureSha256: 032785D808A42ACC98F7E8357F1FD3EDE5A088D5D22CA01C68D024BB7D1DCF16
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/UI/Xaml/2/7/7.2208.15002/Microsoft.UI.Xaml.2.7.locale.en.yaml
+++ b/manifests/m/Microsoft/UI/Xaml/2/7/7.2208.15002/Microsoft.UI.Xaml.2.7.locale.en.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.UI.Xaml.2.7
+PackageVersion: 7.2208.15002
+PackageLocale: en
+Publisher: Microsoft Corporation
+PackageName: Microsoft.UI.Xaml
+PackageUrl: https://www.nuget.org/packages/Microsoft.UI.Xaml/2.7.3
+License: MIT
+ShortDescription: This package provides backward-compatible versions of Windows UI features including UWP XAML controls, dense control styles, and Fluent styles and materials. It is part of the Windows UI Library.
+Moniker: uixaml27
+Tags:
+- microsoft-ui-xaml-2-7
+- microsoftuixaml2.7
+Documentations:
+- DocumentLabel: Alternate Homepage
+  DocumentUrl: https://github.com/microsoft/microsoft-ui-xaml
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/UI/Xaml/2/7/7.2208.15002/Microsoft.UI.Xaml.2.7.yaml
+++ b/manifests/m/Microsoft/UI/Xaml/2/7/7.2208.15002/Microsoft.UI.Xaml.2.7.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.UI.Xaml.2.7
+PackageVersion: 7.2208.15002
+DefaultLocale: en
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -42,6 +42,7 @@
 			"manifests/m/Microsoft/UI/Xaml/2/2": "discontinued",
 			"manifests/m/Microsoft/UI/Xaml/2/3": "discontinued",
 			"manifests/m/Microsoft/UI/Xaml/2/4": "discontinued",
+			"manifests/m/Microsoft/UI/Xaml/2/7": "discontinued",
 			"manifests/m/Microsoft/VCLibs/12": "discontinued",
 			"manifests/m/Microsoft/VCRedist/2012/arm32": "discontinued",
 			"manifests/m/Microsoft/VCRedist/2013/arm32": "discontinued",


### PR DESCRIPTION
Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - N/A — split out of #1110 per review, for the same reason winget-extras already hosts the discontinued Microsoft.UI.Xaml 2.0-2.4 lines: this framework version isn't something winget-pkgs carries as an installable package.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you validated your manifest against the published WinGet JSON schemas (1.12.0, matching the schema version already used across this repo)?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Not tested on real Windows hardware in this environment, but this exact package definition already passed the repo's own `Validate / Installation Validation` CI check across all four architectures (x64, x86, arm64, arm) when it was part of #1110.
- [x] Does your manifest conform to the schema used by this repo (1.12.0)?

Note: `<path>` is `manifests/m/Microsoft/UI/Xaml/2/7/7.2208.15002/`.

---

## Summary

- Adds `Microsoft.UI.Xaml.2.7`, sourced from the `Microsoft.UI.Xaml` 2.7.3 NuGet package (the final patch of the 2.7.x line), the same way the existing `Microsoft.UI.Xaml.2.0`-`2.4` entries are hosted here.
- `Flirc.SkipApp` (#1110) genuinely requires this framework to deploy — without it declared/available, Windows AppX rejects the MSIX install with "depends on a framework that could not be found. Provide the framework Microsoft.UI.Xaml.2.7 ...".
- Marks it `discontinued` in `scripts/manifest-linter/config.json`'s shard-coverage exemptions (2.7.3 is the final published patch of this line), matching the existing Xaml 2.0-2.4 entries.

## Test plan

- [x] Downloaded the `microsoft.ui.xaml.2.7.3.nupkg` from `globalcdn.nuget.org` and extracted each architecture's `.appx` to compute `InstallerSha256`/`SignatureSha256` and confirm the `AppxManifest.xml` identity (`Microsoft.UI.Xaml.2.7`, version `7.2208.15002.0`) satisfies the `Microsoft.UI.Xaml.2.7` MinVersion `7.2109.13004.0` that `Flirc.SkipApp` requires.
- [x] Validated all three manifests against the published `aka.ms/winget-manifest.*.1.12.0.schema.json` schemas.
- [x] This exact manifest content already passed `Validate / Installation Validation` on GitHub Actions for all four architectures while part of #1110 (see [that PR's checks](https://github.com/pl4nty/winget-extras/pull/1110/checks)).

---
_Generated by [Claude Code](https://claude.ai/code/session_016BpVUDYbERGmxWdxM6VM7i)_