### PR TITLE
New package: RadioSky.SkyPipeII version 2.7.34

### DIFF
--- a/manifests/r/RadioSky/SkyPipeII/2.7.34/RadioSky.SkyPipeII.installer.yaml
+++ b/manifests/r/RadioSky/SkyPipeII/2.7.34/RadioSky.SkyPipeII.installer.yaml
@@ -7,8 +7,6 @@ InstallerType: inno
 Scope: machine
 InstallModes:
 - interactive
-- silent
-- silentWithProgress
 ProductCode: Radio-SkyPipe_is1
 ReleaseDate: 2018-03-02
 AppsAndFeaturesEntries:

--- a/manifests/r/RadioSky/SkyPipeII/2.7.34/RadioSky.SkyPipeII.installer.yaml
+++ b/manifests/r/RadioSky/SkyPipeII/2.7.34/RadioSky.SkyPipeII.installer.yaml
@@ -1,0 +1,25 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: RadioSky.SkyPipeII
+PackageVersion: 2.7.34
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+ProductCode: Radio-SkyPipe_is1
+ReleaseDate: 2018-03-02
+AppsAndFeaturesEntries:
+- DisplayName: Radio-SkyPipe version 2.7.34
+  ProductCode: Radio-SkyPipe_is1
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Radio-SkyPipe II'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://radiosky.com/skypipe/RSPII_Install_2_7_34.exe
+  InstallerSha256: 298A07DD335EFE43AA805A099B0E8F6A74FDB65F11E10C02B8C2F7486589D373
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/r/RadioSky/SkyPipeII/2.7.34/RadioSky.SkyPipeII.locale.en-US.yaml
+++ b/manifests/r/RadioSky/SkyPipeII/2.7.34/RadioSky.SkyPipeII.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: RadioSky.SkyPipeII
+PackageVersion: 2.7.34
+PackageLocale: en-US
+Publisher: Radio-Sky Publishing
+PublisherUrl: https://radiosky.com/
+PublisherSupportUrl: https://radiosky.com/
+PackageName: Radio-SkyPipe II
+PackageUrl: https://radiosky.com/skypipeishere.html
+License: Proprietary
+LicenseUrl: https://radiosky.com/skypipeishere.html
+Copyright: © 2012 by Radio-Sky Publishing.
+ShortDescription: Internet-enabled strip chart recorder for radio astronomy
+Moniker: skypipe
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/r/RadioSky/SkyPipeII/2.7.34/RadioSky.SkyPipeII.yaml
+++ b/manifests/r/RadioSky/SkyPipeII/2.7.34/RadioSky.SkyPipeII.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: RadioSky.SkyPipeII
+PackageVersion: 2.7.34
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/RadioSky.SkyPipeII.json
+++ b/shards/json/RadioSky.SkyPipeII.json
@@ -1,0 +1,10 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://radiosky.com/skypipeishere.html",
+		"regex": "RSPII_Install_(\\d+_\\d+_\\d+)\\.exe"
+	},
+	"version": "{version|_|.}",
+	"urls": ["https://radiosky.com/skypipe/RSPII_Install_{version|.|_}.exe"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#115540

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream as an interactive-only installer. The installer URL is the one given in the upstream request.

The filename separates the version with underscores (`RSPII_Install_2_7_34.exe`), so the shard captures that form and converts in both directions: `{version|_|.}` for `PackageVersion`, `{version|.|_}` for the URL. Checked against the live page: one match, resolving to 2.7.34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_