### PR TITLE
New package: FocusriteAudioEngineeringLtd.FocusriteAudioDrivers version 4.150.0.432

### DIFF
--- a/manifests/f/FocusriteAudioEngineeringLtd/FocusriteAudioDrivers/4.150.0.432/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.installer.yaml
+++ b/manifests/f/FocusriteAudioEngineeringLtd/FocusriteAudioDrivers/4.150.0.432/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.installer.yaml
@@ -5,8 +5,6 @@ PackageIdentifier: FocusriteAudioEngineeringLtd.FocusriteAudioDrivers
 PackageVersion: 4.150.0.432
 InstallerType: inno
 Scope: machine
-InstallModes:
-- interactive
 UpgradeBehavior: install
 ProductCode: Focusrite Audio Drivers_is1
 ReleaseDate: 2026-08-20

--- a/manifests/f/FocusriteAudioEngineeringLtd/FocusriteAudioDrivers/4.150.0.432/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.installer.yaml
+++ b/manifests/f/FocusriteAudioEngineeringLtd/FocusriteAudioDrivers/4.150.0.432/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.installer.yaml
@@ -1,0 +1,27 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: FocusriteAudioEngineeringLtd.FocusriteAudioDrivers
+PackageVersion: 4.150.0.432
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+UpgradeBehavior: install
+ProductCode: Focusrite Audio Drivers_is1
+ReleaseDate: 2026-08-20
+AppsAndFeaturesEntries:
+- ProductCode: Focusrite Audio Drivers_is1
+ElevationRequirement: elevatesSelf
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+    MinimumVersion: 14.51.36247.0
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x86
+    MinimumVersion: 14.51.36247.0
+Installers:
+- Architecture: x86
+  InstallerUrl: https://fael-downloads-prod.focusrite.com/customer/prod/downloads/focusritedriver_4.150.0_432.exe
+  InstallerSha256: 136F9F8117CC1BAB32C34B470BFEA52AE1B3874F5A95E71EB9EFEAD313029A04
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/FocusriteAudioEngineeringLtd/FocusriteAudioDrivers/4.150.0.432/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.locale.en-US.yaml
+++ b/manifests/f/FocusriteAudioEngineeringLtd/FocusriteAudioDrivers/4.150.0.432/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.locale.en-US.yaml
@@ -1,0 +1,23 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: FocusriteAudioEngineeringLtd.FocusriteAudioDrivers
+PackageVersion: 4.150.0.432
+PackageLocale: en-US
+Publisher: Focusrite Audio Engineering, Ltd.
+PublisherUrl: https://focusrite.com/
+PackageName: Focusrite Audio Drivers
+PackageUrl: https://downloads.focusrite.com/focusrite/scarlett-2nd-gen/scarlett-2i4-2nd-gen
+License: Freeware
+Copyright: © Focusrite Audio Engineering, Ltd.
+ShortDescription: Drivers for Focusrite Scarlett external AMP/DAC devices.
+Moniker: focusriteaudiodrivers
+Tags:
+- audio-driver
+- focusrite
+- focusrite-audio-drivers
+- focusriteaudiodrivers
+- scarlett
+- sound-card-driver
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/FocusriteAudioEngineeringLtd/FocusriteAudioDrivers/4.150.0.432/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.yaml
+++ b/manifests/f/FocusriteAudioEngineeringLtd/FocusriteAudioDrivers/4.150.0.432/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: FocusriteAudioEngineeringLtd.FocusriteAudioDrivers
+PackageVersion: 4.150.0.432
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.json
+++ b/shards/json/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://downloads.focusrite.com/focusrite/scarlett-2nd-gen/scarlett-2i4-2nd-gen",
+		"regex": "focusritedriver_(?<version>\\d+\\.\\d+\\.\\d+_\\d+)\\.exe"
+	},
+	"version": "{version|_|.}",
+	"urls": [
+		"https://fael-downloads-prod.focusrite.com/customer/prod/downloads/focusritedriver_{version}.exe"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#429843
  - Resolves #1175

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [x] Have you validated your manifest locally? Ran this repo's `manifests:check` linter and full `bun test scripts` suite against the new manifests (all passing).
- [x] Have you tested your manifest locally with `winget install --manifest <path>`? Not possible in this sandboxed session (no Windows host available), but CI's dynamic Installation Validation job ran it and installed successfully.
- [x] Does your manifest conform to the schema? Matches the `1.12.0` manifest schema used by other recent packages in this repo.

---

## Summary

- Adds `FocusriteAudioEngineeringLtd.FocusriteAudioDrivers` 4.150.0.432 (Focusrite Scarlett driver installer) as requested in #1175.
- The identical package/version was submitted upstream as [microsoft/winget-pkgs#429843](https://github.com/microsoft/winget-pkgs/pull/429843) but failed dynamic install validation there. This repo's own CI installed it silently and successfully (exit code 0), so no `InstallModes: interactive` marker was needed here.
- Adds a `page-match` update shard (`shards/json/FocusriteAudioEngineeringLtd.FocusriteAudioDrivers.json`) that tracks Focusrite's download page for new driver versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NfB6D57j8Ug1HP4H9xMVUr