### PR TITLE
New package: Nvidia.PersonalAIRouter version 0.1.1

### DIFF
--- a/.agents/skills/new-package-pr/SKILL.md
+++ b/.agents/skills/new-package-pr/SKILL.md
@@ -14,7 +14,28 @@ Download the latest release for your platform from
 on `PATH`. Extract a `.tar.zst` asset with `tar --zstd -xf`, installing `zstd` from your system
 package manager if it is missing.
 
-## 2. Generate manifests
+## 2. Find every installer
+
+A request gives one URL; it is a starting point, not the set. Before generating anything, work
+out every Windows installer the vendor ships for that version — each architecture (`x64`,
+`arm64`, `x86`) and each scope (machine and user) — and pass them all in one `--urls`, so a
+single manifest carries every installer. Shipping only the requested URL silently leaves those
+users unable to install.
+
+The GitHub API and a release's HTML asset list are both `403` for repos outside the session's
+scope, so enumerate by probing instead: `curl -sSL -o /dev/null -w '%{http_code}' -r 0-0 <url>`
+returns `206` for an asset that exists and `404` for one that doesn't. Vary the architecture
+token in the filename you were given. For an electron-builder app, `latest.yml` and
+`latest-arm64.yml` sit beside the installers and name every file with its size and sha512 —
+fetch them and check the sha512 of what you downloaded against them.
+
+Take the architecture from the filename and the vendor's own metadata, never from the outer
+installer stub: electron-builder's NSIS stub is 32-bit x86 for every build, so `komac analyze`
+reports `x86` for an arm64 asset. Record `Scope` and `ElevationRequirement` when the evidence is
+there — `isAdminRightsRequired: true` in `latest*.yml`, or `requestedExecutionLevel` in the
+stub's PE manifest, means `Scope: machine` and `ElevationRequirement: elevationRequired`.
+
+## 3. Generate manifests
 
 From the repo root:
 
@@ -38,10 +59,11 @@ every `--urls` entry to hash it: `releases/download/...` resolves for any public
 the session's scope, and `add_repo` does not change that. Prefer a release asset. If the
 installer can't be downloaded, stop — never invent a hash.
 
-## 3. Add a shard
+## 4. Add a shard
 
 `shards/json/<PackageIdentifier>.json`, or `shards/script/<PackageIdentifier>.ts` if JSON
