### PR TITLE
New package: ASRock.PolychromeRGB version 2.0.191

### DIFF
--- a/manifests/a/ASRock/PolychromeRGB/2.0.191/ASRock.PolychromeRGB.installer.yaml
+++ b/manifests/a/ASRock/PolychromeRGB/2.0.191/ASRock.PolychromeRGB.installer.yaml
@@ -1,0 +1,19 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: ASRock.PolychromeRGB
+PackageVersion: 2.0.191
+InstallerType: zip
+NestedInstallerType: inno
+NestedInstallerFiles:
+- RelativeFilePath: PolychromeRGB(v2.0.191)/AsrPolychromeRGBSetup(v2.0.191).exe
+ReleaseDate: 2024-12-05
+ElevationRequirement: elevatesSelf
+ProductCode: 'ASRock RGB LED_is1'
+AppsAndFeaturesEntries:
+- ProductCode: 'ASRock RGB LED_is1'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.asrock.com/Utility/RGB/PolychromeRGB(v2.0.191).zip
+  InstallerSha256: 94DAFE5DA4FFE254C8E5477052DF70573D4CE469EF23DDB32FDCED658D16FDB2
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/a/ASRock/PolychromeRGB/2.0.191/ASRock.PolychromeRGB.locale.en-US.yaml
+++ b/manifests/a/ASRock/PolychromeRGB/2.0.191/ASRock.PolychromeRGB.locale.en-US.yaml
@@ -1,0 +1,28 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: ASRock.PolychromeRGB
+PackageVersion: 2.0.191
+PackageLocale: en-US
+Publisher: ASRock Inc.
+PublisherUrl: https://www.asrock.com
+PublisherSupportUrl: https://www.asrock.com/support/
+PackageName: Polychrome RGB
+PackageUrl: https://www.asrock.com/mb/Intel/Z890%20Taichi%20OCF/Specification.asp#Download
+License: Proprietary
+ShortDescription: Manager for ASRock peripherals' LED lights.
+Moniker: polychromergb
+Tags:
+- asrock
+- asrock-peripherals
+- asrock-rgb-led
+- asrockrgbled
+- led
+- lighting
+- motherboard
+- polychrome-rgb
+- rgb
+- utility
+Agreements:
+- Agreement: "This package is untested, as no test environment was available. Please report any issues here: https://github.com/pl4nty/winget-extras/issues/new?template=package_issue.yml"
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/a/ASRock/PolychromeRGB/2.0.191/ASRock.PolychromeRGB.yaml
+++ b/manifests/a/ASRock/PolychromeRGB/2.0.191/ASRock.PolychromeRGB.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: ASRock.PolychromeRGB
+PackageVersion: 2.0.191
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -3,6 +3,7 @@
 		"repository/shard-coverage": {
 			"manifests/a/AMD/BugReportTool": "selfhosted, drivers.amd.com only serves the installer to requests with an amd.com referer",
 			"manifests/a/ASRock/AppShop": "asrock.com blocks automated requests, and the download URL is the only place the version appears",
+			"manifests/a/ASRock/PolychromeRGB": "asrock.com blocks automated requests, and the download URL is the only place the version appears",
 			"manifests/a/AVerMedia/AssistCentral": "discontinued, delisted for Assist Central Pro",
 			"fonts/a/AndreBerg/MesloLG/DZ": "discontinued",
 			"fonts/a/AndreBerg/MesloLG": "discontinued",


### PR DESCRIPTION
Closes #1127

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#424236

Manifests

- [ ] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? (no Windows environment available; validated instead with this repo's `bun manifests:check --deny-warnings` and `bun test:manifests --deny-warnings`, both passing)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (no Windows environment available; see the "untested" agreement in the locale manifest)
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Adds ASRock Polychrome RGB 2.0.191, requested in #1127. The installer is a self-extracting zip containing an Inno Setup executable, following the same pattern as the existing `ASRock.AppShop` manifest from the same publisher.

Since asrock.com blocks automated requests (Incapsula) and the download URL is the only place the version number appears, no automated shard could be added — the same limitation already documented for `ASRock.AppShop`. I added a matching `repository/shard-coverage` ignore entry for `ASRock.PolychromeRGB` in `scripts/manifest-linter/config.json` instead.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CSvdoVLzkZ74xBS91E1pig)_