### PR TITLE
New package: ReVoltGL.RVGL version 23.1030a1

### DIFF
--- a/manifests/r/ReVoltGL/RVGL/23.1030a1/ReVoltGL.RVGL.installer.yaml
+++ b/manifests/r/ReVoltGL/RVGL/23.1030a1/ReVoltGL.RVGL.installer.yaml
@@ -1,0 +1,21 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ReVoltGL.RVGL
+PackageVersion: 23.1030a1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: rvgl.exe
+ReleaseDate: 2023-10-30
+Commands:
+- rvgl
+Installers:
+- Architecture: x86
+  InstallerUrl: https://distribute.re-volt.io/releases/rvgl_full_win32_original.zip
+  InstallerSha256: 96F81025E7FFBCAA996834AAD153CC9E59DBF151C2C825B4E24EBA690B305928
+- Architecture: x64
+  InstallerUrl: https://distribute.re-volt.io/releases/rvgl_full_win64_original.zip
+  InstallerSha256: 8AEBCABAC68A354F1CFC336DA1D0B6D3FD17CE754040FFAAA80D059B86D96A93
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/ReVoltGL/RVGL/23.1030a1/ReVoltGL.RVGL.locale.en-US.yaml
+++ b/manifests/r/ReVoltGL/RVGL/23.1030a1/ReVoltGL.RVGL.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ReVoltGL.RVGL
+PackageVersion: 23.1030a1
+PackageLocale: en-US
+Publisher: RVGL Team
+PublisherUrl: https://rvgl.org/
+PublisherSupportUrl: https://re-volt.io/
+PackageName: RVGL
+PackageUrl: https://rvgl.org/
+License: Freeware
+LicenseUrl: https://rvgl.org/
+ShortDescription: A cross-platform OpenGL port of the racing game Re-Volt
+Moniker: rvgl
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/ReVoltGL/RVGL/23.1030a1/ReVoltGL.RVGL.yaml
+++ b/manifests/r/ReVoltGL/RVGL/23.1030a1/ReVoltGL.RVGL.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ReVoltGL.RVGL
+PackageVersion: 23.1030a1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ReVoltGL.RVGL.json
+++ b/shards/json/ReVoltGL.RVGL.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://distribute.re-volt.io/",
+		"regex": "rvgl_win64 <code>\\[([^\\]]+)\\]"
+	},
+	"urls": [
+		"https://distribute.re-volt.io/releases/rvgl_full_win32_original.zip",
+		"https://distribute.re-volt.io/releases/rvgl_full_win64_original.zip"
+	],
+	"replace": true
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#28835

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream as an interactive-only installer.

Uses the `*_original` bundles (x86 and x64), which carry the game files and soundtrack as well as the engine, so the package is self-contained. Each is ~185 MB.

The download URLs carry no version. RVGL versions its component packages by date on the distribution index, so the shard reads the `rvgl_win64` package version (`23.1030a1`) from that page and sets `replace: true`, since the URLs always point at the current build.

`Commands: rvgl` is set so the portable alias is `rvgl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_