### PR TITLE
Update version: Microsoft.VSTOR.LanguagePack version 10.0.60917

### DIFF
--- a/manifests/m/Microsoft/VSTOR/LanguagePack/10.0.60917/Microsoft.VSTOR.LanguagePack.installer.yaml
+++ b/manifests/m/Microsoft/VSTOR/LanguagePack/10.0.60917/Microsoft.VSTOR.LanguagePack.installer.yaml
@@ -16,146 +16,254 @@ Installers:
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_ara.exe
   InstallerSha256: 3A0DD57C01CFE7F861FAEF733B747B4A67B8743965C470F88FE2CBBD187E7162
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - ARA
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - ARA
 - InstallerLocale: ar
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_ara.exe
   InstallerSha256: 965AC90792E8B7AAB373845AC604D3AE71FAF265B06774418FF44D93668111EA
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ARA
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ARA
 - InstallerLocale: da
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_dan.exe
   InstallerSha256: D090646FBCE09F185A6F4E45C20243A5823AB7B71F50284F7983ACCB4D1A9477
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - DAN
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - DAN
 - InstallerLocale: da
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_dan.exe
   InstallerSha256: D76511E26B53D4FB6E3D7E17D2874A9FA3506C9B3E306B775BCC71AC23B66846
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - DAN
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - DAN
 - InstallerLocale: de
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_deu.exe
   InstallerSha256: FADDAD5BE44A1BA3FE8248D83B91862B7B6CBF65CB06C6386DF74AFE5BBEA0F5
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - DEU
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - DEU
 - InstallerLocale: de
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_deu.exe
   InstallerSha256: D5CC274BE5648759B3FDAF7E742EA2493088CAC9C7F5C1A16FE5508012D1690C
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - DEU
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - DEU
 - InstallerLocale: es
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_esn.exe
   InstallerSha256: 67A1FA0211E8A34717752A80E8CC662371579EEA15754B82B1327809ACE3D8D4
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - ESN
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - ESN
 - InstallerLocale: es
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_esn.exe
   InstallerSha256: DEEB7E8403D711ADBF7117FF29B8D441D3FEC5685B070983B119A8E886E3351F
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ESN
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ESN
 - InstallerLocale: fi
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_fin.exe
   InstallerSha256: 8F3A628C673D2C77C7A203E01AB6FFB7C0D4AD1CA837D795A2447E0F985C0E6B
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - FIN
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - FIN
 - InstallerLocale: fi
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_fin.exe
   InstallerSha256: 8135812A108B17B06B6382F9A397C9E54751F6F985A34D3DD293BF6DE2976C9B
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - FIN
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - FIN
 - InstallerLocale: fr
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_fra.exe
   InstallerSha256: 446440443B94845E21619C4670B7C3C924CE3654F818FFF72FC923E95BE4F146
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - FRA
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - FRA
 - InstallerLocale: fr
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_fra.exe
   InstallerSha256: CD87C37164F7DD5E09C0837755EFB7269C65D28D357BCE80BD8F5EC28C14851A
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - FRA
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - FRA
 - InstallerLocale: he
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_heb.exe
   InstallerSha256: F553E368BD7393E8D791F89342CE42BD1D5C7AE6BC918B6C2C0A02774CC89FAB
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - HEB
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - HEB
 - InstallerLocale: he
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_heb.exe
   InstallerSha256: D2E0220E1DC578083E24C37B1C74A5A5B2C5C21A6DD0EB24A0EA0E5AB772CC99
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - HEB
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - HEB
 - InstallerLocale: it
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_ita.exe
   InstallerSha256: E6AD84E95F40A8352C46C07D495441BB4567B82D2776BA0132950F50012851D2
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - ITA
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - ITA
 - InstallerLocale: it
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_ita.exe
   InstallerSha256: 722EBE46473294ED14A6A9C2E94BE5D5290A1BB327ADA82AC316972081D85DCE
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ITA
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ITA
 - InstallerLocale: ja
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_jpn.exe
   InstallerSha256: 3B7CB55E7A05172BC393E7E149AFC5041D6AEF54096F26052F8C6587D4A0B2B5
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - JPN
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - JPN
 - InstallerLocale: ja
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_jpn.exe
   InstallerSha256: 85AEDB9B0F6C5F2240647D4242A1BD3B025F1E389F74E52D77126DACE1598219
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - JPN
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - JPN
 - InstallerLocale: ko
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_kor.exe
   InstallerSha256: A587ABB3C061605003913A6144209F8E27CC865751A11A615A5CA03624A8FBE3
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - KOR
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - KOR
 - InstallerLocale: ko
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_kor.exe
   InstallerSha256: D71653905FA7E5DD1B858EDAF0860EB10E7B683F9EF92281387BA175E2F99ADA
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - KOR
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - KOR
 - InstallerLocale: nb
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_nor.exe
   InstallerSha256: E807476D27714AE371047A5C3F9A411478DA8D854C219E0BBD77EDD52F0345C5
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - NOR
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - NOR
 - InstallerLocale: nb
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_nor.exe
   InstallerSha256: 33031B0CE2C903F91BE1688C3DC994CE529D4202E5247B7E8CC81F9FAE3D07FD
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - NOR
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - NOR
 - InstallerLocale: nl
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_nld.exe
   InstallerSha256: 7637EA3C466B172E72DE47D433BD7AA2BE098AE52E2825BA9C78FEB122F45481
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - NLD
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - NLD
 - InstallerLocale: nl
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_nld.exe
   InstallerSha256: A7E48AFF77A33B6E2770C9005D43C61B70239339B9A7202DC4AD32C52B17CBAE
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - NLD
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - NLD
 - InstallerLocale: pl
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_plk.exe
   InstallerSha256: 20ABEE060EBC598A914B4094E3CD571946B666044B78980E9A38E900A0FC3EF9
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - PLK
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - PLK
 - InstallerLocale: pl
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_plk.exe
   InstallerSha256: 44107A2867D2BE600E1688D73ABE56A72176EB75521BFE9E5C94A09E16CB108F
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - PLK
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - PLK
 - InstallerLocale: pt-BR
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_ptb.exe
   InstallerSha256: 42C5C731084DC765C222CEF1E2E39BC5820CAF7AC23BB3B60C75F196CB598E60
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - PTB
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - PTB
 - InstallerLocale: pt-BR
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_ptb.exe
   InstallerSha256: B4B0D463D02265D426D1D4994EC286DC526C228A62CFD4BC42008A3E29AB7091
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - PTB
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - PTB
 - InstallerLocale: ru
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_rus.exe
   InstallerSha256: 2A5FA67BB3B9003A4370556D27766F56438E9911D1EFE3F32DF1B22CDDFA35AC
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - RUS
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - RUS
 - InstallerLocale: ru
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_rus.exe
   InstallerSha256: 97522CE45CF343426ED9E73303C037C3C6B847782290B98895E1DD3A4D6432C5
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - RUS
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - RUS
 - InstallerLocale: sv
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_sve.exe
   InstallerSha256: 0BF2B18C6F682319AF9BAAA992D92555DBB873E308C87725B4580FFB4739CF44
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - SVE
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - SVE
 - InstallerLocale: sv
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_sve.exe
   InstallerSha256: C6C9D79B1B707C924776CB6BDC07A57F3D464734738263C2B73D499A70DE6226
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - SVE
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - SVE
 - InstallerLocale: zh-CN
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_chs.exe
   InstallerSha256: 7E15C54C4CF1086CD81883EAF4C09343045763A210AB162A7DC60ED49EDBC2DD
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - CHS
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - CHS
 - InstallerLocale: zh-CN
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_chs.exe
   InstallerSha256: 28B14F2BAE427768DA20D4C8D4E649D8880C435224B6DF832B58E04935770DF9
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - CHS
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - CHS
 - InstallerLocale: zh-TW
   Architecture: x86
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x86_cht.exe
   InstallerSha256: 918E0C0019157902DA8744EF72E0F6F3F06FC7A1F25C294C534CD6B79CA52CB5
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - CHT
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x86) Language Pack - CHT
 - InstallerLocale: zh-TW
   Architecture: x64
   InstallerUrl: https://download.microsoft.com/download/4/a/e/4aed151e-5203-4e79-bc40-45ce7626d471/vstor40_LP_x64_cht.exe
   InstallerSha256: 6E5A8FAFF3B16E1BB80285A57B94CF55D9D9D6F595E927AEB11B3CF0A984738B
