### PR TITLE
New package: Nvidia.Nsight.Systems version 26.4.1.191

### DIFF
--- a/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.installer.yaml
+++ b/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.installer.yaml
@@ -1,0 +1,21 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.Nsight.Systems
+PackageVersion: 26.4.1.191
+InstallerType: wix
+Scope: machine
+ProductCode: '{FB12A7CF-4737-4473-8D36-9AFA3E0BC863}'
+ReleaseDate: 2026-07-28
+AppsAndFeaturesEntries:
+- DisplayName: NVIDIA Nsight Systems 2026.4.1
+  ProductCode: '{FB12A7CF-4737-4473-8D36-9AFA3E0BC863}'
+  UpgradeCode: '{0F2F933C-91D8-8955-1CAF-E4942DCC2253}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/NVIDIA Corporation/Nsight Systems 2026.4.1'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://developer.nvidia.com/downloads/assets/tools/secure/nsight-systems/2026_4/NsightSystems-2026.4.1.191-3860507.msi
+  InstallerSha256: 3D28E92B23FC28508E38E9DC7268168F4083F9EDA613D58252BE1DBE6B49E103
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.installer.yaml
+++ b/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.installer.yaml
@@ -8,8 +8,7 @@ Scope: machine
 ProductCode: '{FB12A7CF-4737-4473-8D36-9AFA3E0BC863}'
 ReleaseDate: 2026-07-28
 AppsAndFeaturesEntries:
-- DisplayName: NVIDIA Nsight Systems 2026.4.1
-  ProductCode: '{FB12A7CF-4737-4473-8D36-9AFA3E0BC863}'
+- ProductCode: '{FB12A7CF-4737-4473-8D36-9AFA3E0BC863}'
   UpgradeCode: '{0F2F933C-91D8-8955-1CAF-E4942DCC2253}'
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%/NVIDIA Corporation/Nsight Systems 2026.4.1'

--- a/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.locale.en-US.yaml
+++ b/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.locale.en-US.yaml
@@ -7,7 +7,7 @@ PackageLocale: en-US
 Publisher: NVIDIA Corporation
 PublisherUrl: https://www.nvidia.com/
 PublisherSupportUrl: https://forums.developer.nvidia.com/c/development-tools/nsight-systems/116
-PackageName: Nsight Systems
+PackageName: NVIDIA Nsight Systems
 PackageUrl: https://developer.nvidia.com/nsight-systems
 License: Proprietary
 LicenseUrl: https://docs.nvidia.com/nsight-systems/CopyrightAndLicenses/index.html

--- a/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.locale.en-US.yaml
+++ b/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.locale.en-US.yaml
@@ -1,0 +1,30 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.Nsight.Systems
+PackageVersion: 26.4.1.191
+PackageLocale: en-US
+Publisher: NVIDIA Corporation
+PublisherUrl: https://www.nvidia.com/
+PublisherSupportUrl: https://forums.developer.nvidia.com/c/development-tools/nsight-systems/116
+PackageName: Nsight Systems
+PackageUrl: https://developer.nvidia.com/nsight-systems
+License: Proprietary
+LicenseUrl: https://docs.nvidia.com/nsight-systems/CopyrightAndLicenses/index.html
+ShortDescription: A system-wide performance analysis tool designed to visualize an application's algorithm, help you select the largest opportunities to optimize, and tune to scale efficiently across any quantity of CPUs and GPUs in your computer.
+Description: |-
+  A system-wide performance analysis tool designed to visualize an application's algorithm, help you select the largest opportunities to optimize, and tune to scale efficiently across any quantity of CPUs and GPUs in your computer.
+
+  Nsight Systems traces CPU, GPU, OS runtime, CUDA, NVTX, and graphics API activity on a unified timeline, and can profile local and remote Windows and Linux targets. Profiling targets are limited to x86-64 on Windows.
+Moniker: nsight-systems
+Tags:
+- cuda
+- gpu
+- nsight
+- nvidia
+- nvtx
+- performance
+- profiler
+- tracing
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.yaml
+++ b/manifests/n/Nvidia/Nsight/Systems/26.4.1.191/Nvidia.Nsight.Systems.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Nvidia.Nsight.Systems
+PackageVersion: 26.4.1.191
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Nvidia.Nsight.Systems.json
+++ b/shards/json/Nvidia.Nsight.Systems.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://developer.nvidia.com/nsight-systems/get-started",
+		"regex": "(?<url>https://developer\\.nvidia\\.com/downloads/assets/tools/secure/nsight-systems/\\d{4}_\\d+/NsightSystems-20(?<version>\\d+(?:\\.\\d+)+)-\\d+\\.msi)"
+	},
+	"urls": ["{captures.url}"]
+}


### PR DESCRIPTION
Fixes #1232

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#340157 (closed after repeated `-2147467260` validation failures, per microsoft/winget-pkgs#333811)

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

The request listed version `26.1.1.204` but linked the `2026.4.1.191-3860507` installer, so this packages the linked build. `26.4.1.191` is the MSI's `ProductVersion` — NVIDIA ships the `20xx.y.z.b` marketing version as `xx.y.z.b` in the MSI because an MSI version's major field caps at 255. That matches the version scheme of the closed winget-pkgs PR (`26.1.1.204` for `2026.1.1.204`).

The vendor page offers only one Windows installer (x64 MSI); the other assets are Linux and macOS. The shard captures the whole URL rather than templating it, since the `2026_4` directory and the `3860507` build number aren't derivable from the version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTvEtJh9MiSVJjwQiRg26X

---
_Generated by [Claude Code](https://claude.ai/code/session_01TTvEtJh9MiSVJjwQiRg26X)_