### PR TITLE
New package: HubDev.HubDev version 1.31.1

### DIFF
--- a/manifests/h/HubDev/HubDev/1.31.1/HubDev.HubDev.installer.yaml
+++ b/manifests/h/HubDev/HubDev/1.31.1/HubDev.HubDev.installer.yaml
@@ -1,0 +1,19 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: HubDev.HubDev
+PackageVersion: 1.31.1
+InstallerType: nullsoft
+Scope: machine
+ProductCode: HubDevHubDev
+ReleaseDate: 2026-09-03
+AppsAndFeaturesEntries:
+- ProductCode: HubDevHubDev
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\HubDev\HubDev'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://apt.hubdev.io/v1.31.1/HubDev_1.31.1_Setup.exe
+  InstallerSha256: 7025CEFF68737D5BD264BC942891F9EACA4199A74FF115D51E7B060EBE1CCB7B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/HubDev/HubDev/1.31.1/HubDev.HubDev.locale.en-US.yaml
+++ b/manifests/h/HubDev/HubDev/1.31.1/HubDev.HubDev.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: HubDev.HubDev
+PackageVersion: 1.31.1
+PackageLocale: en-US
+Publisher: HubDev
+PublisherUrl: https://hubdev.io/
+PackageName: HubDev
+PackageUrl: https://hubdev.io/
+License: Proprietary
+Copyright: © .........
+ShortDescription: Hybrid development environment manager
+Moniker: hubdev
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/HubDev/HubDev/1.31.1/HubDev.HubDev.yaml
+++ b/manifests/h/HubDev/HubDev/1.31.1/HubDev.HubDev.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: HubDev.HubDev
+PackageVersion: 1.31.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -67,7 +67,8 @@
 			"fonts/v/VileR/BigBlueTerminal": "discontinued",
 			"fonts/a/antijingoist/OpenDyslexic": "official ZIP archive endpoints currently return HTTP 500. working downloads are separate OTF files",
 			"fonts/l/larsenwork/Monoid": "discontinued",
-			"fonts/g/gheyret/UKIJTuz": "discontinued"
+			"fonts/g/gheyret/UKIJTuz": "discontinued",
+			"manifests/h/HubDev/HubDev": "apt.hubdev.io serves no index and hubdev.io does not publish the version, so there is nothing to match a new release against"
 		},
 		"repository/upstream-versions": {
 			"manifests/m/Microsoft/VisualStudioCode/**": "upstream updates are frequently blocked on approval from vscode maintainers",


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#428924

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream by a binary validation false positive.

No shard: the download URL is templatable as `apt.hubdev.io/v{version}/HubDev_{version}_Setup.exe`, but there is nothing to read a new version *from*. `apt.hubdev.io` returns 404 for its root, `/latest` and `/version.json`, and hubdev.io does not publish the version number anywhere on the page. The package is listed in `repository/shard-coverage` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_