### PR TITLE
New package: MattPharoah.ParallelLauncher version 9.0.6

### DIFF
--- a/manifests/m/MattPharoah/ParallelLauncher/9.0.6/MattPharoah.ParallelLauncher.installer.yaml
+++ b/manifests/m/MattPharoah/ParallelLauncher/9.0.6/MattPharoah.ParallelLauncher.installer.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.28.0.schema.json
+
+PackageIdentifier: MattPharoah.ParallelLauncher
+PackageVersion: 9.0.6
+InstallerLocale: en-US
+InstallerType: zip
+NestedInstallerType: inno
+NestedInstallerFiles:
+- RelativeFilePath: parallel-launcher_setup_win64.exe
+ReleaseDate: 2026-08-12
+Scope: machine
+ProductCode: '{2C94867F-0911-4237-B447-CE6E30AD7F55}_is1'
+AppsAndFeaturesEntries:
+- DisplayVersion: 9.0.6
+  ProductCode: '{2C94867F-0911-4237-B447-CE6E30AD7F55}_is1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://parallel-launcher.ca/windows-releases/parallel-launcher-v9.0.6-windows64.zip
+  InstallerSha256: 91E847D25202EF7E854958F0FCBF8616C910842CCE684A5391E6AE2597B03B46
+ManifestType: installer
+ManifestVersion: 1.28.0

--- a/manifests/m/MattPharoah/ParallelLauncher/9.0.6/MattPharoah.ParallelLauncher.locale.en-US.yaml
+++ b/manifests/m/MattPharoah/ParallelLauncher/9.0.6/MattPharoah.ParallelLauncher.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.28.0.schema.json
+
+PackageIdentifier: MattPharoah.ParallelLauncher
+PackageVersion: 9.0.6
+PackageLocale: en-US
+Publisher: Matt Pharoah
+PublisherUrl: https://parallel-launcher.ca
+PublisherSupportUrl: https://gitlab.com/parallel-launcher/parallel-launcher/-/issues
+PackageName: Parallel Launcher
+PackageUrl: https://parallel-launcher.ca
+License: GPL-3.0-or-later
+LicenseUrl: https://gitlab.com/parallel-launcher/parallel-launcher/-/raw/master/LICENSE
+ShortDescription: An easy to use launcher for the ParallelN64 emulator, featuring very easy controller configuration, custom modifications to the emulator core that improve accuracy and add enhancements, and automatic loading of ROMs from given folders.
+Moniker: parallellauncher
+Tags:
+- emulator
+- n64
+- nintendo-64
+- nintendo64
+- paralleln64
+- retroarch
+ManifestType: defaultLocale
+ManifestVersion: 1.28.0

--- a/manifests/m/MattPharoah/ParallelLauncher/9.0.6/MattPharoah.ParallelLauncher.yaml
+++ b/manifests/m/MattPharoah/ParallelLauncher/9.0.6/MattPharoah.ParallelLauncher.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.28.0.schema.json
+
+PackageIdentifier: MattPharoah.ParallelLauncher
+PackageVersion: 9.0.6
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.28.0

--- a/shards/json/MattPharoah.ParallelLauncher.json
+++ b/shards/json/MattPharoah.ParallelLauncher.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://parallel-launcher.ca/",
+		"regex": "windows-releases/parallel-launcher-v(?<version>\\d+(?:\\.\\d+)+)-windows64\\.zip"
+	},
+	"urls": [
+		"https://parallel-launcher.ca/windows-releases/parallel-launcher-v{version}-windows64.zip"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#422415
  - Closes #1156

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? (validated via this repo's `bun run manifests:check`, which reports all 2300 manifests OK)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (no Windows environment available in this session)
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

## Summary
- Adds `MattPharoah.ParallelLauncher` version `9.0.6`, an Inno Setup installer nested inside a zip download, per the request in #1156.
- The installer URL and ProductCode match the already-submitted [winget-pkgs PR #422415](https://github.com/microsoft/winget-pkgs/pull/422415).
- Adds a `page-match` shard at `shards/json/MattPharoah.ParallelLauncher.json` so future releases (detected from the version embedded in the download link on https://parallel-launcher.ca/) are picked up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NniC5NiY7q4CKKdbjubZP1

---
_Generated by [Claude Code](https://claude.ai/code/session_01NniC5NiY7q4CKKdbjubZP1)_