### PR TITLE
New packages: five winget-pkgs requests that can't be added upstream

### DIFF
--- a/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.installer.yaml
+++ b/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.installer.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 0xJacky.nginx-ui
+PackageVersion: 2.5.10
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: nginx-ui.exe
+ReleaseDate: 2026-08-21
+Commands:
+- nginx-ui
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/0xJacky/nginx-ui/releases/download/v2.5.10/nginx-ui-windows-32.zip
+  InstallerSha256: F8573DB336A8A1FE43B3A307DBE153ECE3AB05EFA7E5CA6B8C96E315CECA36F8
+- Architecture: x64
+  InstallerUrl: https://github.com/0xJacky/nginx-ui/releases/download/v2.5.10/nginx-ui-windows-64.zip
+  InstallerSha256: 15863594288A9275832320EF19797A48F9A62464A5288AA8195DAF2B45C6A46D
+- Architecture: arm64
+  InstallerUrl: https://github.com/0xJacky/nginx-ui/releases/download/v2.5.10/nginx-ui-windows-arm64-v8a.zip
+  InstallerSha256: 8D4E2F11B2FFEBC788259F839E603FDF57D0FCB6B8CB6BD26194C6BEF13A66F0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.locale.en-US.yaml
+++ b/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 0xJacky.nginx-ui
+PackageVersion: 2.5.10
+PackageLocale: en-US
+Publisher: 0xJacky
+PublisherUrl: https://nginxui.com/
+PublisherSupportUrl: https://github.com/0xJacky/nginx-ui/issues
+Author: 0xJacky
+PackageName: Nginx UI
+PackageUrl: https://github.com/0xJacky/nginx-ui
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/0xJacky/nginx-ui/blob/master/LICENSE
+ShortDescription: Yet another WebUI for Nginx
+Moniker: nginx-ui
+ReleaseNotesUrl: https://github.com/0xJacky/nginx-ui/releases/tag/v2.5.10
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.yaml
+++ b/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 0xJacky.nginx-ui
+PackageVersion: 2.5.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/e/ESET/OnlineScanner/3.7.11.0/ESET.OnlineScanner.installer.yaml
+++ b/manifests/e/ESET/OnlineScanner/3.7.11.0/ESET.OnlineScanner.installer.yaml
@@ -1,0 +1,15 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ESET.OnlineScanner
+PackageVersion: 3.7.11.0
+InstallerType: portable
+ReleaseDate: 2026-07-09
+Commands:
+- esetonlinescanner
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.eset.com/com/eset/tools/online_scanner/latest/esetonlinescanner.exe
+  InstallerSha256: D43D70E6AEBE0A5E34FC767D046993375921C23D39EA3FEB79DE90CEECD617F7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/ESET/OnlineScanner/3.7.11.0/ESET.OnlineScanner.locale.en-US.yaml
+++ b/manifests/e/ESET/OnlineScanner/3.7.11.0/ESET.OnlineScanner.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ESET.OnlineScanner
+PackageVersion: 3.7.11.0
+PackageLocale: en-US
+Publisher: ESET, spol. s r.o.
+PublisherUrl: https://www.eset.com/
+PublisherSupportUrl: https://support.eset.com/
+Author: ESET, spol. s r.o.
+PackageName: ESET Online Scanner
+PackageUrl: https://www.eset.com/int/home/online-scanner/
+License: Proprietary
+LicenseUrl: https://www.eset.com/int/eula/
+Copyright: © ESET, spol. s r.o. 1992-2026. All rights reserved.
+ShortDescription: Free one-time scanner that removes malware from a Windows computer
+Moniker: esetonlinescanner
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/ESET/OnlineScanner/3.7.11.0/ESET.OnlineScanner.yaml
+++ b/manifests/e/ESET/OnlineScanner/3.7.11.0/ESET.OnlineScanner.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ESET.OnlineScanner
+PackageVersion: 3.7.11.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/g/go-gost/Gost/3.3.0/go-gost.Gost.installer.yaml
+++ b/manifests/g/go-gost/Gost/3.3.0/go-gost.Gost.installer.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: go-gost.Gost
+PackageVersion: 3.3.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: gost.exe
+ReleaseDate: 2026-08-30
+Commands:
+- gost
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/go-gost/gost/releases/download/v3.3.0/gost_3.3.0_windows_386.zip
+  InstallerSha256: 5DB2E0E5941508BA4650075371FBCDF90B6908AFF186DB437EFC1535518C62F6
+- Architecture: x64
+  InstallerUrl: https://github.com/go-gost/gost/releases/download/v3.3.0/gost_3.3.0_windows_amd64.zip
+  InstallerSha256: CC8AC946F86994A3AED47EF1F838CFB6B7649D9245C91FCB9899654B33D61170
+- Architecture: arm64
+  InstallerUrl: https://github.com/go-gost/gost/releases/download/v3.3.0/gost_3.3.0_windows_arm64.zip
+  InstallerSha256: F423E10B0E5FAC02CA1D2294E008BAB16480938055E7620AF27ABA319979CCAC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/g/go-gost/Gost/3.3.0/go-gost.Gost.locale.en-US.yaml
+++ b/manifests/g/go-gost/Gost/3.3.0/go-gost.Gost.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: go-gost.Gost
+PackageVersion: 3.3.0
+PackageLocale: en-US
+Publisher: go-gost
+PublisherUrl: https://github.com/go-gost
+PublisherSupportUrl: https://github.com/go-gost/gost/issues
+Author: go-gost
+PackageName: GO Simple Tunnel
+PackageUrl: https://github.com/go-gost/gost
+License: MIT
+LicenseUrl: https://github.com/go-gost/gost/blob/master/LICENSE
+ShortDescription: A simple security tunnel written in Go
+Moniker: gost
+ReleaseNotesUrl: https://github.com/go-gost/gost/releases/tag/v3.3.0
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/g/go-gost/Gost/3.3.0/go-gost.Gost.yaml
+++ b/manifests/g/go-gost/Gost/3.3.0/go-gost.Gost.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: go-gost.Gost
+PackageVersion: 3.3.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.installer.yaml
+++ b/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.installer.yaml
@@ -1,0 +1,15 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: k0sproject.k0sctl
+PackageVersion: 0.32.2
+InstallerType: portable
+ReleaseDate: 2026-07-28
+Commands:
+- k0sctl
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/k0sproject/k0sctl/releases/download/v0.32.2/k0sctl-win-amd64.exe
+  InstallerSha256: 3D06CCA961BA0BD2571836A19F6A67A9C2B44FE0D5684944028393265562B467
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.locale.en-US.yaml
+++ b/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: k0sproject.k0sctl
+PackageVersion: 0.32.2
+PackageLocale: en-US
+Publisher: k0sproject
+PublisherUrl: https://k0sproject.io/
+PublisherSupportUrl: https://github.com/k0sproject/k0sctl/issues
+Author: k0sproject
+PackageName: k0sctl
+PackageUrl: https://github.com/k0sproject/k0sctl
+License: Apache-2.0
+LicenseUrl: https://github.com/k0sproject/k0sctl/blob/main/LICENSE
+ShortDescription: A bootstrapping and management tool for k0s clusters
+Moniker: k0sctl
+ReleaseNotesUrl: https://github.com/k0sproject/k0sctl/releases/tag/v0.32.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.yaml
+++ b/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: k0sproject.k0sctl
+PackageVersion: 0.32.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.installer.yaml
+++ b/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.installer.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Uotan-Dev.UotanToolboxNT
+PackageVersion: 3.7.1
+InstallerType: portable
+ReleaseDate: 2026-07-31
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/Uotan-Dev/UotanToolboxNT/releases/download/3.7.1/UotanToolbox_Windows_x64_Installer_3.7.1.exe
+  InstallerSha256: 5B171EA1D0B174047C1133B05E4C574BF5761155CDFBCA9445E09F76A31BCD09
+- Architecture: arm64
+  InstallerUrl: https://github.com/Uotan-Dev/UotanToolboxNT/releases/download/3.7.1/UotanToolbox_Windows_arm64_Installer_3.7.1.exe
+  InstallerSha256: DB0BC10A53A57CD827496A526AB2F768FD318C34570BE98014C81404EDB40DF3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.locale.en-US.yaml
+++ b/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.locale.en-US.yaml
@@ -1,0 +1,20 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Uotan-Dev.UotanToolboxNT
+PackageVersion: 3.7.1
+PackageLocale: en-US
+Publisher: Uotan-Dev
+PublisherUrl: https://uotan.cn/
+PublisherSupportUrl: https://github.com/Uotan-Dev/UotanToolboxNT/issues
+Author: Uotan-Dev
+PackageName: UotanToolbox NT
+PackageUrl: https://toolbox.uotan.cn/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/Uotan-Dev/UotanToolboxNT/blob/master/LICENSE
+Copyright: © 2020-2026 UOTAN, All Rights Reserved.
+ShortDescription: A cross-platform toolbox for Android and OpenHarmony device management and flashing
+Moniker: uotantoolbox
+ReleaseNotesUrl: https://github.com/Uotan-Dev/UotanToolboxNT/releases/tag/3.7.1
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.yaml
+++ b/manifests/u/Uotan-Dev/UotanToolboxNT/3.7.1/Uotan-Dev.UotanToolboxNT.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Uotan-Dev.UotanToolboxNT
+PackageVersion: 3.7.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/0xJacky.nginx-ui.json
+++ b/shards/json/0xJacky.nginx-ui.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "0xJacky", "repo": "nginx-ui" },
+	"urls": [
+		"https://github.com/0xJacky/nginx-ui/releases/download/v{version}/nginx-ui-windows-32.zip",
+		"https://github.com/0xJacky/nginx-ui/releases/download/v{version}/nginx-ui-windows-64.zip",
+		"https://github.com/0xJacky/nginx-ui/releases/download/v{version}/nginx-ui-windows-arm64-v8a.zip"
+	]
+}

