### PR TITLE
New package: CollegeBoard.Bluebook version 0.9.725

### DIFF
--- a/manifests/c/CollegeBoard/Bluebook/0.9.725/CollegeBoard.Bluebook.installer.yaml
+++ b/manifests/c/CollegeBoard/Bluebook/0.9.725/CollegeBoard.Bluebook.installer.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: CollegeBoard.Bluebook
+PackageVersion: 0.9.725
+InstallerType: nullsoft
+ProductCode: 1cbaa20e-7271-53dc-8885-e8182e6aadb3
+ReleaseDate: 2026-09-04
+AppsAndFeaturesEntries:
+- ProductCode: 1cbaa20e-7271-53dc-8885-e8182e6aadb3
+Installers:
+- Architecture: x86
+  InstallerUrl: https://bluebook.app.collegeboard.org/downloads/Bluebook%20Setup%200.9.725.exe
+  InstallerSha256: C0F45552DD6C8A16FD9ADA85B3A6EED593A6C3225EA0486B551B7500E60130C3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/CollegeBoard/Bluebook/0.9.725/CollegeBoard.Bluebook.locale.en-US.yaml
+++ b/manifests/c/CollegeBoard/Bluebook/0.9.725/CollegeBoard.Bluebook.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: CollegeBoard.Bluebook
+PackageVersion: 0.9.725
+PackageLocale: en-US
+Publisher: College Board
+PublisherUrl: https://www.collegeboard.org/
+PublisherSupportUrl: https://bluebook.collegeboard.org/students/help
+PackageName: Bluebook
+PackageUrl: https://bluebook.collegeboard.org/
+License: Proprietary
+Copyright: © 2026 College Board.
+ShortDescription: Digital testing application for students and proctors
+Moniker: bluebook
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/CollegeBoard/Bluebook/0.9.725/CollegeBoard.Bluebook.yaml
+++ b/manifests/c/CollegeBoard/Bluebook/0.9.725/CollegeBoard.Bluebook.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: CollegeBoard.Bluebook
+PackageVersion: 0.9.725
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/CollegeBoard.Bluebook.json
+++ b/shards/json/CollegeBoard.Bluebook.json
@@ -1,9 +1,7 @@
 {
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
-	"strategy": "page-match",
-	"pageMatch": {
-		"url": "https://bluebook.app.collegeboard.org/downloads/latest.yml",
-		"regex": "version:\\s*(\\d+(?:\\.\\d+)+)"
-	},
-	"urls": ["https://bluebook.app.collegeboard.org/downloads/Bluebook%20Setup%20{version}.exe"]
+	"strategy": "electron-builder",
+	"electronBuilder": {
+		"url": "https://bluebook.app.collegeboard.org/downloads/latest.yml"
+	}
 }

--- a/shards/json/CollegeBoard.Bluebook.json
+++ b/shards/json/CollegeBoard.Bluebook.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://bluebook.app.collegeboard.org/downloads/latest.yml",
+		"regex": "version:\\s*(\\d+(?:\\.\\d+)+)"
+	},
+	"urls": ["https://bluebook.app.collegeboard.org/downloads/Bluebook%20Setup%20{version}.exe"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#429229

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream by a binary validation false positive.

Bluebook is an Electron app and publishes an electron-updater feed at `downloads/latest.yml`.

**Shard corrected in 2fb735a** following review. I had used `page-match` with a hand-written `version:` regex against that `latest.yml`. Anthelion has a dedicated `electron-builder` strategy for exactly this file format, and that is the right tool — the regex approach reimplemented, less reliably, what the strategy already does:

```json
{
  "strategy": "electron-builder",
  "electronBuilder": { "url": ".../downloads/latest.yml" }
}
```

The strategy resolves the installer from `files[].url`, so the top-level `urls` override is gone too. The feed's `files[].url` is `Bluebook Setup 0.9.725.exe`, which resolves against the feed directory to the percent-encoded URL already in the manifest, so the installer URL is unchanged.

I also re-checked every other shard I have open — 31 files — for the same mistake. Bluebook was the only one pointing `page-match` at a machine-readable feed; the rest either use a dedicated strategy already or match against genuine HTML pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry