### PR TITLE
New package: Creative.SoundBlasterCommand version 3.4.94.00

### DIFF
--- a/manifests/c/Creative/SoundBlasterCommand/3.4.94.00/Creative.SoundBlasterCommand.installer.yaml
+++ b/manifests/c/Creative/SoundBlasterCommand/3.4.94.00/Creative.SoundBlasterCommand.installer.yaml
@@ -1,0 +1,25 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Creative.SoundBlasterCommand
+PackageVersion: 3.4.94.00
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+ProductCode: G3Master_is1
+ReleaseDate: 2020-11-13
+AppsAndFeaturesEntries:
+- Publisher: Creative Technology Ltd.
+  ProductCode: G3Master_is1
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Creative\Sound Blaster Command'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://files.creative.com/manualdn/Drivers/100337/e7DhBdRr2t/USBCMDMasterInstaller_3.4.94.00.exe
+  InstallerSha256: EC2A8E7F5BC3CA46F3BBDB72224133A3342A4049E9ECEDB16D1330709936FD15
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Creative/SoundBlasterCommand/3.4.94.00/Creative.SoundBlasterCommand.locale.en-US.yaml
+++ b/manifests/c/Creative/SoundBlasterCommand/3.4.94.00/Creative.SoundBlasterCommand.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Creative.SoundBlasterCommand
+PackageVersion: 3.4.94.00
+PackageLocale: en-US
+Publisher: Creative Technology Ltd
+PublisherUrl: https://us.creative.com/
+PublisherSupportUrl: https://support.creative.com/
+PackageName: Sound Blaster Command
+PackageUrl: https://us.creative.com/
+License: Proprietary
+LicenseUrl: https://support.creative.com/downloads/download.aspx?nDownloadId=100337
+Copyright: © Creative Technology Ltd., 2016-2020. All Rights Reserved.
+ShortDescription: Control software and USB audio drivers for Creative Sound Blaster devices
+Moniker: soundblastercommand
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Creative/SoundBlasterCommand/3.4.94.00/Creative.SoundBlasterCommand.yaml
+++ b/manifests/c/Creative/SoundBlasterCommand/3.4.94.00/Creative.SoundBlasterCommand.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Creative.SoundBlasterCommand
+PackageVersion: 3.4.94.00
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -67,7 +67,8 @@
 			"fonts/v/VileR/BigBlueTerminal": "discontinued",
 			"fonts/a/antijingoist/OpenDyslexic": "official ZIP archive endpoints currently return HTTP 500. working downloads are separate OTF files",
 			"fonts/l/larsenwork/Monoid": "discontinued",
-			"fonts/g/gheyret/UKIJTuz": "discontinued"
+			"fonts/g/gheyret/UKIJTuz": "discontinued",
+			"manifests/c/Creative/SoundBlasterCommand": "selfhosted, files.creative.com download URLs carry a per-release opaque token that cannot be derived from the version"
 		},
 		"repository/upstream-versions": {
 			"manifests/m/Microsoft/VisualStudioCode/**": "upstream updates are frequently blocked on approval from vscode maintainers",


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#16773

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream as an interactive-only download.

The download is published as `USBCMDMasterInstaller_3.4.94.00.exe`, but its Apps and Features entry and install location both name the product Sound Blaster Command, so the identifier follows the product rather than the filename.

No shard: `files.creative.com` download URLs carry a per-release opaque path segment (`/100337/e7DhBdRr2t/`) that cannot be derived from the version, so the package is listed in `repository/shard-coverage` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_