### PR TITLE
New package: nba-emu.NanoBoyAdvance version 1.8.3

### DIFF
--- a/manifests/n/nba-emu/NanoBoyAdvance/1.8.3/nba-emu.NanoBoyAdvance.installer.yaml
+++ b/manifests/n/nba-emu/NanoBoyAdvance/1.8.3/nba-emu.NanoBoyAdvance.installer.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: nba-emu.NanoBoyAdvance
+PackageVersion: 1.8.3
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: NanoBoyAdvance.exe
+ReleaseDate: 2026-05-10
+Installers:
+- Architecture: x64
+  InstallerUrl: https://codeberg.org/nba-emu/NanoBoyAdvance/releases/download/v1.8.3/NanoBoyAdvance-Windows-x64.zip
+  InstallerSha256: 47FF4FC83AA507E319E150B39037352FEFC679EAD92F6E9C161151A1089BF9BC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/nba-emu/NanoBoyAdvance/1.8.3/nba-emu.NanoBoyAdvance.locale.en-US.yaml
+++ b/manifests/n/nba-emu/NanoBoyAdvance/1.8.3/nba-emu.NanoBoyAdvance.locale.en-US.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: nba-emu.NanoBoyAdvance
+PackageVersion: 1.8.3
+PackageLocale: en-US
+Publisher: nba-emu
+PublisherUrl: https://codeberg.org/nba-emu
+PublisherSupportUrl: https://codeberg.org/nba-emu/NanoBoyAdvance/issues
+PackageName: NanoBoyAdvance
+PackageUrl: https://codeberg.org/nba-emu/NanoBoyAdvance
+License: GPL-3.0-or-later
+LicenseUrl: https://codeberg.org/nba-emu/NanoBoyAdvance/src/branch/master/LICENSE
+ShortDescription: A cycle-accurate Game Boy Advance emulator. It aims to be as accurate as possible, while also offering enhancements such as improved audio quality.
+Moniker: nanoboyadvance
+Tags:
+- emulator
+- game-boy-advance
+- gameboyadvance
+- gba
+- nintendo
+ReleaseNotesUrl: https://codeberg.org/nba-emu/NanoBoyAdvance/releases/tag/v1.8.3
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/nba-emu/NanoBoyAdvance/1.8.3/nba-emu.NanoBoyAdvance.yaml
+++ b/manifests/n/nba-emu/NanoBoyAdvance/1.8.3/nba-emu.NanoBoyAdvance.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: nba-emu.NanoBoyAdvance
+PackageVersion: 1.8.3
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/nba-emu.NanoBoyAdvance.json
+++ b/shards/json/nba-emu.NanoBoyAdvance.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "json",
+	"json": {
+		"url": "https://codeberg.org/api/v1/repos/nba-emu/NanoBoyAdvance/releases/latest",
+		"path": "tag_name"
+	},
+	"urls": [
+		"https://codeberg.org/nba-emu/NanoBoyAdvance/releases/download/v{version}/NanoBoyAdvance-Windows-x64.zip"
+	]
+}


### PR DESCRIPTION
Fixes #1210

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#430462

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Upstream is hosted on Codeberg, so the shard uses the `json` strategy against the Codeberg releases API (`tag_name`) rather than `github-release`.

`License` is `GPL-3.0-or-later` per the `SPDX-License-Identifier` headers in the sources; the issue's plain `GPL-3.0` is a deprecated SPDX identifier and is rejected by `manifests:check`.

Validated with `bun fmt`, `bun manifests:check --deny-warnings` and `bun test:manifests --deny-warnings`. `bun lint` and `bun test:shard` could not run here: the `anthelion` dependency resolves to `UnownPlain/anthelion-external`, which this environment's egress policy blocks (403). The shard was instead checked against the published Anthelion JSON schema, and its resolved URL confirmed to match the manifest installer URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BixJUsSGik7FiGWRYy3TJP

---
_Generated by [Claude Code](https://claude.ai/code/session_01BixJUsSGik7FiGWRYy3TJP)_