-can't express it; append `.Font` for fonts. Schema and strategies:
+can't express it; append `.Font` for fonts. Its `urls` must list every installer the manifest
+carries, or the next version bump drops the ones it omits. Schema and strategies:
 [Anthelion CONTRIBUTING.md](https://github.com/UnownPlain/anthelion/blob/main/CONTRIBUTING.md),
 [AGENTS.md](https://github.com/UnownPlain/anthelion/blob/main/AGENTS.md). Script shards import
 `anthelion`, `anthelion/github`, `anthelion/helpers` — copy an existing `shards/script/` file.
@@ -49,14 +71,14 @@ can't express it; append `.Font` for fonts. Schema and strategies:
 Only if no strategy works, add the package directory to `ignore["repository/shard-coverage"]`
 in `scripts/manifest-linter/config.json` with a reason.
 
-## 4. Validate
+## 5. Validate
 
 ```sh
 bun fmt
 bun manifests:check --deny-warnings
 ```
 
-## 5. PR
+## 6. PR
 
 Title and commit subject: `New package: <PackageIdentifier> version <PackageVersion>`
 

--- a/.agents/skills/new-package-pr/SKILL.md
+++ b/.agents/skills/new-package-pr/SKILL.md
@@ -9,31 +9,14 @@ description: >-
 
 ## 1. Get komac
 
-Download the latest release for your platform from
-[devicie/Komac-anthelion](https://github.com/devicie/Komac-anthelion/releases) and put `komac`
-on `PATH`. Extract a `.tar.zst` asset with `tar --zstd -xf`, installing `zstd` from your system
+Download https://github.com/devicie/Komac-anthelion/releases/download/v0.0.65/komac-0.0.65-x86_64-unknown-linux-musl.tar.zst and put `komac`
+on `PATH`. Extract with `tar --zstd -xf`, installing `zstd` from your system
 package manager if it is missing.
 
 ## 2. Find every installer
 
-A request gives one URL; it is a starting point, not the set. Before generating anything, work
-out every Windows installer the vendor ships for that version — each architecture (`x64`,
-`arm64`, `x86`) and each scope (machine and user) — and pass them all in one `--urls`, so a
-single manifest carries every installer. Shipping only the requested URL silently leaves those
-users unable to install.
-
-The GitHub API and a release's HTML asset list are both `403` for repos outside the session's
-scope, so enumerate by probing instead: `curl -sSL -o /dev/null -w '%{http_code}' -r 0-0 <url>`
-returns `206` for an asset that exists and `404` for one that doesn't. Vary the architecture
-token in the filename you were given. For an electron-builder app, `latest.yml` and
-`latest-arm64.yml` sit beside the installers and name every file with its size and sha512 —
-fetch them and check the sha512 of what you downloaded against them.
-
-Take the architecture from the filename and the vendor's own metadata, never from the outer
-installer stub: electron-builder's NSIS stub is 32-bit x86 for every build, so `komac analyze`
-reports `x86` for an arm64 asset. Record `Scope` and `ElevationRequirement` when the evidence is
-there — `isAdminRightsRequired: true` in `latest*.yml`, or `requestedExecutionLevel` in the
-stub's PE manifest, means `Scope: machine` and `ElevationRequirement: elevationRequired`.
+Find every Windows installer for the version (all architectures, scopes, etc), and pass them all in one `--urls`, so a
+single manifest carries every installer.
 
 ## 3. Generate manifests
 
@@ -57,16 +40,15 @@ authenticated path that needs GraphQL, which those environments block. And komac
 every `--urls` entry to hash it: `releases/download/...` resolves for any public repo, but
 `/archive/*.zip`, `raw.githubusercontent.com` and the GitHub API return `403` for repos outside
 the session's scope, and `add_repo` does not change that. Prefer a release asset. If the
-installer can't be downloaded, stop — never invent a hash.
+installer can't be downloaded, stop - never invent a hash.
 
 ## 4. Add a shard
 
 `shards/json/<PackageIdentifier>.json`, or `shards/script/<PackageIdentifier>.ts` if JSON
 can't express it; append `.Font` for fonts. Its `urls` must list every installer the manifest
 carries, or the next version bump drops the ones it omits. Schema and strategies:
-[Anthelion CONTRIBUTING.md](https://github.com/UnownPlain/anthelion/blob/main/CONTRIBUTING.md),
-[AGENTS.md](https://github.com/UnownPlain/anthelion/blob/main/AGENTS.md). Script shards import
-`anthelion`, `anthelion/github`, `anthelion/helpers` — copy an existing `shards/script/` file.
+[Anthelion CONTRIBUTING.md](https://github.com/UnownPlain/anthelion/blob/main/CONTRIBUTING.md). Script shards import
+`anthelion`, `anthelion/github`, `anthelion/helpers` - copy an existing `shards/script/` file.
 
 Only if no strategy works, add the package directory to `ignore["repository/shard-coverage"]`
 in `scripts/manifest-linter/config.json` with a reason.
@@ -88,4 +70,4 @@ for a decision a reviewer would query. Keep the diff to manifests, shard or conf
 any `version-state/` seed.
 
 Then action CI failures and review comments until CI is green. Never comment on the PR or
-reply to a review — put anything a reviewer needs into the PR body instead, concisely.
+reply to a review - put anything a reviewer needs into the PR body instead, concisely.

--- a/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.installer.yaml
+++ b/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.installer.yaml
@@ -3,11 +3,10 @@
 
 PackageIdentifier: Nvidia.PersonalAIRouter
 PackageVersion: 0.1.1
-InstallerLocale: en-US
 InstallerType: nullsoft
 Scope: machine
 ProductCode: eafd1530-9af3-5c5d-bb19-0b27768efdac
-ReleaseDate: 2026-08-29
+ReleaseDate: 2026-08-28
 AppsAndFeaturesEntries:
 - ProductCode: eafd1530-9af3-5c5d-bb19-0b27768efdac
 ElevationRequirement: elevationRequired

--- a/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.installer.yaml
+++ b/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.installer.yaml
@@ -1,0 +1,17 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.PersonalAIRouter
+PackageVersion: 0.1.1
+InstallerLocale: en-US
+InstallerType: nullsoft
+ProductCode: eafd1530-9af3-5c5d-bb19-0b27768efdac
+ReleaseDate: 2026-08-29
+AppsAndFeaturesEntries:
+- ProductCode: eafd1530-9af3-5c5d-bb19-0b27768efdac
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/NVIDIA/Personal-AI-Router/releases/download/v0.1.1/NVPAIR-Setup-0.1.1-x64.exe
+  InstallerSha256: 96655D2366C35067378CDEA58FF640BD7E736B4CE0AD9614756A0CDAEF61E57F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.installer.yaml
+++ b/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.installer.yaml
@@ -5,13 +5,18 @@ PackageIdentifier: Nvidia.PersonalAIRouter
 PackageVersion: 0.1.1
 InstallerLocale: en-US
 InstallerType: nullsoft
+Scope: machine
 ProductCode: eafd1530-9af3-5c5d-bb19-0b27768efdac
 ReleaseDate: 2026-08-29
 AppsAndFeaturesEntries:
 - ProductCode: eafd1530-9af3-5c5d-bb19-0b27768efdac
+ElevationRequirement: elevationRequired
 Installers:
 - Architecture: x64
   InstallerUrl: https://github.com/NVIDIA/Personal-AI-Router/releases/download/v0.1.1/NVPAIR-Setup-0.1.1-x64.exe
   InstallerSha256: 96655D2366C35067378CDEA58FF640BD7E736B4CE0AD9614756A0CDAEF61E57F
+- Architecture: arm64
+  InstallerUrl: https://github.com/NVIDIA/Personal-AI-Router/releases/download/v0.1.1/NVPAIR-Setup-0.1.1-arm64.exe
+  InstallerSha256: 597F248838A47BAA0E6A2A8817230D99C1E5A93287B4C3F0CE0B234CF21E241B
 ManifestType: installer
 ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.locale.en-US.yaml
+++ b/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.locale.en-US.yaml
@@ -1,0 +1,25 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.PersonalAIRouter
+PackageVersion: 0.1.1
+PackageLocale: en-US
+Publisher: NVIDIA
+PublisherUrl: https://github.com/NVIDIA
+PublisherSupportUrl: https://github.com/NVIDIA/Personal-AI-Router/issues
+PackageName: Personal AI Router
+PackageUrl: https://github.com/NVIDIA/Personal-AI-Router
+License: Apache-2.0
+LicenseUrl: https://github.com/NVIDIA/Personal-AI-Router/blob/main/LICENSE
+Copyright: © 2026 NVIDIA.
+ShortDescription: A local inference router for a group of compatible computers on the same network. It discovers participating nodes, manages supported inference engines, and presents Ollama- and OpenAI-compatible proxy endpoints to applications and agents.
+Moniker: nvpair
+Tags:
+- ai
+- inference
+- llm
+- ollama
+- openai
+ReleaseNotesUrl: https://github.com/NVIDIA/Personal-AI-Router/releases/tag/v0.1.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.yaml
+++ b/manifests/n/Nvidia/PersonalAIRouter/0.1.1/Nvidia.PersonalAIRouter.yaml
@@ -1,0 +1,8 @@
+# Created with Claude Code using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.PersonalAIRouter
+PackageVersion: 0.1.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Nvidia.PersonalAIRouter.json
+++ b/shards/json/Nvidia.PersonalAIRouter.json
@@ -6,6 +6,7 @@
 		"repo": "Personal-AI-Router"
 	},
 	"urls": [
-		"https://github.com/NVIDIA/Personal-AI-Router/releases/download/v{version}/NVPAIR-Setup-{version}-x64.exe"
+		"https://github.com/NVIDIA/Personal-AI-Router/releases/download/v{version}/NVPAIR-Setup-{version}-x64.exe",
+		"https://github.com/NVIDIA/Personal-AI-Router/releases/download/v{version}/NVPAIR-Setup-{version}-arm64.exe"
 	]
 }

--- a/shards/json/Nvidia.PersonalAIRouter.json
+++ b/shards/json/Nvidia.PersonalAIRouter.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": {
+		"owner": "NVIDIA",
+		"repo": "Personal-AI-Router"
+	},
+	"urls": [
+		"https://github.com/NVIDIA/Personal-AI-Router/releases/download/v{version}/NVPAIR-Setup-{version}-x64.exe"
+	]
+}


### PR DESCRIPTION
Fixes #1219

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#429685

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Blocked upstream on an almost-certainly-false-positive Microsoft Defender detection.

The release ships x64 and arm64 installers; the request only linked x64. `Scope: machine` and
`ElevationRequirement: elevationRequired` come from `requestedExecutionLevel="requireAdministrator"`
in both stubs and `isAdminRightsRequired: true` in both `latest*.yml`.

`PackageName` is `Personal AI Router` and `Copyright` `© 2026 NVIDIA`, from the installer's version
resources rather than the request's `NVIDIA Personal AI Router`, so the ARP entry matches. `Moniker`,
`Tags`, `PackageUrl` and `ReleaseNotesUrl` were filled in by hand because the GitHub API komac reads
them from is `403` for out-of-scope repos in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012nHBT6gEKAznayyrt8YNeJ