### PR TITLE
New package: DocRepairProject.Agdasima version 2.002

### DIFF
--- a/fonts/d/DocRepairProject/Agdasima/2.002/DocRepairProject.Agdasima.installer.yaml
+++ b/fonts/d/DocRepairProject/Agdasima/2.002/DocRepairProject.Agdasima.installer.yaml
@@ -10,6 +10,6 @@ NestedInstallerFiles:
 Installers:
 - Architecture: neutral
   InstallerUrl: https://github.com/docrepair-fonts/agdasima-fonts/archive/c971400d774dfd6d28e7a8e34aedc3b3dfdce6f9.zip
-  InstallerSha256: DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
+  InstallerSha256: 414381CAAC8D949661DCB05AC77EAA939C796C7832E11BE7DED4ACE075A4D6B4
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/fonts/d/DocRepairProject/Agdasima/2.002/DocRepairProject.Agdasima.installer.yaml
+++ b/fonts/d/DocRepairProject/Agdasima/2.002/DocRepairProject.Agdasima.installer.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DocRepairProject.Agdasima
+PackageVersion: '2.002'
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: agdasima-fonts-c971400d774dfd6d28e7a8e34aedc3b3dfdce6f9/fonts/ttf/Agdasima-Bold.ttf
+- RelativeFilePath: agdasima-fonts-c971400d774dfd6d28e7a8e34aedc3b3dfdce6f9/fonts/ttf/Agdasima-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/docrepair-fonts/agdasima-fonts/archive/c971400d774dfd6d28e7a8e34aedc3b3dfdce6f9.zip
+  InstallerSha256: DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/d/DocRepairProject/Agdasima/2.002/DocRepairProject.Agdasima.locale.en-US.yaml
+++ b/fonts/d/DocRepairProject/Agdasima/2.002/DocRepairProject.Agdasima.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DocRepairProject.Agdasima
+PackageVersion: '2.002'
+PackageLocale: en-US
+Publisher: The DocRepair Project
+PackageName: Agdasima
+PackageUrl: https://github.com/docrepair-fonts/agdasima-fonts
+License: OFL-1.1
+LicenseUrl: https://github.com/docrepair-fonts/agdasima-fonts/blob/main/OFL.txt
+ShortDescription: A font intended to improve compliance with the ISO/IEC 29500 standard by providing fallback that minimizes text reflow in Office Open XML documents. It is based on Big Shoulders, a condensed American Gothic sans-serif font family.
+Moniker: agdasima
+Tags:
+- font
+- agdasima
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/d/DocRepairProject/Agdasima/2.002/DocRepairProject.Agdasima.yaml
+++ b/fonts/d/DocRepairProject/Agdasima/2.002/DocRepairProject.Agdasima.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DocRepairProject.Agdasima
+PackageVersion: '2.002'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/DocRepairProject.Agdasima.Font.json
+++ b/shards/json/DocRepairProject.Agdasima.Font.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-commit",
+	"github": {
+		"owner": "docrepair-fonts",
+		"repo": "agdasima-fonts",
+		"path": "fonts/ttf"
+	},
+	"version": { "source": "fontVersion" },
+	"urls": [
+		{
+			"url": "https://github.com/docrepair-fonts/agdasima-fonts/archive/{github.commit}.zip",
+			"nestedInstallerMatches": ["fonts/ttf/Agdasima-"]
+		}
+	],
+	"state": { "source": "value", "value": "{github.commit}" }
+}


### PR DESCRIPTION
Fixes #1209

Adds the Agdasima font from [docrepair-fonts/agdasima-fonts](https://github.com/docrepair-fonts/agdasima-fonts), pinned to the commit given in the issue (`c971400`). Also adds a `github-commit` shard for automatic future updates.

**`InstallerSha256` is a placeholder (`DEADBEEF...`) and needs to be replaced with the real hash before merge.** This session's GitHub access is scoped to `pl4nty/winget-extras` only, so `komac`/`curl` can't download the installer from `docrepair-fonts/agdasima-fonts` (via `codeload.github.com`, `github.com`, or the GitHub API) to compute it — every attempt returns a 403 from this session's own network policy, not from GitHub. The intent is for the validation CI run to fail on the hash mismatch and report the real SHA256 in its logs, which can then be substituted in.

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Not applicable — fonts aren't accepted into winget-pkgs (per the issue).

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`? — not run (no Windows in this environment); `bun manifests:check` and `bun test:manifests` pass.
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`? — not run; blocked on the real `InstallerSha256` above.
- [x] Does your manifest conform to the 1.28 schema?

Note: `<path>` is the directory's name containing the manifest you're submitting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ndu1dG5RmUbt3NS9bLvvbc

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ndu1dG5RmUbt3NS9bLvvbc)_