### PR TITLE
New package: Microsoft.Teams.MeetingAddin version 1.26.20101

### DIFF
--- a/manifests/m/Microsoft/Teams/MeetingAddin/1.26.20101/Microsoft.Teams.MeetingAddin.installer.yaml
+++ b/manifests/m/Microsoft/Teams/MeetingAddin/1.26.20101/Microsoft.Teams.MeetingAddin.installer.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Teams.MeetingAddin
+PackageVersion: 1.26.20101
+InstallerType: zip
+NestedInstallerType: msi
+ReleaseDate: 2026-08-13
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x86
+  NestedInstallerFiles:
+  - RelativeFilePath: MicrosoftTeamsMeetingAddinInstallerX86.msi
+  InstallerUrl: https://statics.teams.cdn.office.net/production-windows-x86/enterprise/webview2/lkg/MSTeams-x86.msix
+  InstallerSha256: 531440E868410AF490F3C24E84552220B981215CBE000924A87D82E489BAB4F7
+  ProductCode: '{6C5FD2BE-C855-4BEC-AAFA-ADE7E194ABB9}'
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: MicrosoftTeamsMeetingAddinInstaller.msi
+  InstallerUrl: https://statics.teams.cdn.office.net/production-windows-x64/enterprise/webview2/lkg/MSTeams-x64.msix
+  InstallerSha256: A231449E57C60719C2EB290B1C5B988A04457A15299B5ADF3FD59CAC5FF1754A
+  ProductCode: '{A7AB73A3-CB10-4AA5-9D38-6AEFFBDE4C91}'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Teams/MeetingAddin/1.26.20101/Microsoft.Teams.MeetingAddin.locale.en-US.yaml
+++ b/manifests/m/Microsoft/Teams/MeetingAddin/1.26.20101/Microsoft.Teams.MeetingAddin.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Teams.MeetingAddin
+PackageVersion: 1.26.20101
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/microsoft-teams/
+PublisherSupportUrl: https://support.microsoft.com/microsoft-teams
+Author: Microsoft Corporation
+PackageName: Microsoft Teams Meeting Add-in for Microsoft Office
+PackageUrl: https://learn.microsoft.com/en-us/microsoftteams/teams-client-bulk-install
+License: Freeware
+Copyright: © Microsoft Corporation. All rights reserved.
+ShortDescription: Microsoft Teams' meeting add-in for Microsoft Office.
+Moniker: ms-teams-meeting-addin
+Tags:
+- add-in
+- meeting
+- microsoft-teams
+- microsoft-teams-meeting-addin
+- office
+- outlook
+- teams
+- teams-meeting-addin
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/Teams/MeetingAddin/1.26.20101/Microsoft.Teams.MeetingAddin.yaml
+++ b/manifests/m/Microsoft/Teams/MeetingAddin/1.26.20101/Microsoft.Teams.MeetingAddin.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.Teams.MeetingAddin
+PackageVersion: 1.26.20101
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -38,6 +38,7 @@
 			"manifests/m/Microsoft/IISExpress": "discontinued",
 			"manifests/m/Microsoft/Kusto/Explorer": "selfhosted, ClickOnce deployment with no standalone download",
 			"manifests/m/Microsoft/Scribble": "discontinued",
+			"manifests/m/Microsoft/Teams/MeetingAddin": "komac can't update msix treated as a zip",
 			"manifests/m/Microsoft/UI/Xaml/2/0": "discontinued",
 			"manifests/m/Microsoft/UI/Xaml/2/1": "discontinued",
 			"manifests/m/Microsoft/UI/Xaml/2/2": "discontinued",


### PR DESCRIPTION
Closes #1125.

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#426404 (closed upstream with a validation error)

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally? `bun manifests:check` and `bun test:manifests` pass, and I additionally validated all YAML files against the official 1.12.0 JSON schemas with ajv. CI's `Validate / Installation Validation` jobs have since passed too, confirming the zip/nested-msi extraction actually installs.
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? Not run locally (no Windows environment in this sandbox), but CI's real sandboxed installation validation passed.
- [x] Does your manifest conform to the schema? Uses the 1.12.0 schema, matching the most recently added packages in this repo.

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

### What this adds

The requester's installer URL (`.../lkg/MSTeams-x64.msix`) is actually the full "New Teams" MSIX package, which bundles the Meeting Add-in as a nested MSI (`MicrosoftTeamsMeetingAddinInstaller.msi`) at `LocalAppData\Microsoft\TeamsMeetingAddinMsis`. I downloaded and inspected the `lkg` MSIX packages directly to confirm this, and extracted `ProductCode`/`ProductVersion`/`UpgradeCode` from the nested MSIs with `msiinfo`:

| Architecture | Nested file | ProductCode |
|---|---|---|
| x86 | `MicrosoftTeamsMeetingAddinInstallerX86.msi` | `{6C5FD2BE-C855-4BEC-AAFA-ADE7E194ABB9}` |
| x64 | `MicrosoftTeamsMeetingAddinInstaller.msi` | `{A7AB73A3-CB10-4AA5-9D38-6AEFFBDE4C91}` |

The manifest uses `InstallerType: zip` with `NestedInstallerType: msi`, pointing `InstallerUrl` directly at each `.msix` (which is itself a standard zip container).

The arm64 `lkg` MSIX bundles the exact same nested MSI as the x64 one (verified byte-for-byte identical), so per @UnownPlain's guidance a separate arm64 entry was intentionally left out — x64 covers arm64 devices.

### Shard

I initially added `shards/json/Microsoft.Teams.MeetingAddin.json` with a `static`/`product`-version-source strategy, but CI's `Test / Test` job caught that it doesn't actually work: `display`/`product`/`file` version sources only read PE `VERSIONINFO` resources (`.exe`/`.dll`) and never populate for MSI installers. Since this add-in ships only as an MSI, no `static` shard strategy can detect its version automatically, so I documented the gap in `scripts/manifest-linter/config.json`'s `repository/shard-coverage` ignores instead of shipping a shard that fails CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_018rd4QyjwPfjJJVLNRWbXMJ)_