### PR TITLE
New package: aglab2.StarDisplay version 1.41

### DIFF
--- a/manifests/a/aglab2/StarDisplay/1.41/aglab2.StarDisplay.installer.yaml
+++ b/manifests/a/aglab2/StarDisplay/1.41/aglab2.StarDisplay.installer.yaml
@@ -1,0 +1,12 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: aglab2.StarDisplay
+PackageVersion: "1.41"
+InstallerType: portable
+ReleaseDate: 2025-08-11
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/aglab2/SM64StarDisplay/releases/download/1.41/StarManager.exe
+  InstallerSha256: B2A0956F2A97565164054AAEBDE2DCE8B49C6853C23C9BBF8F852A41281AF8D7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/a/aglab2/StarDisplay/1.41/aglab2.StarDisplay.locale.en-US.yaml
+++ b/manifests/a/aglab2/StarDisplay/1.41/aglab2.StarDisplay.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: aglab2.StarDisplay
+PackageVersion: "1.41"
+PackageLocale: en-US
+Publisher: aglab2
+PackageName: Star Display
+PackageUrl: https://github.com/aglab2/SM64StarDisplay
+License: GPL-3.0-or-later
+Copyright: © aglab2 2025.
+ShortDescription: A tool that reads Super Mario 64 game memory to display acquired Stars, Keys, and Caps during casual playthroughs, highlighting the current level.
+Moniker: stardisplay
+Tags:
+- mario
+- mario-64
+- overlay
+- romhack
+- sm64
+- speedrun
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/a/aglab2/StarDisplay/1.41/aglab2.StarDisplay.yaml
+++ b/manifests/a/aglab2/StarDisplay/1.41/aglab2.StarDisplay.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: aglab2.StarDisplay
+PackageVersion: "1.41"
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/aglab2.StarDisplay.json
+++ b/shards/json/aglab2.StarDisplay.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "aglab2", "repo": "SM64StarDisplay" },
+	"urls": ["https://github.com/aglab2/SM64StarDisplay/releases/download/{version}/StarManager.exe"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#422189

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? (no Windows environment available here; validated instead with this repo's `bun manifests:check --deny-warnings` and `bun test:manifests`, both pass)
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? (same limitation as above — untested on real Windows; relying on repo CI's `Validate` workflow)
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? (authored against the 1.12.0 schema, matching the convention used by the most recently added packages in this repo)

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Adds `aglab2.StarDisplay`, requested in #1176: a portable status overlay for casual Super Mario 64 playthroughs. It reads game memory to display acquired Stars, Keys, and Caps, and highlights the current level.

- `InstallerType: portable`, single x86 exe asset (`StarManager.exe`), pinned to release tag `1.41`
- License is GPL-3.0-or-later per the upstream repo
- Added `shards/json/aglab2.StarDisplay.json` using the `github-release` strategy for automated updates (the release asset filename and tag format are stable across recent releases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HCnxdyqA9GV1eQdeNoS1n

---
_Generated by [Claude Code](https://claude.ai/code/session_014HCnxdyqA9GV1eQdeNoS1n)_