+  ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - CHT
+  AppsAndFeaturesEntries:
+  - ProductCode: Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - CHT
 ExpectedReturnCodes:
 - InstallerReturnCode: 1641
   ReturnResponse: rebootInitiated


### PR DESCRIPTION
Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - N/A

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
  - Supersedes [#1147](https://github.com/pl4nty/winget-extras/pull/1147) — see below.
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? — Linux session, no `winget`; `bun manifests:check --deny-warnings` passes instead.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — same reason; the Installation Validation jobs on this PR cover it.
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Adds `ProductCode` and a one-entry `AppsAndFeaturesEntries` to each of the 36 installers.

## Replaces #1147

The values are **byte-identical** to #1147's, minus the trailing whitespace on the `x64`/`CHS` line. #1147's product-name strings were right; this PR derives the same 36 values from the installers and confirms them against a real install, so they can be re-checked.

## Proof, from #1147's own validation run

The review question on #1147 ([comment](https://github.com/pl4nty/winget-extras/pull/1147#discussion_r3913391551)) was whether the ProductCode is really the English product name, since the validation logs showed `Microsoft Visual Studio 2010 Tools لحزمة اللغة لـ Office Runtime (x64) - ARA`. That Arabic string is the ARP entry's **DisplayName**, not its subkey name — and winget's ProductCode is the subkey name.

The Attack Surface Analyzer SARIF from #1147's own Installation Validation jobs (run `33621723729`) shows the registry after installing `vstor40_LP_x64_ara.exe`. Two ARP keys are created:

```
HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{E5E92CEB-CD48-30AF-A023-C30764707DCA}
  SystemComponent = 1                                       <-- winget skips this entry
  DisplayName     = Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ARA
  DisplayVersion  = 10.0.60917
  WindowsInstaller= 1

HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ARA
  (no SystemComponent)                                      <-- the entry winget sees
  DisplayName     = Microsoft Visual Studio 2010 Tools لحزمة اللغة لـ Office Runtime (x64) - ARA
  DisplayVersion  = 10.0.60917
  Publisher       = Microsoft Corporation
  ModifyPath      = MsiExec.exe /I {E5E92CEB-CD48-30AF-A023-C30764707DCA}
  UninstallString = "C:\Program Files\Common Files\Microsoft Shared\VSTO\10.0\Microsoft Visual Studio 2010 Tools for Office Runtime (x64) Language Pack - ARA\install.exe"
```

The x86 job shows the same pair under `SOFTWARE\Wow6432Node\...` (and mirrored into the 64-bit view), with `{FB3DDA04-7FDF-36D4-A06A-0E36FE5D3E23}` carrying `SystemComponent = 1`.

winget skips SystemComponent entries ([`ARPHelper.cpp` L418-421](https://github.com/microsoft/winget-cli/blob/master/src/AppInstallerRepositoryCore/Microsoft/ARPHelper.cpp#L418-L421)) and takes ProductCode from the surviving entry's subkey name (`productCode = arpEntry.Name()`, L396). So the ProductCode is the English string — the localised DisplayName the logs surfaced belongs to the same key but is a different value.

`DisplayName`/`Publisher`/`DisplayVersion` are deliberately omitted from `AppsAndFeaturesEntries`: every field present in an entry must match for correlation to succeed, the DisplayName is localised per language pack, and the ProductCode alone is already unique per installer.

## What the installers are

Microsoft **SFXCAB** self-extracting cabinets (`sfxcab.pdb`, `_SFX_CAB_EXE_PACKAGE`/`_SFX_CAB_SHUTDOWN_REQUEST` in `.text`) — not a custom format. The cabinet is a valid `MSCF` stream appended to the end of the `.rsrc` section, past the last resource-directory entry, so a resource-table walk does not find it but a validated `MSCF` scan does. Each cabinet holds the VS 2010 `install.exe` bootstrapper, `install.ini`, an EULA, a resource DLL, and exactly one MSI.

The `SystemComponent` flag comes from an unconditional type-51 custom action `CA_SETARPSYSTEMCOMPONENT_<arch>_<loc>` at `InstallExecuteSequence` 1501 in every one of the 36 MSIs, setting `ARPSYSTEMCOMPONENT=1`. The surviving ARP key is written by the MSI `Registry` table under component `GUID_ARP_RED_38517…`, keyed on the English product name with `DisplayName = [LocProductName]`.

<details><summary>36 MSI ProductCodes, for reference — all hidden by SystemComponent, none usable here</summary>

| Installer | MSI ProductCode |
| --- | --- |
| `vstor40_LP_x86_ara.exe` | `{FB3DDA04-7FDF-36D4-A06A-0E36FE5D3E23}` |
| `vstor40_LP_x64_ara.exe` | `{E5E92CEB-CD48-30AF-A023-C30764707DCA}` |
| `vstor40_LP_x86_dan.exe` | `{AF171DBD-9685-36C4-83EA-024A490DEC97}` |
| `vstor40_LP_x64_dan.exe` | `{9A400343-8A13-3F09-A745-3BCD63A117A9}` |
| `vstor40_LP_x86_deu.exe` | `{14EA873D-C1D6-3C11-BD36-B02789F28DA4}` |
| `vstor40_LP_x64_deu.exe` | `{F0894539-547E-346C-A799-5E758B7FF678}` |
| `vstor40_LP_x86_esn.exe` | `{B41DF412-C557-32B8-83A5-6508D523416B}` |
| `vstor40_LP_x64_esn.exe` | `{206EF976-3670-31C8-A5E2-12911652BAAC}` |
| `vstor40_LP_x86_fin.exe` | `{125D97F2-2253-3FD9-A697-7C6E39CDFC16}` |
| `vstor40_LP_x64_fin.exe` | `{696C9A54-E79E-355F-80BD-96E89C633430}` |
| `vstor40_LP_x86_fra.exe` | `{F306F510-A1B1-3DBB-9EDD-DB7ED0203182}` |
| `vstor40_LP_x64_fra.exe` | `{42954209-D7AE-375A-8E95-561A8F11A358}` |
| `vstor40_LP_x86_heb.exe` | `{0B520EFC-6089-3200-B448-ADBB8A542332}` |
| `vstor40_LP_x64_heb.exe` | `{6C7D38C9-AA18-30AC-8002-F347B82F9F60}` |
| `vstor40_LP_x86_ita.exe` | `{49AAEC2D-9EDB-374B-A921-059917B3D1DF}` |
| `vstor40_LP_x64_ita.exe` | `{961E939A-6FC8-3F17-B362-FB0CEB82E821}` |
| `vstor40_LP_x86_jpn.exe` | `{AF3ECE5C-84F4-3DE4-A874-F292085D8E44}` |
| `vstor40_LP_x64_jpn.exe` | `{78A97AFF-94FB-359E-ACB7-D55A0CF7D747}` |
| `vstor40_LP_x86_kor.exe` | `{B02DF164-5666-3F50-B4A6-9AA52D3C075B}` |
| `vstor40_LP_x64_kor.exe` | `{181FF135-5A65-376F-9611-257C564A4FD5}` |
| `vstor40_LP_x86_nor.exe` | `{82AD92D2-7FE8-3005-9B10-C6EFAB5522BF}` |
| `vstor40_LP_x64_nor.exe` | `{A67BC81A-80EA-30D0-8B1E-CEEF98BB64EA}` |
| `vstor40_LP_x86_nld.exe` | `{8FC1553F-87E8-32F7-8CB4-D35D576DD329}` |
| `vstor40_LP_x64_nld.exe` | `{46AC02BC-68B6-32FD-A360-492499BF9C9D}` |
| `vstor40_LP_x86_plk.exe` | `{23FAE020-0EDB-3864-BB2D-4827C7CACB7B}` |
| `vstor40_LP_x64_plk.exe` | `{9C520865-2EE2-36ED-8B34-4593E788E0C7}` |
| `vstor40_LP_x86_ptb.exe` | `{66DE4D3E-4616-36AA-97CE-6C835D2BBDE8}` |
| `vstor40_LP_x64_ptb.exe` | `{E54E2500-144F-3726-8E2D-D421B8F9E803}` |
| `vstor40_LP_x86_rus.exe` | `{D7A4FAB8-5B67-3726-AD54-9968BA2481B9}` |
| `vstor40_LP_x64_rus.exe` | `{F197F703-669C-3DAA-8BE2-DCC651AE0BEB}` |
| `vstor40_LP_x86_sve.exe` | `{65CA6908-2A2F-352A-928B-E1ACF5636943}` |
| `vstor40_LP_x64_sve.exe` | `{D3D8FB22-075D-37B4-94E2-F62A2DEEE225}` |
| `vstor40_LP_x86_chs.exe` | `{90203F63-255C-3CA6-9729-7A60E2078B93}` |
| `vstor40_LP_x64_chs.exe` | `{AB9296FD-ABCD-3E3C-A858-BB4DD0AC7441}` |
| `vstor40_LP_x86_cht.exe` | `{F83A2A07-192D-34F6-9DC6-18FD4C4539E4}` |
| `vstor40_LP_x64_cht.exe` | `{CCADEECD-C5BC-3471-AEF2-BDE6D84E083E}` |

All 36 share `UpgradeCode {86F51A87-483B-3FB8-AA42-F4A76FF56032}`, which is why it is not in the manifest either — it cannot distinguish the 36 installers.

</details>

## How the values were derived

For each of the 36 `InstallerUrl`s: download, verify SHA-256 against the `InstallerSha256` already in the manifest, `cabextract` the SFXCAB, then read the inner MSI's `Registry` table and take the single `…\CurrentVersion\Uninstall\<name>` subkey. All 36 verified their hash, contained exactly one MSI and exactly one Uninstall subkey, and carried the `ARPSYSTEMCOMPONENT` custom action. The `ar` pair was then cross-checked against the observed registry above; the other 34 follow the identical MSI structure.

## Known limitation, not addressed here

The surviving ARP entry's `UninstallString` is `install.exe` with no arguments, so `winget uninstall` will launch the VS 2010 maintenance UI rather than uninstalling silently. That is the installer's own metadata; nothing in the manifest can change it.

## komac

`komac analyse` (2.16.0) does not recognise SFXCAB — `Exe::new` sniffs Advanced Installer, Burn, Inno, NSIS, then Squirrel, and falls through to `InstallerType: portable` here. Given the inner MSI directly it produces the right shape. Two changes would be needed for it to handle this family end to end:

1. An `ExeType::SfxCab` arm that scans for a valid `MSCF` header and reads the cabinet — the `cab` crate is already a dependency, used by the Burn analyser.
2. `installers/msi` reading the `Registry` and `CustomAction` tables, so that an MSI which sets `ARPSYSTEMCOMPONENT=1` reports its Registry-table ARP subkey name as the ProductCode rather than the hidden `{GUID}`. Today it reads only `Property` and `Directory`.

(2) is the part that matters — without it komac would confidently emit the 36 GUIDs above, which winget never sees.

## Validation

`bun manifests:check --deny-warnings` (2360 files OK), `bun test scripts` (131 pass), `bun --bun oxfmt` clean. `bun install --frozen-lockfile` cannot run in this session — `anthelion` resolves to `github:UnownPlain/anthelion-external`, which a repo-scoped token gets a 403 for — so the linter's own deps (`@unownplain/anthelion-komac`, `ky`, `zod`, `unicode-case-folding`) were installed from the versions pinned in `bun.lock`; `package.json` and `bun.lock` are unchanged in the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WmTJbfC2ME1AuzxCcsx9YG