--- a/shards/json/ESET.OnlineScanner.json
+++ b/shards/json/ESET.OnlineScanner.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{
+			"url": "https://download.eset.com/com/eset/tools/online_scanner/latest/esetonlinescanner.exe",
+			"architecture": "x86"
+		}
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://download.eset.com/com/eset/tools/online_scanner/latest/esetonlinescanner.exe",
+		"header": "etag"
+	},
+	"replace": true
+}

--- a/shards/json/Uotan-Dev.UotanToolboxNT.json
+++ b/shards/json/Uotan-Dev.UotanToolboxNT.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "Uotan-Dev", "repo": "UotanToolboxNT" },
+	"urls": [
+		"https://github.com/Uotan-Dev/UotanToolboxNT/releases/download/{version}/UotanToolbox_Windows_x64_Installer_{version}.exe",
+		"https://github.com/Uotan-Dev/UotanToolboxNT/releases/download/{version}/UotanToolbox_Windows_arm64_Installer_{version}.exe"
+	]
+}

--- a/shards/json/go-gost.Gost.json
+++ b/shards/json/go-gost.Gost.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "go-gost", "repo": "gost" },
+	"urls": [
+		"https://github.com/go-gost/gost/releases/download/v{version}/gost_{version}_windows_386.zip",
+		"https://github.com/go-gost/gost/releases/download/v{version}/gost_{version}_windows_amd64.zip",
+		"https://github.com/go-gost/gost/releases/download/v{version}/gost_{version}_windows_arm64.zip"
+	]
+}

