### PR TITLE
New package: Jagex.JagexLauncher version 2.4.0

### DIFF
--- a/manifests/j/Jagex/JagexLauncher/2.4.0/Jagex.JagexLauncher.installer.yaml
+++ b/manifests/j/Jagex/JagexLauncher/2.4.0/Jagex.JagexLauncher.installer.yaml
@@ -1,0 +1,17 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Jagex.JagexLauncher
+PackageVersion: 2.4.0
+InstallerType: exe
+Scope: user
+UpgradeBehavior: install
+ReleaseDate: 2026-06-26
+InstallerSwitches:
+  Silent: --install --silent
+Installers:
+- Architecture: x86
+  InstallerUrl: https://files.publishing.production.jxp.jagex.com/installer/Jagex%20Launcher%20Installer.exe
+  InstallerSha256: 8FABAD6E32932C775725ECB6A539175E052EBD1E90F169029813EC0B62D52103
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/j/Jagex/JagexLauncher/2.4.0/Jagex.JagexLauncher.locale.en-US.yaml
+++ b/manifests/j/Jagex/JagexLauncher/2.4.0/Jagex.JagexLauncher.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Jagex.JagexLauncher
+PackageVersion: 2.4.0
+PackageLocale: en-US
+Publisher: Jagex
+PublisherUrl: https://www.jagex.com/
+PackageName: Jagex Launcher
+PackageUrl: https://osrs.runescape.com/download
+License: Proprietary
+Copyright: © 2026 Jagex Ltd.
+ShortDescription: Offers a new and improved experience for RuneScape and beyond. It allows you to access Jagex games seamlessly and securely, all in one place and with the safety and convenience of a single login.
+Moniker: jagexlauncher
+Tags:
+- game
+- gaming
+- jagex
+- launcher
+- oldschool-runescape
+- osrs
+- runescape
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/j/Jagex/JagexLauncher/2.4.0/Jagex.JagexLauncher.yaml
+++ b/manifests/j/Jagex/JagexLauncher/2.4.0/Jagex.JagexLauncher.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Jagex.JagexLauncher
+PackageVersion: 2.4.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Jagex.JagexLauncher.json
+++ b/shards/json/Jagex.JagexLauncher.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{
+			"url": "https://files.publishing.production.jxp.jagex.com/installer/Jagex%20Launcher%20Installer.exe",
+			"architecture": "x86"
+		}
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://files.publishing.production.jxp.jagex.com/installer/Jagex%20Launcher%20Installer.exe",
+		"header": "etag"
+	},
+	"replace": true
+}

--- a/shards/json/Jagex.JagexLauncher.json
+++ b/shards/json/Jagex.JagexLauncher.json
@@ -3,10 +3,7 @@
 	"strategy": "static",
 	"version": { "source": "product" },
 	"urls": [
-		{
-			"url": "https://files.publishing.production.jxp.jagex.com/installer/Jagex%20Launcher%20Installer.exe",
-			"architecture": "x86"
-		}
+		"https://files.publishing.production.jxp.jagex.com/installer/Jagex%20Launcher%20Installer.exe"
 	],
 	"state": {
 		"source": "response-header",

--- a/version-state/Jagex.JagexLauncher
+++ b/version-state/Jagex.JagexLauncher
@@ -1,0 +1,1 @@
+"8f20024199fecf57eca2baa65f9f70af"


### PR DESCRIPTION
Adds `Jagex.JagexLauncher` 2.4.0, closing #1163.

The installer is flagged as a Microsoft Defender false positive, so it can't be added to winget-pkgs (see the linked upstream issue in #1163), which is exactly the kind of package this repo hosts.

- `InstallerType: exe`, `Scope: user` — the bundled `RT_MANIFEST` requests `asInvoker`, so it installs per-user without elevation.
- `PackageVersion` (2.4.0) and `InstallerSha256` were taken directly from the downloaded installer's PE resources, not the version quoted in the issue, since the binary is authoritative.
- `InstallerSwitches.Silent: --install --silent` as reported in the issue; both tokens are present in the binary's own CLI parser strings.
- Added a `static` shard (`shards/json/Jagex.JagexLauncher.json`) using `version.source: product` and an `etag` response-header state token, plus an initial `version-state/Jagex.JagexLauncher` entry so automation doesn't immediately re-flag the version this PR already publishes.

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#386180

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? — not run; this session has no Windows/winget available. `bun manifests:check --deny-warnings` and `bun test:manifests` both pass locally.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — not run, same reason.
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? — written against 1.12.0, matching this repo's other manifests.

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gN7vyHzVfKgYL7UQ5MW6J

---
_Generated by [Claude Code](https://claude.ai/code/session_017gN7vyHzVfKgYL7UQ5MW6J)_