### PR TITLE
New package: Tencent.QiDian version 6.9.11.23617

### DIFF
--- a/manifests/t/Tencent/QiDian/6.9.11.23617/Tencent.QiDian.installer.yaml
+++ b/manifests/t/Tencent/QiDian/6.9.11.23617/Tencent.QiDian.installer.yaml
@@ -1,0 +1,15 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Tencent.QiDian
+PackageVersion: 6.9.11.23617
+InstallerType: exe
+InstallModes:
+- interactive
+ReleaseDate: 2026-09-07
+Installers:
+- Architecture: x86
+  InstallerUrl: https://dldir1v6.qq.com/qqfile/crm/qidian/QiDian6.9.11.23617.exe
+  InstallerSha256: 5BBF8DC0EBD047E908DD6C56AFBC81D67E78992ABBEEA0E9F522D83C805D9F3B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/t/Tencent/QiDian/6.9.11.23617/Tencent.QiDian.locale.en-US.yaml
+++ b/manifests/t/Tencent/QiDian/6.9.11.23617/Tencent.QiDian.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Tencent.QiDian
+PackageVersion: 6.9.11.23617
+PackageLocale: en-US
+Publisher: 腾讯科技(深圳)有限公司
+PublisherUrl: https://www.tencent.com/
+PublisherSupportUrl: https://qidian.qq.com/
+PackageName: 腾讯企点
+PackageUrl: https://qidian.qq.com/
+License: Proprietary
+Copyright: © 1999-2026 Tencent. All Rights Reserved.
+ShortDescription: Intelligent customer communication and operation platform
+Moniker: qidian
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/t/Tencent/QiDian/6.9.11.23617/Tencent.QiDian.yaml
+++ b/manifests/t/Tencent/QiDian/6.9.11.23617/Tencent.QiDian.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Tencent.QiDian
+PackageVersion: 6.9.11.23617
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -67,7 +67,8 @@
 			"fonts/v/VileR/BigBlueTerminal": "discontinued",
 			"fonts/a/antijingoist/OpenDyslexic": "official ZIP archive endpoints currently return HTTP 500. working downloads are separate OTF files",
 			"fonts/l/larsenwork/Monoid": "discontinued",
-			"fonts/g/gheyret/UKIJTuz": "discontinued"
+			"fonts/g/gheyret/UKIJTuz": "discontinued",
+			"manifests/t/Tencent/QiDian": "qidian.qq.com does not publish the version or a download link, and the dldir1v6.qq.com filename is the only place the version appears"
 		},
 		"repository/upstream-versions": {
 			"manifests/m/Microsoft/VisualStudioCode/**": "upstream updates are frequently blocked on approval from vscode maintainers",


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#430863

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Blocked upstream by a binary validation false positive.

Komac reports `portable` because it does not recognise the installer stub; corrected to `exe` with `InstallModes: [interactive]`, since as `portable` WinGet would drop a `QiDian6.9.11.23617` shim on PATH instead of running the installer. The ~234 MB download may not finish inside Installation Validation's five-minute budget.

No shard: the version appears only in the `dldir1v6.qq.com` filename, and qidian.qq.com publishes neither the version nor a download link, so there is nothing to match a new release against. Listed in `repository/shard-coverage` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_