--- a/shards/json/k0sproject.k0sctl.json
+++ b/shards/json/k0sproject.k0sctl.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "k0sproject", "repo": "k0sctl" },
+	"urls": ["https://github.com/k0sproject/k0sctl/releases/download/v{version}/k0sctl-win-amd64.exe"]
+}


### PR DESCRIPTION
Adds five packages triaged from open `microsoft/winget-pkgs` issues and pull requests that are blocked upstream.

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#421811 (`0xJacky.nginx-ui`, Binary-Validation-Error)
  - Relates to microsoft/winget-pkgs#429325 (`go-gost.Gost`, Binary-Validation-Error)
  - Relates to microsoft/winget-pkgs#419190 (`k0sproject.k0sctl`, Binary-Validation-Error)
  - Relates to microsoft/winget-pkgs#414760 (`Uotan-Dev.UotanToolboxNT`, Binary-Validation-Error)
  - Relates to microsoft/winget-pkgs#35157 (`ESET.OnlineScanner`, Interactive-Only-Installer)

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

## Packages

| Package | Version | Upstream blocker |
| --- | --- | --- |
| `0xJacky.nginx-ui` | 2.5.10 | Binary validation false positive |
| `go-gost.Gost` | 3.3.0 | Binary validation false positive |
| `k0sproject.k0sctl` | 0.32.2 | Binary validation false positive |
| `Uotan-Dev.UotanToolboxNT` | 3.7.1 | Binary validation false positive |
| `ESET.OnlineScanner` | 3.7.11.0 | Interactive-only installer |

