### PR TITLE
New package: k0sproject.k0sctl version 0.32.2

### DIFF
--- a/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.installer.yaml
+++ b/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.installer.yaml
@@ -1,0 +1,15 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: k0sproject.k0sctl
+PackageVersion: 0.32.2
+InstallerType: portable
+ReleaseDate: 2026-07-28
+Commands:
+- k0sctl
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/k0sproject/k0sctl/releases/download/v0.32.2/k0sctl-win-amd64.exe
+  InstallerSha256: 3D06CCA961BA0BD2571836A19F6A67A9C2B44FE0D5684944028393265562B467
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.locale.en-US.yaml
+++ b/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.locale.en-US.yaml
@@ -1,0 +1,19 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: k0sproject.k0sctl
+PackageVersion: 0.32.2
+PackageLocale: en-US
+Publisher: k0sproject
+PublisherUrl: https://k0sproject.io/
+PublisherSupportUrl: https://github.com/k0sproject/k0sctl/issues
+Author: k0sproject
+PackageName: k0sctl
+PackageUrl: https://github.com/k0sproject/k0sctl
+License: Apache-2.0
+LicenseUrl: https://github.com/k0sproject/k0sctl/blob/main/LICENSE
+ShortDescription: A bootstrapping and management tool for k0s clusters
+Moniker: k0sctl
+ReleaseNotesUrl: https://github.com/k0sproject/k0sctl/releases/tag/v0.32.2
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.yaml
+++ b/manifests/k/k0sproject/k0sctl/0.32.2/k0sproject.k0sctl.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: k0sproject.k0sctl
+PackageVersion: 0.32.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/k0sproject.k0sctl.json
+++ b/shards/json/k0sproject.k0sctl.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "k0sproject", "repo": "k0sctl" },
+	"urls": ["https://github.com/k0sproject/k0sctl/releases/download/v{version}/k0sctl-win-amd64.exe"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#419190

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream by a binary validation false positive.

`Commands: k0sctl` is set so the portable alias is `k0sctl` rather than `k0sctl-win-amd64`. The release ships a Windows build for x64 only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_