### PR TITLE
New package: 0xJacky.nginx-ui version 2.5.10

### DIFF
--- a/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.installer.yaml
+++ b/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.installer.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: 0xJacky.nginx-ui
+PackageVersion: 2.5.10
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: nginx-ui.exe
+ReleaseDate: 2026-08-21
+Commands:
+- nginx-ui
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/0xJacky/nginx-ui/releases/download/v2.5.10/nginx-ui-windows-32.zip
+  InstallerSha256: F8573DB336A8A1FE43B3A307DBE153ECE3AB05EFA7E5CA6B8C96E315CECA36F8
+- Architecture: x64
+  InstallerUrl: https://github.com/0xJacky/nginx-ui/releases/download/v2.5.10/nginx-ui-windows-64.zip
+  InstallerSha256: 15863594288A9275832320EF19797A48F9A62464A5288AA8195DAF2B45C6A46D
+- Architecture: arm64
+  InstallerUrl: https://github.com/0xJacky/nginx-ui/releases/download/v2.5.10/nginx-ui-windows-arm64-v8a.zip
+  InstallerSha256: 8D4E2F11B2FFEBC788259F839E603FDF57D0FCB6B8CB6BD26194C6BEF13A66F0
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.locale.en-US.yaml
+++ b/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: 0xJacky.nginx-ui
+PackageVersion: 2.5.10
+PackageLocale: en-US
+Publisher: 0xJacky
+PublisherUrl: https://nginxui.com/
+PublisherSupportUrl: https://github.com/0xJacky/nginx-ui/issues
+Author: 0xJacky
+PackageName: Nginx UI
+PackageUrl: https://github.com/0xJacky/nginx-ui
+License: AGPL-3.0-only
+LicenseUrl: https://github.com/0xJacky/nginx-ui/blob/master/LICENSE
+ShortDescription: Yet another WebUI for Nginx
+Moniker: nginx-ui
+ReleaseNotesUrl: https://github.com/0xJacky/nginx-ui/releases/tag/v2.5.10
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.yaml
+++ b/manifests/0/0xJacky/nginx-ui/2.5.10/0xJacky.nginx-ui.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: 0xJacky.nginx-ui
+PackageVersion: 2.5.10
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/0xJacky.nginx-ui.json
+++ b/shards/json/0xJacky.nginx-ui.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "0xJacky", "repo": "nginx-ui" },
+	"urls": [
+		"https://github.com/0xJacky/nginx-ui/releases/download/v{version}/nginx-ui-windows-32.zip",
+		"https://github.com/0xJacky/nginx-ui/releases/download/v{version}/nginx-ui-windows-64.zip",
+		"https://github.com/0xJacky/nginx-ui/releases/download/v{version}/nginx-ui-windows-arm64-v8a.zip"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#421811

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream by a binary validation false positive.

`Commands: nginx-ui` is set so the portable alias is `nginx-ui` rather than the archive member's path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_