### PR TITLE
New package: Google.Noto.SansCJK.JP version 2.004

### DIFF
--- a/fonts/g/Google/Noto/SansCJK/JP/2.004/Google.Noto.SansCJK.JP.installer.yaml
+++ b/fonts/g/Google/Noto/SansCJK/JP/2.004/Google.Noto.SansCJK.JP.installer.yaml
@@ -1,0 +1,22 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Google.Noto.SansCJK.JP
+PackageVersion: '2.004'
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: NotoSansCJKjp-Black.otf
+- RelativeFilePath: NotoSansCJKjp-Bold.otf
+- RelativeFilePath: NotoSansCJKjp-DemiLight.otf
+- RelativeFilePath: NotoSansCJKjp-Light.otf
+- RelativeFilePath: NotoSansCJKjp-Medium.otf
+- RelativeFilePath: NotoSansCJKjp-Regular.otf
+- RelativeFilePath: NotoSansCJKjp-Thin.otf
+ReleaseDate: 2022-03-20
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/06_NotoSansCJKjp.zip
+  InstallerSha256: BF5B26FEB83EE02533D4EB4A127BD90ED9D42BDD7CA7CB6E4030B2F21EF55CC5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/g/Google/Noto/SansCJK/JP/2.004/Google.Noto.SansCJK.JP.locale.en-US.yaml
+++ b/fonts/g/Google/Noto/SansCJK/JP/2.004/Google.Noto.SansCJK.JP.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Google.Noto.SansCJK.JP
+PackageVersion: '2.004'
+PackageLocale: en-US
+Publisher: Google
+PublisherUrl: https://fonts.google.com/
+PublisherSupportUrl: https://github.com/notofonts/noto-cjk/issues
+Author: Google
+PackageName: Noto Sans CJK JP
+PackageUrl: https://github.com/notofonts/noto-cjk
+License: OFL-1.1
+LicenseUrl: https://github.com/notofonts/noto-cjk/blob/HEAD/LICENSE
+ShortDescription: The Japanese font that is part of the Google Noto Sans CJK project.
+Description: Noto Sans CJK JP is the Japanese language-specific subset of Noto Sans CJK, the sans serif Pan-CJK typeface family from the Noto CJK project. It ships seven weights of OpenType/CFF fonts covering Japanese text, and installing it alone avoids pulling in the Simplified Chinese, Traditional Chinese and Korean fonts that the combined Noto Sans CJK package provides.
+Moniker: noto-sans-cjk-jp
+ReleaseNotesUrl: https://github.com/notofonts/noto-cjk/releases/tag/Sans2.004
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/g/Google/Noto/SansCJK/JP/2.004/Google.Noto.SansCJK.JP.yaml
+++ b/fonts/g/Google/Noto/SansCJK/JP/2.004/Google.Noto.SansCJK.JP.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Google.Noto.SansCJK.JP
+PackageVersion: '2.004'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Google.Noto.SansCJK.JP.Font.json
+++ b/shards/json/Google.Noto.SansCJK.JP.Font.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": {
+		"owner": "notofonts",
+		"repo": "noto-cjk",
+		"tagFilter": "Sans"
+	},
+	"urls": [
+		"https://github.com/notofonts/noto-cjk/releases/download/{github.rawTag}/06_NotoSansCJKjp.zip"
+	]
+}


### PR DESCRIPTION
Fixes #1241

Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - No related winget-pkgs issue or pull request; the request was filed here only.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

The request asked for `NotoSansCJKjp-VF.otf` from `raw.githubusercontent.com`. This manifest uses the `06_NotoSansCJKjp.zip` release asset instead, for two reasons: it is the Japanese language-specific set the request actually wants (7 static weights, no other CJK languages), and the Sans2.004 release notes warn that Windows mishandles CFF2 variable fonts badly enough to corrupt text, recommending against the `-VF` files on Windows. It also mirrors how `Adobe.SourceHanSans.LanguageSpecific.Japanese` is packaged.

Shard is `github-release` with `tagFilter: Sans`, matching the existing `Google.Noto.SansCJK.Font.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkAuE4QqZW85AhzviCKwRe

---
_Generated by [Claude Code](https://claude.ai/code/session_01GkAuE4QqZW85AhzviCKwRe)_