### PR TITLE
New package: Samsung.AndroidUSBDriver version 1.9.5.0

### DIFF
--- a/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.installer.yaml
+++ b/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.installer.yaml
@@ -4,7 +4,12 @@
 PackageIdentifier: Samsung.AndroidUSBDriver
 PackageVersion: 1.9.5.0
 InstallerType: nullsoft
+Scope: machine
+InstallModes:
+- interactive
+UpgradeBehavior: install
 ReleaseDate: 2026-05-06
+ElevationRequirement: elevatesSelf
 Installers:
 - Architecture: x86
   InstallerUrl: https://developer.samsung.com/SDP/file/a2fcaf64-7aa3-49f7-b06f-9e646590d528

--- a/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.installer.yaml
+++ b/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.installer.yaml
@@ -1,0 +1,13 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Samsung.AndroidUSBDriver
+PackageVersion: 1.9.5.0
+InstallerType: nullsoft
+ReleaseDate: 2026-05-06
+Installers:
+- Architecture: x86
+  InstallerUrl: https://developer.samsung.com/SDP/file/a2fcaf64-7aa3-49f7-b06f-9e646590d528
+  InstallerSha256: 0ECC9E47D836A7CFF7215EC9CDF33DC7F3E416A7D5EDEDAD522B978B2EB84A20
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.installer.yaml
+++ b/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.installer.yaml
@@ -5,9 +5,9 @@ PackageIdentifier: Samsung.AndroidUSBDriver
 PackageVersion: 1.9.5.0
 InstallerType: nullsoft
 Scope: machine
-InstallModes:
-- interactive
-UpgradeBehavior: install
+InstallerSwitches:
+  Silent: -s -no_chk_inst_ui -quiet -force_inst
+  SilentWithProgress: -s -no_chk_inst_ui -quiet -force_inst
 ReleaseDate: 2026-05-06
 ElevationRequirement: elevatesSelf
 Installers:

--- a/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.locale.en-US.yaml
+++ b/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.locale.en-US.yaml
@@ -1,0 +1,22 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Samsung.AndroidUSBDriver
+PackageVersion: 1.9.5.0
+PackageLocale: en-US
+Publisher: Samsung Electronics Co., Ltd
+PackageName: Samsung Android USB Driver for Windows
+PackageUrl: https://developer.samsung.com/android-usb-driver
+License: Proprietary
+Copyright: Samsung Electronics Co., Ltd. All Rights Reserved
+ShortDescription: USB driver for connecting Samsung Android devices to a Windows development environment.
+Description: You need the driver only if you are developing on Windows and want to connect a Samsung Android device to your development environment over USB.
+Moniker: samsungandroidusbdriver
+Tags:
+- adb
+- android
+- driver
+- samsung
+- usb
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.yaml
+++ b/manifests/s/Samsung/AndroidUSBDriver/1.9.5.0/Samsung.AndroidUSBDriver.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Samsung.AndroidUSBDriver
+PackageVersion: 1.9.5.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Samsung.AndroidUSBDriver.json
+++ b/shards/json/Samsung.AndroidUSBDriver.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://developer.samsung.com/android-usb-driver",
+		"regex": "data-original-title=\"Samsung Android USB Driver for Windows v(?<version>\\d+(?:\\.\\d+)+)\"[^>]*href=\"/SDP/file/(?<id>[0-9a-f-]+)\""
+	},
+	"urls": ["https://developer.samsung.com/SDP/file/{captures.id}"]
+}


### PR DESCRIPTION
Fixes #1224

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#409360 (closed by its author)

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---

Manifests generated with Anthelion komac 2.16.0; `bun manifests:check --deny-warnings` passes. Windows-only tooling (`winget validate` / `winget install`) wasn't available in this Linux environment.

**Installer switches.** The default nullsoft `/S` fails with `ShellExecute installer failed: 8`. Decompiling the outer installer (NSIS 3.06.1) shows why: on the `/S` path it runs a preflight `"$INSTDIR\Setup.exe" -chk_inst_ui -user ...`, accepts only exit codes `0x105`/`0x106`/`0x107`, and otherwise calls `SetErrorLevel` with that code and quits — `Setup.exe` returned 8 on the runner. The wrapper parses its own switches instead, so the manifest overrides `Silent`/`SilentWithProgress` with `-s -no_chk_inst_ui -quiet -force_inst`: `-no_chk_inst_ui` skips that preflight, and the rest drive the bundled `Setup.exe` quietly. This is the same combination the [Chocolatey package](https://community.chocolatey.org/packages/samsung-usb-driver) for this installer has used since 2020.

Also set from the installer's own metadata: `Scope: machine` and `ElevationRequirement: elevatesSelf` (the NSIS and inner `Setup.exe` PE manifests both request `requireAdministrator`).

**Shard.** The `SDP/file/<uuid>` download URL is per-file, so the shard uses `page-match` on the download page to capture both the version and the file UUID from the download anchor, then templates the installer URL with `{captures.id}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UZ1yDv8V8axk93GBKbwW3D