### PR TITLE
New package: laurentiu021.SysManager version 1.75.15

### DIFF
--- a/manifests/l/laurentiu021/SysManager/1.75.15/laurentiu021.SysManager.installer.yaml
+++ b/manifests/l/laurentiu021/SysManager/1.75.15/laurentiu021.SysManager.installer.yaml
@@ -1,0 +1,15 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: laurentiu021.SysManager
+PackageVersion: 1.75.15
+InstallerType: portable
+ReleaseDate: 2026-09-01
+Commands:
+- SysManager
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/laurentiu021/SystemManager/releases/download/v1.75.15/SysManager-v1.75.15.exe
+  InstallerSha256: 5C253AD7C1D0D59775E62FE2FBDA9F454846AC8D95B29FB47F56DCFF0FD83CBF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/l/laurentiu021/SysManager/1.75.15/laurentiu021.SysManager.locale.en-US.yaml
+++ b/manifests/l/laurentiu021/SysManager/1.75.15/laurentiu021.SysManager.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: laurentiu021.SysManager
+PackageVersion: 1.75.15
+PackageLocale: en-US
+Publisher: laurentiu021
+PublisherUrl: https://github.com/laurentiu021
+PublisherSupportUrl: https://github.com/laurentiu021/SystemManager/issues
+PackageName: SysManager
+PackageUrl: https://github.com/laurentiu021/SystemManager
+License: MIT
+LicenseUrl: https://github.com/laurentiu021/SystemManager/blob/main/LICENSE
+Copyright: © 2026 laurentiu021.
+ShortDescription: Modern Windows system toolkit with network monitor, performance tuning, cleanup, battery health and process manager
+Moniker: sysmanager
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/l/laurentiu021/SysManager/1.75.15/laurentiu021.SysManager.yaml
+++ b/manifests/l/laurentiu021/SysManager/1.75.15/laurentiu021.SysManager.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: laurentiu021.SysManager
+PackageVersion: 1.75.15
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/laurentiu021.SysManager.json
+++ b/shards/json/laurentiu021.SysManager.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "laurentiu021", "repo": "SystemManager" },
+	"urls": [
+		"https://github.com/laurentiu021/SystemManager/releases/download/v{version}/SysManager-v{version}.exe"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#427204

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream by a binary validation false positive.

Note the GitHub repository is `laurentiu021/SystemManager` while the product and identifier are `SysManager`, so the shard's repo name does not match the package name.

`Commands: SysManager` is set so the portable alias is `SysManager` rather than `SysManager-v1.75.15`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_