## Notes for reviewers

- All manifests were generated with the Anthelion fork of komac 2.16.0 from the real installer bytes; every SHA256 comes from a download, none is hand-written.
- `Commands` was added by hand to the portable and nested-portable packages, because the asset filenames (`k0sctl-win-amd64.exe`, `esetonlinescanner.exe`) would otherwise become the portable alias.
- `ESET.OnlineScanner` is served from a `latest/` URL with no version in the path. The shard follows the `Fortinet.FortiClientVPN` pattern: ETag for state, product version from the binary. No `version-state/` seed is included; the first update run will seed it.

## Dropped from this PR: `Hamrick.VueScan`

VueScan 9.8.57 was in the first push and both of its Installation Validation jobs timed out. It is not a manifest defect — the installer is 85 MB and hamrick.com serves it slowly:

- x64 reached 77,576,280 of 84,916,312 bytes before `validate.ps1`'s `WaitForExit(5 * 60 * 1000)` killed it
- arm64 reached 4,194,304 of 82,114,224 bytes in the same budget

Three ways to make it pass were considered and rejected. Declaring `InstallModes: [interactive]` would take the `expectTimeout` path, but winget never executes a `portable` installer, so the timeout is entirely download and that flag would permanently mask it. Raising the timeout in `validate.ps1` would change CI policy for every package to accommodate one. Re-running does not help: the size-versus-bandwidth shortfall is deterministic, and arm64 missed by 20x, not by a margin. If VueScan is wanted, it needs a decision about the install budget first, so it is left out rather than forced through.

## Requests reviewed but not added

Open upstream requests that are in scope for this repo but were left out, with the reason:

- Already in winget-extras: Nmap, Npcap, Equalizer APO, Ghostscript, SmartSDR, Gemini Amplifier, XyGrib, Audiveris, NetBalancer, Plex Media Server Service Wrapper, AMD Bug Report Tool, ASRock App Shop, NVIDIA app.
- Already in winget-pkgs: MiKTeX (microsoft/winget-pkgs#34998 asks for LaTeX generally; only TeX Live is still missing).
- No stable download URL: FreeFileSync (microsoft/winget-pkgs#57900, download is gated behind a form), Creative Labs audio (microsoft/winget-pkgs#16773), HiLookVision (microsoft/winget-pkgs#232482).
- Needs hardware or a vendor account to verify: Thrustmaster TARGET (microsoft/winget-pkgs#28041), Radio-SkyPipe II (microsoft/winget-pkgs#115540), Poly Lens (microsoft/winget-pkgs#231493), AMD chipset driver (microsoft/winget-pkgs#98416), AMD Ryzen Master (microsoft/winget-pkgs#27170).
- Discontinued upstream: Macrium Reflect Free (microsoft/winget-pkgs#15850).
- Still to triage: Genshin Impact (microsoft/winget-pkgs#20435), RVGL (microsoft/winget-pkgs#28835), LyX (microsoft/winget-pkgs#54476), GameRanger (microsoft/winget-pkgs#148223), LDPlayer (microsoft/winget-pkgs#153615), Cloudflare WARP beta channel (microsoft/winget-pkgs#190056), Nerd Fonts (microsoft/winget-pkgs#17547), and the remaining Binary-Validation-Error pull requests whose installers are not GitHub release assets (`Lenovo.LeAppStore`, `Tencent.QiDian`, `CollegeBoard.Bluebook`, `HubDev.HubDev`, `laurentiu021.SysManager`, `OctoWatch.OctoWatchDLP.Server`, `rgst-io.stencil`, `OsmanOnurKoc.WindhawkBackupManager`).

### NVIDIA Broadcast

Raised on this PR as another hardware-gated candidate. It checks out: NVIDIA Broadcast is in neither repo, although its predecessor `Nvidia.RTXVoice` is already in winget-pkgs. It is left out of this PR because there is no upstream request for it yet, so it falls outside the criterion this PR was built from, and because the PR is green and adding an unrelated package would widen it. Worth a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry