### PR TITLE
New package: Hamrick.VueScan version 9.8.57

### DIFF
--- a/manifests/h/Hamrick/VueScan/9.8.57/Hamrick.VueScan.installer.yaml
+++ b/manifests/h/Hamrick/VueScan/9.8.57/Hamrick.VueScan.installer.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Hamrick.VueScan
+PackageVersion: 9.8.57
+InstallerType: portable
+ReleaseDate: 2026-09-07
+Commands:
+- vuescan
+Installers:
+- Architecture: x64
+  InstallerUrl: https://www.hamrick.com/files/vuex6498.exe
+  InstallerSha256: C1E34837D6390FC9531ED1187AD49167D5B210AB4A282C6BE2B780E9062BE8AE
+- Architecture: arm64
+  InstallerUrl: https://www.hamrick.com/files/vuea6498.exe
+  InstallerSha256: BDA08A1EF4AB21E8EE10A0B4105D6A041273EDB3249CA9F00487319AFDD005C5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/Hamrick/VueScan/9.8.57/Hamrick.VueScan.locale.en-US.yaml
+++ b/manifests/h/Hamrick/VueScan/9.8.57/Hamrick.VueScan.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Hamrick.VueScan
+PackageVersion: 9.8.57
+PackageLocale: en-US
+Publisher: Hamrick Software
+PublisherUrl: https://www.hamrick.com/
+PublisherSupportUrl: https://www.hamrick.com/vuescan/vuescan.htm
+Author: Hamrick Software
+PackageName: VueScan
+PackageUrl: https://www.hamrick.com/
+License: Proprietary
+Copyright: © 2026 Hamrick Software.
+ShortDescription: Scanner software with support for over 7500 scanners
+Moniker: vuescan
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/Hamrick/VueScan/9.8.57/Hamrick.VueScan.yaml
+++ b/manifests/h/Hamrick/VueScan/9.8.57/Hamrick.VueScan.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Hamrick.VueScan
+PackageVersion: 9.8.57
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Hamrick.VueScan.json
+++ b/shards/json/Hamrick.VueScan.json
@@ -1,0 +1,13 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://www.hamrick.com/alternate-versions.html",
+		"regex": "vuescan-versions/((?<major>\\d+)\\.(?<minor>\\d+)\\.\\d+)\\.html"
+	},
+	"urls": [
+		"https://www.hamrick.com/files/vuex64{captures.major}{captures.minor}.exe",
+		"https://www.hamrick.com/files/vuea64{captures.major}{captures.minor}.exe"
+	],
+	"replace": true
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#63455

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream as an interactive-only installer.

**Installation Validation is expected to fail here, and that is accepted.** The installer is ~85 MB and hamrick.com serves it slowly enough that it cannot finish inside `validate.ps1`'s `WaitForExit(5 * 60 * 1000)`. On an earlier run x64 reached 77,576,280 of 84,916,312 bytes and arm64 only 4,194,304 of 82,114,224 before the budget expired. Nothing in the manifest changes that — it is the download, not the install.

`InstallModes: [interactive]` is deliberately **not** set to dodge the timeout. WinGet never executes a `portable` installer, so the timeout is purely the download; claiming interactive-only would be false and would mask the real cause permanently.

Carries x64 and arm64 only. The 32-bit build for the 9.8 series is frozen at 9.8.37 under `oldfiles/`, so publishing it under 9.8.57 would misstate its version.

The URL encodes only the major/minor series (`vuex6498.exe`), so the shard derives that segment from named capture groups on the version rather than hard-coding `98`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_