### PR TITLE
New package: Thrustmaster.TARGET version 3.0.26.303

### DIFF
--- a/manifests/t/Thrustmaster/TARGET/3.0.26.303/Thrustmaster.TARGET.installer.yaml
+++ b/manifests/t/Thrustmaster/TARGET/3.0.26.303/Thrustmaster.TARGET.installer.yaml
@@ -1,0 +1,38 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Thrustmaster.TARGET
+PackageVersion: 3.0.26.303
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+InstallerSwitches:
+  Silent: /s
+  SilentWithProgress: /s
+ExpectedReturnCodes:
+- InstallerReturnCode: -1
+  ReturnResponse: cancelledByUser
+- InstallerReturnCode: 1
+  ReturnResponse: invalidParameter
+- InstallerReturnCode: 1150
+  ReturnResponse: systemNotSupported
+- InstallerReturnCode: 1201
+  ReturnResponse: diskFull
+- InstallerReturnCode: 1203
+  ReturnResponse: invalidParameter
+- InstallerReturnCode: 3010
+  ReturnResponse: rebootRequiredToFinish
+ProductCode: '{8036A569-CA02-4D33-A7E9-E9BC8A482E91}'
+ReleaseDate: 2026-03-09
+AppsAndFeaturesEntries:
+- Publisher: Thrustmaster
+  ProductCode: '{8036A569-CA02-4D33-A7E9-E9BC8A482E91}'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://ts.thrustmaster.com/download/accessories/pc/hotas/software/TARGET/TARGET_v3.0.26.303.exe
+  InstallerSha256: 62E4950B15987FD3F4F8622CDA62315219678C75D788009D8D16A1B95741D179
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Thrustmaster/TARGET/3.0.26.303/Thrustmaster.TARGET.locale.en-US.yaml
+++ b/manifests/t/Thrustmaster/TARGET/3.0.26.303/Thrustmaster.TARGET.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Thrustmaster.TARGET
+PackageVersion: 3.0.26.303
+PackageLocale: en-US
+Publisher: Guillemot Corporation
+PublisherUrl: https://www.thrustmaster.com/
+PublisherSupportUrl: https://support.thrustmaster.com/
+PackageName: Thrustmaster T.A.R.G.E.T
+PackageUrl: https://support.thrustmaster.com/
+License: Proprietary
+LicenseUrl: https://support.thrustmaster.com/
+Copyright: © 2024 Flexera. All Rights Reserved.
+ShortDescription: Thrustmaster Advanced pRogramming Graphical EdiTor for HOTAS controllers
+Moniker: target
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Thrustmaster/TARGET/3.0.26.303/Thrustmaster.TARGET.yaml
+++ b/manifests/t/Thrustmaster/TARGET/3.0.26.303/Thrustmaster.TARGET.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Thrustmaster.TARGET
+PackageVersion: 3.0.26.303
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Thrustmaster.TARGET.json
+++ b/shards/json/Thrustmaster.TARGET.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://support.thrustmaster.com/en/product/t16000m-en/",
+		"regex": "(?<url>https://ts\\.thrustmaster\\.com/download/accessories/pc/hotas/software/TARGET/TARGET_v(?<version>\\d+(?:\\.\\d+)+)\\.exe)"
+	},
+	"urls": ["{captures.url}"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#28041

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream as an interactive-only installer and hardware-gated. The upstream request states the author could not find a direct download URL — it is on the joystick support pages, and this PR uses `ts.thrustmaster.com/download/accessories/pc/hotas/software/TARGET/TARGET_v3.0.26.303.exe`, found on the T.16000M product page.

This packages **3.0.26.303**, newer than the 3.0.20.826 named in the request.

The installer is InstallShield and advertises silent install, so komac read the switches, `ProductCode` and the full `ExpectedReturnCodes` table from the binary; none of that is hand-written.

The shard scrapes the T.16000M support page. TARGET is linked from every Thrustmaster HOTAS product page, so that choice is arbitrary but stable; the regex was checked against the live page and returns exactly one match.

## Installation Validation is red, and I have not guessed at a fix

All 101,948,224 bytes downloaded and the hash verified, `/s` was passed, and the installer then exited **2147753984** (`0x80042000`); winget reported `ShellExecute installer failed`. So this is neither a download problem nor a hang — the installer ran and rejected the environment.

I have not mapped that code in `ExpectedReturnCodes`, because I do not know what it means and inventing a `ReturnResponse` for it would be worse than leaving it out. Two leads for anyone with the hardware:

- The winget log shows `Reading MSI UpgradeCode`, so this is an InstallShield **MSI wrapper**. Those often need `/s /v"/qn"` rather than `/s` alone to silence the embedded MSI. I did not change the switch because komac read `/s` from the binary's own metadata, and overriding that on a hunch is more likely to break the package than fix it.
- If `0x80042000` turns out to mean "required device absent", it belongs in `ExpectedReturnCodes` as `systemNotSupported`, the same way `Nvidia.NVIDIAApp` handles its no-GPU code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry