### PR TITLE
New package: MSI.CleanCenterMaster version 1.0.0.9

### DIFF
--- a/manifests/m/MSI/CleanCenterMaster/1.0.0.9/MSI.CleanCenterMaster.installer.yaml
+++ b/manifests/m/MSI/CleanCenterMaster/1.0.0.9/MSI.CleanCenterMaster.installer.yaml
@@ -1,0 +1,17 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MSI.CleanCenterMaster
+PackageVersion: 1.0.0.9
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: CleanCenterMaster.exe
+ElevationRequirement: elevatesSelf
+ArchiveBinariesDependOnPath: true
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.msi.com/uti_exe/nb/CleanCenterMaster.zip
+  InstallerSha256: 0D7AC1F026DA9CDF891A16551E79D5D6857279205AB5AED7E33CC83987C94128
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MSI/CleanCenterMaster/1.0.0.9/MSI.CleanCenterMaster.locale.en-US.yaml
+++ b/manifests/m/MSI/CleanCenterMaster/1.0.0.9/MSI.CleanCenterMaster.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MSI.CleanCenterMaster
+PackageVersion: 1.0.0.9
+PackageLocale: en-US
+Publisher: Micro-Star International
+PackageName: Clean Center Master
+PackageUrl: https://www.msi.com/faq/faq-4147
+License: Proprietary
+ShortDescription: Run Clean Center Master to completely remove MSI Center before reinstalling it.
+Moniker: clean-center-master
+Tags:
+- msi-clean-center-master
+- msicleancentermaster
+- microstarinternationalcleancentermaster
+- msi-center
+- msicenter
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MSI/CleanCenterMaster/1.0.0.9/MSI.CleanCenterMaster.yaml
+++ b/manifests/m/MSI/CleanCenterMaster/1.0.0.9/MSI.CleanCenterMaster.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MSI.CleanCenterMaster
+PackageVersion: 1.0.0.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/MSI.CleanCenterMaster.json
+++ b/shards/json/MSI.CleanCenterMaster.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{
+			"url": "https://download.msi.com/uti_exe/nb/CleanCenterMaster.zip",
+			"nestedInstallerMatches": ["CleanCenterMaster.exe"]
+		}
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://download.msi.com/uti_exe/nb/CleanCenterMaster.zip",
+		"header": "etag"
+	},
+	"replace": true
+}


### PR DESCRIPTION
Adds a manifest for MSI Clean Center Master, requested in #1142.

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#424242 (as provided in #1142; this is an interactive-only removal tool, so it's a better fit here than upstream)

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally? Ran this repo's `bun manifests:check` linter, which passed with no errors or warnings.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Not run locally (no Windows environment available here) — CI's install-validation workflow will exercise it on a Windows runner.
- [x] Does your manifest conform to the 1.28 schema? Uses ManifestVersion 1.12.0, matching the schema version this repo's other manifests currently target.

Note: `<path>` is `manifests/m/MSI/CleanCenterMaster/1.0.0.9/`.

## Summary

- `MSI.CleanCenterMaster` v1.0.0.9 — a zip containing a portable, self-elevating .NET exe (`CleanCenterMaster.exe`) published by Micro-Star International that removes MSI Center before reinstalling it. Downloaded and inspected the installer to confirm the PE version resource (`ProductVersion: 1.0.0.9`), embedded manifest (`requireAdministrator`), and architecture (x86).
- Added `shards/json/MSI.CleanCenterMaster.json` using the `static` strategy (version sourced from the exe's `ProductVersion`, with `etag`-based state tracking) since the download URL carries no version string, following the precedent set by `Maxon.Cinebench.json` and `Microsoft.SystemCenter.Orchestrator.RunbookDesigner.json`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q2FTcdS3XfB62okLJfUK1i

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q2FTcdS3XfB62okLJfUK1i)_