### PR TITLE
New package: Macrium.Reflect version 10.0.8944.0

### DIFF
--- a/manifests/m/Macrium/Reflect/10.0.8944.0/Macrium.Reflect.installer.yaml
+++ b/manifests/m/Macrium/Reflect/10.0.8944.0/Macrium.Reflect.installer.yaml
@@ -1,0 +1,15 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Macrium.Reflect
+PackageVersion: 10.0.8944.0
+InstallerType: exe
+InstallModes:
+- interactive
+ReleaseDate: 2026-08-19
+Installers:
+- Architecture: x86
+  InstallerUrl: https://updates.macrium.com/reflect/v10/ReflectDLHF.exe
+  InstallerSha256: 3B0F470A0A08CB05688162CA52A13ED2398818DF9A92498363D62CB8EDB8F60B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Macrium/Reflect/10.0.8944.0/Macrium.Reflect.locale.en-US.yaml
+++ b/manifests/m/Macrium/Reflect/10.0.8944.0/Macrium.Reflect.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Macrium.Reflect
+PackageVersion: 10.0.8944.0
+PackageLocale: en-US
+Publisher: Paramount Software UK Ltd
+PublisherUrl: https://www.macrium.com/
+PublisherSupportUrl: https://forum.macrium.com/
+PackageName: Macrium Reflect
+PackageUrl: https://www.macrium.com/
+License: Proprietary
+LicenseUrl: https://www.macrium.com/legal/eula
+Copyright: © Paramount Software.  All rights reserved.
+ShortDescription: Disk imaging, cloning and backup software
+Moniker: macriumreflect
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Macrium/Reflect/10.0.8944.0/Macrium.Reflect.yaml
+++ b/manifests/m/Macrium/Reflect/10.0.8944.0/Macrium.Reflect.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Macrium.Reflect
+PackageVersion: 10.0.8944.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Macrium.Reflect.json
+++ b/shards/json/Macrium.Reflect.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": ["https://updates.macrium.com/reflect/v10/ReflectDLHF.exe"],
+	"state": {
+		"source": "response-header",
+		"url": "https://updates.macrium.com/reflect/v10/ReflectDLHF.exe",
+		"header": "etag"
+	},
+	"replace": true
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#15850

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream as an interactive-only installer.

The upstream request names Reflect Free, which is discontinued. This packages the current v10 line from `updates.macrium.com/reflect/v10/`. Note `download.macrium.com` returns 403 to every path including `/`, with an identical 244-byte body regardless of headers, so it is not a user-agent block; `updates.macrium.com` serves the same agent and is used instead.

`ReflectDLHF.exe` is the "Macrium Reflect Package Download" agent: it fetches the real installer and then runs a wizard. Komac classifies it `portable`, which is corrected to `exe` with `InstallModes: [interactive]` — as `portable` WinGet would drop a `ReflectDLHF` shim on PATH instead of running the installer, which is not what this binary is for.

`ElevationRequirement` is left unset, now on evidence rather than absence of it: the embedded application manifest requests `<requestedExecutionLevel level="asInvoker" uiAccess="false">`, so the agent itself does not ask for elevation.

The agent's URL carries no version, so the shard follows the `Fortinet.FortiClientVPN` pattern: ETag for state, product version read from the binary, `replace: true`.

---

## On replacing the downloader with a full installer, or driving it silently

### A full installer is licence-gated, and here is the exact mechanism

The agent builds its download URL from this template, recovered from the binary's UTF-16 strings:

```
%s://updates.macrium.com/reflect/v%d/getmsi.asp?major=%d&minor=%d&build=%d&
    edition=%d&lkey=%s&arch=%d&osmajor=%d&osminor=%d&osbuild=%d
```

`getmsi.asp` answers with the installer details:

```xml
<install>
  <valid>False</valid>
  <standarderror>False</standarderror>
  <verify>N</verify>
  <filename></filename>
  <version></version>
  <message show="N"></message>
  <newKey></newKey>
  <url></url>
</install>
```

`<url>` and `<filename>` are what a manifest would need. I swept the endpoint at the current build (`major=10&minor=0&build=8944`) across `arch` in {0, 1, 2, 64, 86} × `edition` in {5 Free, 6 Home, 7 Workstation}, with real `osmajor/osminor/osbuild` values. Every combination returns `valid=False` and an empty `<url>`. The parameter that is missing is `lkey` — the licence key. The HTML variant of the same call (`&manual=Y&redirect=Y`) renders "Download Request Failed".

The other endpoints agree: `install.asp` returns `License key is required`, `UpdateInstall.asp` returns `Product key required`, and `action=check` succeeds but carries no URL at all. `action=` values of `trial`, `trialactivate`, `download`, `getinstaller`, `installer` and `url` all fall back to the licence-key form. Under `/reflect/v10/` and `/reflect/v8/` the only paths that return 200 are the two agent stubs, `ReflectDLHF.exe` and `ReflectDL.exe`; directory listing is 403 and the obvious installer names 404.

So there is no unlicensed installer to point a manifest at, on either the v10 or the v8 line.

### Correction to what this PR previously claimed about silent switches

The earlier revision said the agent has "no argument handling". **That was wrong**, and the error was mine — I searched only for switch spellings, not for a parser. The binary contains an MFC command-line parser class, `CReflectDLCommandLineInfo` (from the RTTI descriptor `.?AVCReflectDLCommandLineInfo@@`, alongside `.?AVCCommandLineInfo@@`), so the agent does parse a command line.

What I could not establish is which parameters it accepts. Two literals sit directly beside the agent's own startup banner:

```
Macrium Reflect download agent %s | Architecture: %s | Loglevel: %d |
DLBT | 07 Workstation | 08 Server | 09 Server Plus |
DLBF | NoPrompt | Software\Macrium\Reflect\FreeReg | 05 Free | …
```

`NoPrompt` and `Loglevel` are plausible switches, but `NoPrompt` is adjacent to a registry path and may equally be a registry value name, and I have no Windows host to test either against. Treat both as unverified.

It does not change the outcome regardless: even a fully silent agent still has to obtain the installer through `getmsi.asp`, which needs a key a manifest cannot carry.

### Where that leaves the package

Neither of the two things you asked for is achievable. The remaining choices are yours:

1. Keep it as an interactive downloader — this repo already carries interactive-only packages, but it is still a stub rather than the product.
2. Close the PR as a package that cannot meet the bar.
3. Package the v8 Free line instead — a different product and version rather than a fix to this one, and the v8 endpoints are key-gated in the same way, so its installer would have to come from somewhere other than `updates.macrium.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry
