### PR TITLE
New package: Nvidia.SDKManager version 2.4.1.13536

### DIFF
--- a/manifests/n/Nvidia/SDKManager/2.4.1.13536/Nvidia.SDKManager.installer.yaml
+++ b/manifests/n/Nvidia/SDKManager/2.4.1.13536/Nvidia.SDKManager.installer.yaml
@@ -1,0 +1,16 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+PackageIdentifier: Nvidia.SDKManager
+PackageVersion: 2.4.1.13536
+InstallerType: exe
+InstallerSwitches:
+  Silent: -s
+  SilentWithProgress: -s
+Installers:
+- Architecture: x64
+  InstallerUrl: https://developer.nvidia.com/downloads/sdkmanager/secure/clients/sdkmanager-2.4.1.13536/NVIDIA_SDK_Manager_2.4.1.13536.exe
+  InstallerSha256: AAB8AD7A813E731FBE801C839798343BABC9BB005A05E307081729CC04019434
+  ProductCode: '{B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_SDK_Manager'
+AppsAndFeaturesEntries:
+- ProductCode: '{B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_SDK_Manager'
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/SDKManager/2.4.1.13536/Nvidia.SDKManager.locale.en-US.yaml
+++ b/manifests/n/Nvidia/SDKManager/2.4.1.13536/Nvidia.SDKManager.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Nvidia.SDKManager
+PackageVersion: 2.4.1.13536
+PackageLocale: en-US
+Publisher: NVIDIA Corporation
+PackageName: NVIDIA SDK Manager
+PackageUrl: https://developer.nvidia.com/sdk-manager
+License: Freeware
+ShortDescription: An end-to-end development environment setup solution for NVIDIA's Jetson, RAPIDS, RTX Kit, Holoscan, DeepStream, Rivermax, GXF Runtime, Video Codec, ARC-OTA, and Ethernet Switch SDKs.
+Moniker: nvidiasdkmanager
+Tags:
+- deepstream
+- holoscan
+- jetson
+- nvidia
+- nvidia-sdk-manager
+- rapids
+- rivermax
+- rtx-kit
+- sdk-manager
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/SDKManager/2.4.1.13536/Nvidia.SDKManager.yaml
+++ b/manifests/n/Nvidia/SDKManager/2.4.1.13536/Nvidia.SDKManager.yaml
@@ -1,0 +1,6 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+PackageIdentifier: Nvidia.SDKManager
+PackageVersion: 2.4.1.13536
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Nvidia.SDKManager.json
+++ b/shards/json/Nvidia.SDKManager.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://developer.download.nvidia.com/sdkmanager/redirects/sdkmanager-exe.html",
+		"regex": "NVIDIA_SDK_Manager_(?<version>\\d+(?:\\.\\d+)+)\\.exe"
+	},
+	"urls": [
+		"https://developer.nvidia.com/downloads/sdkmanager/secure/clients/sdkmanager-{version}/NVIDIA_SDK_Manager_{version}.exe"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#430386

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? Not runnable in this sandbox (no Windows/winget); manually checked against this repo's manifest-linter rules and the `1.12.0` schema convention used elsewhere in the repo. CI's `Validate` workflow will exercise the actual installer.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Same limitation as above.
- [x] Does your manifest conform to the schema used across this repo (`1.12.0`, matching all other manifests here)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

## Summary

Adds [NVIDIA SDK Manager](https://developer.nvidia.com/sdk-manager) per #1204, mirroring the manifest already submitted upstream at microsoft/winget-pkgs#430386 (adapted to this repo's conventions).

- `manifests/n/Nvidia/SDKManager/2.4.1.13536/`: version, installer, and `en-US` locale manifests
  - `InstallerSha256` was recomputed locally from the vendor download rather than copied, to confirm it's correct
- `shards/json/Nvidia.SDKManager.json`: a `page-match` shard for automated updates. The download page itself is rendered client-side, but the stable Windows redirect link (`developer.download.nvidia.com/sdkmanager/redirects/sdkmanager-exe.html`) serves a small static HTML snippet embedding the current version and installer URL, so it's used as the match target instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QVRzjxFLNC8qjRA41ESatz

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVRzjxFLNC8qjRA41ESatz)_