### PR TITLE
New package: Microsoft.SurfaceITToolkit version 1.345.139.0

### DIFF
--- a/manifests/m/Microsoft/SurfaceITToolkit/1.345.139.0/Microsoft.SurfaceITToolkit.installer.yaml
+++ b/manifests/m/Microsoft/SurfaceITToolkit/1.345.139.0/Microsoft.SurfaceITToolkit.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.SurfaceITToolkit
+PackageVersion: 1.345.139.0
+ReleaseDate: 2026-08-06
+Platform:
+- Windows.Desktop
+MinimumOSVersion: 10.0.17763.0
+InstallerType: msix
+PackageFamilyName: Microsoft.SurfaceITToolkit_8wekyb3d8bbwe
+Installers:
+- Architecture: x64
+  InstallerUrl: https://sit.microsoft.com/install/stable/x64/AppPackages/Microsoft.SurfaceITToolkit.UI_1.345.139.0_x64_Release/Microsoft.SurfaceITToolkit.UI_1.345.139.0_x64_Release.msix
+  InstallerSha256: 70CBFD0567711FAAA6659ED0463B64BC3F9C94C82627DD10360064625AFA6C0F
+  SignatureSha256: E747401F26CC052859EA6A0D7921FDD7BF204D2FD32057192403A78EAB1BE2CB
+- Architecture: arm64
+  InstallerUrl: https://sit.microsoft.com/install/stable/arm64/AppPackages/Microsoft.SurfaceITToolkit.UI_1.345.139.0_arm64_Release/Microsoft.SurfaceITToolkit.UI_1.345.139.0_arm64_Release.msix
+  InstallerSha256: 5835E03F6BE6AED9BF562227806934083CFE4FF1E427274AF28F8CD3042FF48D
+  SignatureSha256: E119D5947824523A3DE34D36DC8D52D446AB877CE636FEE73C28BD91FF6858B2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/SurfaceITToolkit/1.345.139.0/Microsoft.SurfaceITToolkit.locale.en-US.yaml
+++ b/manifests/m/Microsoft/SurfaceITToolkit/1.345.139.0/Microsoft.SurfaceITToolkit.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.SurfaceITToolkit
+PackageVersion: 1.345.139.0
+PackageLocale: en-US
+Publisher: Microsoft Corporation
+PublisherUrl: https://www.microsoft.com/
+PublisherSupportUrl: https://learn.microsoft.com/en-us/surface/
+Author: Microsoft Corporation
+PackageName: Surface IT Toolkit
+PackageUrl: https://www.microsoft.com/en-us/download/details.aspx?id=46703
+License: Proprietary
+Copyright: © Microsoft Corporation. All rights reserved.
+ShortDescription: Maintenance dashboard for Microsoft Surface devices, aimed at company IT admins.
+Moniker: surface-it-toolkit
+Tags:
+- microsoft-surface-it-toolkit
+- surface
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microsoft/SurfaceITToolkit/1.345.139.0/Microsoft.SurfaceITToolkit.yaml
+++ b/manifests/m/Microsoft/SurfaceITToolkit/1.345.139.0/Microsoft.SurfaceITToolkit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microsoft.SurfaceITToolkit
+PackageVersion: 1.345.139.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Microsoft.SurfaceITToolkit.json
+++ b/shards/json/Microsoft.SurfaceITToolkit.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://sit.microsoft.com/install/stable/x64/AppPackages/Microsoft.SurfaceITToolkit.UI_x64.appinstaller",
+		"regex": "MainPackage[\\s\\S]*?Version=\"(\\d+(?:\\.\\d+)+)\""
+	},
+	"urls": [
+		"https://sit.microsoft.com/install/stable/x64/AppPackages/Microsoft.SurfaceITToolkit.UI_{version}_x64_Release/Microsoft.SurfaceITToolkit.UI_{version}_x64_Release.msix",
+		"https://sit.microsoft.com/install/stable/arm64/AppPackages/Microsoft.SurfaceITToolkit.UI_{version}_arm64_Release/Microsoft.SurfaceITToolkit.UI_{version}_arm64_Release.msix"
+	]
+}


### PR DESCRIPTION
Adds the Surface IT Toolkit, a maintenance dashboard for Microsoft Surface devices aimed at IT admins, as requested in #1154.

- msix manifest set (x64 + arm64) for version 1.345.139.0, identity/hashes extracted directly from the published packages
- `shards/json/Microsoft.SurfaceITToolkit.json`: page-match shard against the download center's stable appinstaller endpoints, so future releases are picked up automatically

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#428543

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? (no Windows environment available here; relies on this repo's automated `validate.yml`/`lint.yml` CI)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (same limitation as above)
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XbpptqWr4gfhpqgs3nySrd

---
_Generated by [Claude Code](https://claude.ai/code/session_01XbpptqWr4gfhpqgs3nySrd)_