### PR TITLE
New package: HP.AICompanion version 2.6.1003

### DIFF
--- a/manifests/h/HP/AICompanion/2.6.1003/HP.AICompanion.installer.yaml
+++ b/manifests/h/HP/AICompanion/2.6.1003/HP.AICompanion.installer.yaml
@@ -1,0 +1,32 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: HP.AICompanion
+PackageVersion: 2.6.1003
+ReleaseDate: 2026-04-09
+MinimumOSVersion: 10.0.22000.0
+InstallerType: exe
+Platform:
+- Windows.Universal
+- Windows.Desktop
+InstallerSwitches:
+  Silent: /s
+  SilentWithProgress: /s
+Installers:
+- Architecture: x64
+  InstallerUrl: https://ftp.hp.com/pub/softpaq/sp165501-166000/sp165958.exe
+  InstallerSha256: 20991977456EE4C8DF0C1EEC9859FAA1FC2D41A2DAADF5C7400CB789E4129A6C
+PackageFamilyName: AD2F1837.HPAIExperienceCenter_v10z8vjag6ke6
+AppsAndFeaturesEntries:
+- InstallerType: msix
+ElevationRequirement: elevationRequired
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.WindowsAppRuntime.1.5
+    MinimumVersion: 1.5.9
+  - PackageIdentifier: Microsoft.VCLibs.14
+    MinimumVersion: 14.0.33519.0
+  - PackageIdentifier: Microsoft.VCLibs.Desktop.14
+    MinimumVersion: 14.0.33728.0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/HP/AICompanion/2.6.1003/HP.AICompanion.locale.en-US.yaml
+++ b/manifests/h/HP/AICompanion/2.6.1003/HP.AICompanion.locale.en-US.yaml
@@ -1,0 +1,21 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: HP.AICompanion
+PackageVersion: 2.6.1003
+PackageLocale: en-US
+Publisher: HP Inc.
+PackageName: HP AI Companion
+PackageUrl: https://support.hp.com/drivers/hp-elitebook-ultra-g1i-14-inch-notebook-next-gen-ai-pc/2102681800
+License: Proprietary
+Copyright: © 2024-2025 HP Development Company, L.P.
+ShortDescription: Get the most out of your AI PC with HP AI Companion. Elevate your everyday tasks with a collection of AI tools and solutions that can increase your productivity and keep your PC running at its best.
+Moniker: hpaicompanion
+Tags:
+- hp-ai-companion-package
+- hpaicompanionpackage
+- artificial-intelligence
+- artificialintelligence
+- 9nx5372pr99p
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/HP/AICompanion/2.6.1003/HP.AICompanion.yaml
+++ b/manifests/h/HP/AICompanion/2.6.1003/HP.AICompanion.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: HP.AICompanion
+PackageVersion: 2.6.1003
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -14,6 +14,7 @@
 			"manifests/g/GameJolt/GameJolt": "selfhosted, download.gamejolt.net only serves signed URLs that expire after 24h",
 			"manifests/h/HiguchiM/MikuMikuDance": "discontinued",
 			"manifests/h/HOIC/HOIC": "discontinued",
+			"manifests/h/HP/AICompanion": "support.hp.com blocks automated requests, and the softpaq number changes each release with no discoverable public catalog",
 			"manifests/m/MSI/TrueColor": "msi.com blocks automated requests, and download filenames carry an opaque hash",
 			"manifests/m/Microsoft/ConfigMgr/CMPivot": "selfhosted, shipped inside the Configuration Manager install",
 			"manifests/m/Microsoft/ConfigMgr/CMTrace": "selfhosted, shipped inside the Configuration Manager install",


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#430101

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? Not run locally (no Windows environment available here); this repo's `validate.yml` CI performs an equivalent installation validation and passed.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? Same as above — verified via CI instead.
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)? Uses 1.12.0, matching this repo's newest manifests; `bun manifests:check` passes.

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Fixes #1205.

Manifests generated with the Komac-anthelion fork. `InstallerSha256` was independently verified by downloading the installer and recomputing the hash.

Komac's binary analysis can't identify this exe as a silent installer that provisions an MSIX (`AD2F1837.HPAIExperienceCenter`), so it fell back to `InstallerType: portable`. I added `InstallerType: exe`, `Platform`, `InstallerSwitches`, `PackageFamilyName`, `AppsAndFeaturesEntries`, `ElevationRequirement` and `Dependencies` by hand to match the upstream winget-pkgs submission, minus `AppsAndFeaturesEntries[].PackageFamilyName` which this repo's manifest schema doesn't allow there. CI's installation validation confirms the silent install works.

No automated-update shard: `support.hp.com` blocks automated requests (Akamai bot protection) and the softpaq number in the installer URL changes every release with no discoverable public catalog for version detection — confirmed against upstream Anthelion too, which has no shard for this or other bot-protected vendors (ASRock, MSI) either. `manifests/h/HP/AICompanion` is added to the `repository/shard-coverage` ignore list instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WpB7Aj9MJ33qfq28mesLr1