### PR TITLE
New package: LyX.LyX version 2.5.2

### DIFF
--- a/manifests/l/LyX/LyX/2.5.2/LyX.LyX.installer.yaml
+++ b/manifests/l/LyX/LyX/2.5.2/LyX.LyX.installer.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: LyX.LyX
+PackageVersion: 2.5.2
+InstallerType: nullsoft
+ProductCode: LyX252
+ReleaseDate: 2026-08-11
+AppsAndFeaturesEntries:
+- ProductCode: LyX252
+Installers:
+- Architecture: x64
+  InstallerUrl: https://lyx.mirror.garr.it/bin/2.5.2/LyX-252-Installer-1-x64.exe
+  InstallerSha256: FB47B383745FAD68F5981AEB01CF9E661F9155853A19C691EAB910C5FD06736B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/LyX/LyX/2.5.2/LyX.LyX.installer.yaml
+++ b/manifests/l/LyX/LyX/2.5.2/LyX.LyX.installer.yaml
@@ -4,6 +4,8 @@
 PackageIdentifier: LyX.LyX
 PackageVersion: 2.5.2
 InstallerType: nullsoft
+InstallModes:
+- interactive
 ProductCode: LyX252
 ReleaseDate: 2026-08-11
 AppsAndFeaturesEntries:

--- a/manifests/l/LyX/LyX/2.5.2/LyX.LyX.locale.en-US.yaml
+++ b/manifests/l/LyX/LyX/2.5.2/LyX.LyX.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: LyX.LyX
+PackageVersion: 2.5.2
+PackageLocale: en-US
+Publisher: LyX Team
+PublisherUrl: https://www.lyx.org/
+PublisherSupportUrl: https://www.lyx.org/MailingLists
+PackageName: LyX
+PackageUrl: https://www.lyx.org/
+License: GPL-2.0-or-later
+LicenseUrl: https://www.lyx.org/Licensing
+Copyright: LyX is © 1995 by Matthias Ettrich, 1995-2020 by the LyX Team.
+ShortDescription: A document processor that combines a WYSIWYM interface with the power of TeX
+Moniker: lyx
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/LyX/LyX/2.5.2/LyX.LyX.yaml
+++ b/manifests/l/LyX/LyX/2.5.2/LyX.LyX.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: LyX.LyX
+PackageVersion: 2.5.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/LyX.LyX.json
+++ b/shards/json/LyX.LyX.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://www.lyx.org/Download",
+		"regex": "(?<url>https://lyx\\.mirror\\.garr\\.it/bin/(?<version>\\d+(?:\\.\\d+)+)/LyX-\\d+-Installer-\\d+-x64\\.exe)"
+	},
+	"urls": ["{captures.url}"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#54476

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

winget-pkgs carries `LyX.LyX` but cannot keep it current: the upstream issue is an Interactive-Only-Installer "outdated" report, not a missing-package request. This adds 2.5.2.

The URL is the one lyx.org/Download itself publishes (`lyx.mirror.garr.it`) rather than a mirror of my choosing, and the shard captures that whole URL the way `Nvidia.Nsight.Systems` does — the filename compresses the version to `252` and carries a separate installer revision (`-1-`), so neither can be templated from `{version}` alone. The regex was checked against the live page: one match, resolving to 2.5.2.

### The validation screenshot error, and what it turned into

The screenshot you flagged showed a modal titled *LyX 2.5.2 Setup* reading **The file "latex.exe" is not in the specified path**. That was the installer, not the app: LyX probes for a LaTeX distribution even under NSIS `/S`, and a bare runner has none. The `InstallModes: [interactive]` on that revision made `validate.ps1` treat the resulting block as the expected interactive-only timeout, so the check went green for the wrong reason. That label was wrong on its own terms too — upstream's `LyX.LyX` 2.4.4.1 carries no such label, and the installer is an ordinary silent NSIS one once its prerequisite is present.

Dropped `InstallModes` and declared the real requirement instead:

```yaml
Dependencies:
  PackageDependencies:
  - PackageIdentifier: MiKTeX.MiKTeX
```

LyX used to ship a Bundle installer with MiKTeX included, which would have avoided the dependency, but 2.5.2 publishes only the plain installer — `LyX-252-Bundle-1-x64.exe` 404s and the mirror directory lists `LyX-252-Installer-1-x64.exe` alone.

That worked as far as it goes. On the current run winget resolved and installed `MiKTeX.MiKTeX` 25.12, then downloaded and hash-verified LyX, and the `latex.exe` error is gone. **Installation Validation is still red**, and the new screenshot shows why — a different dialog, and this one is MiKTeX's, not LyX's:

> **Package Installation** — This required file could not be found: `accents.sty`. The file is a part of this package: `accents`. The package will be retrieved from this source: `<Random package repository>` … `Install` / `Cancel`

LyX's post-install configuration invokes LaTeX; LaTeX pulls in `accents.sty`; Basic MiKTeX does not ship it and its on-the-fly package installer asks before fetching. Installed non-interactively by winget, MiKTeX leaves that prompt at "ask me first", so the install waits on a click nobody makes and hits `validate.ps1`'s five-minute `WaitForExit`.

Timings from the run, for whoever picks this up:

| | |
| --- | --- |
| winget starts | 05:35:21 |
| MiKTeX download + install | 05:35:25 – 05:37:22 |
| LyX download | 05:37:23 – 05:37:30 |
| LyX install starts | 05:37:30 |
| `Install timed out` | 05:40:28 |

So MiKTeX spends about two of the five minutes and LyX's own install gets roughly three. The dialog is the proximate blocker; the budget would only become the question once the dialog is gone.

### What I have not changed, and why

Nothing in a manifest can set MiKTeX's on-the-fly policy — it is machine configuration, not an installer switch. The fix belongs in `validate.ps1`, which would need to turn auto-install on after a MiKTeX dependency lands, along the lines of `initexmf --set-config-value=[MPM]AutoInstall=1`. The `--set-config-value=[section]valuename=value` form is straight from the initexmf manual; I could not confirm the `[MPM]AutoInstall` key itself on the current docs pages, so treat the exact key as unverified. Either way `validate.ps1` is shared CI and yours to change, so I have not touched it.

The manifest as it stands is correct and strictly better than upstream's, which declares no LaTeX dependency at all. A user whose MiKTeX is already configured to install packages on the fly — the default when MiKTeX is installed interactively — gets a clean silent install. Options if you would rather not carry a red check: land it red, hold it until `validate.ps1` configures MiKTeX, or tell me to put `InstallModes: [interactive]` back, which I would rather not do since it is not true of the installer.

If Installation Validation cannot reach `lyx.mirror.garr.it`, the fix is to repoint at another LyX mirror — `ftp.lip6.fr/pub/lyx/bin/2.5.2/` carries the same file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry
