### PR TITLE
New package: Nvidia.NVIDIAApp version 11.0.9.251

### DIFF
--- a/manifests/n/Nvidia/NVIDIAApp/11.0.9.251/Nvidia.NVIDIAApp.installer.yaml
+++ b/manifests/n/Nvidia/NVIDIAApp/11.0.9.251/Nvidia.NVIDIAApp.installer.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.NVIDIAApp
+PackageVersion: 11.0.9.251
+InstallerType: exe
+Scope: machine
+InstallerSwitches:
+  Silent: -s
+  SilentWithProgress: -s
+ExpectedReturnCodes:
+- InstallerReturnCode: 3858759680
+  ReturnResponse: systemNotSupported
+ElevationRequirement: elevationRequired
+ProductCode: '{B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_Display.NvApp'
+ReleaseDate: 2026-08-31
+AppsAndFeaturesEntries:
+- ProductCode: '{B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_Display.NvApp'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://us.download.nvidia.com/nvapp/client/11.0.9.251/NVIDIA_app_v11.0.9.251.exe
+  InstallerSha256: 0A43D4BD1B676B85816F893D345FA130BC7C00453D09654317799147F3B61D9C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/NVIDIAApp/11.0.9.251/Nvidia.NVIDIAApp.locale.en-US.yaml
+++ b/manifests/n/Nvidia/NVIDIAApp/11.0.9.251/Nvidia.NVIDIAApp.locale.en-US.yaml
@@ -1,0 +1,35 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.NVIDIAApp
+PackageVersion: 11.0.9.251
+PackageLocale: en-US
+Publisher: NVIDIA Corporation
+PublisherUrl: https://www.nvidia.com/
+PublisherSupportUrl: https://www.nvidia.com/en-us/support/
+PackageName: NVIDIA App
+PackageUrl: https://www.nvidia.com/en-us/software/nvidia-app/
+License: Freeware
+LicenseUrl: https://www.nvidia.com/en-us/drivers/nvidia-license/
+Copyright: © 2011-2025 NVIDIA Corporation.
+ShortDescription: A companion for NVIDIA-using PC gamers and creators. Optimize games and apps with a new unified GPU control center, powerful recording tools through the in-game overlay, and discover the latest NVIDIA tools and software.
+Description: |-
+  A companion for NVIDIA-using PC gamers and creators. Optimize games and apps with a new unified GPU control center, powerful recording tools through the in-game overlay, and discover the latest NVIDIA tools and software.
+
+  The app replaces GeForce Experience and the NVIDIA Control Panel, and installs and updates GeForce Game Ready and NVIDIA Studio drivers.
+
+  An NVIDIA GPU is required: on a machine without one the installer exits with 0xE6000000, which this manifest maps to systemNotSupported.
+Moniker: nvidiaapp
+Tags:
+- dlss
+- drivers
+- gaming
+- geforce
+- gpu
+- graphics
+- nvidia
+- optimization
+- recording
+- rtx
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/NVIDIAApp/11.0.9.251/Nvidia.NVIDIAApp.yaml
+++ b/manifests/n/Nvidia/NVIDIAApp/11.0.9.251/Nvidia.NVIDIAApp.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.NVIDIAApp
+PackageVersion: 11.0.9.251
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Nvidia.NVIDIAApp.json
+++ b/shards/json/Nvidia.NVIDIAApp.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://www.nvidia.com/en-us/software/nvidia-app/",
+		"regex": "NVIDIA_app_v(?<version>\\d+(?:\\.\\d+)+)\\.exe"
+	},
+	"urls": ["https://us.download.nvidia.com/nvapp/client/{version}/NVIDIA_app_v{version}.exe"]
+}


### PR DESCRIPTION
Fixes #1226

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#353183, closed because winget-pkgs does not accept packages that require specific hardware

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Identifier follows the casing winget-pkgs settled on in microsoft/winget-pkgs#353183, and the publisher directory already in this repo.

The installer is a 7-Zip SFX around NVIDIA's `setup.exe`, so it takes the same `-s` silent switch as the driver packages and its PE manifest requests `requireAdministrator`. On a machine with no NVIDIA GPU it exits with `0xE6000000` (required hardware not present) — the failure that blocked the winget-pkgs submission — so that code is mapped to `systemNotSupported` here, alongside the ARP `ProductCode` from the request.

The shard reads the version straight off the download page, which carries the versioned installer URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QMp7zUAEkwTnXN8ms5LV67

---
_Generated by [Claude Code](https://claude.ai/code/session_01QMp7zUAEkwTnXN8ms5LV67)_