### PR TITLE
New package: ryanoasis.FiraCode.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/FiraCode/NerdFont/3.5.1/ryanoasis.FiraCode.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/FiraCode/NerdFont/3.5.1/ryanoasis.FiraCode.NerdFont.installer.yaml
@@ -1,0 +1,32 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.FiraCode.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: FiraCodeNerdFont-Bold.ttf
+- RelativeFilePath: FiraCodeNerdFont-Light.ttf
+- RelativeFilePath: FiraCodeNerdFont-Medium.ttf
+- RelativeFilePath: FiraCodeNerdFont-Regular.ttf
+- RelativeFilePath: FiraCodeNerdFont-Retina.ttf
+- RelativeFilePath: FiraCodeNerdFont-SemiBold.ttf
+- RelativeFilePath: FiraCodeNerdFontMono-Bold.ttf
+- RelativeFilePath: FiraCodeNerdFontMono-Light.ttf
+- RelativeFilePath: FiraCodeNerdFontMono-Medium.ttf
+- RelativeFilePath: FiraCodeNerdFontMono-Regular.ttf
+- RelativeFilePath: FiraCodeNerdFontMono-Retina.ttf
+- RelativeFilePath: FiraCodeNerdFontMono-SemiBold.ttf
+- RelativeFilePath: FiraCodeNerdFontPropo-Bold.ttf
+- RelativeFilePath: FiraCodeNerdFontPropo-Light.ttf
+- RelativeFilePath: FiraCodeNerdFontPropo-Medium.ttf
+- RelativeFilePath: FiraCodeNerdFontPropo-Regular.ttf
+- RelativeFilePath: FiraCodeNerdFontPropo-Retina.ttf
+- RelativeFilePath: FiraCodeNerdFontPropo-SemiBold.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/FiraCode.zip
+  InstallerSha256: 239395BAF60C89B2EAF4862B6B09DB0EF95605CD3E8EEF51C00345822A81A665
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/FiraCode/NerdFont/3.5.1/ryanoasis.FiraCode.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/FiraCode/NerdFont/3.5.1/ryanoasis.FiraCode.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.FiraCode.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: FiraCode Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: FiraCode patched with Nerd Fonts glyphs
+Moniker: firacode-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/FiraCode/NerdFont/3.5.1/ryanoasis.FiraCode.NerdFont.yaml
+++ b/fonts/r/ryanoasis/FiraCode/NerdFont/3.5.1/ryanoasis.FiraCode.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.FiraCode.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.FiraCode.NerdFont.Font.json
+++ b/shards/json/ryanoasis.FiraCode.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/FiraCode.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

First of the Nerd Fonts patched families, from the long-standing upstream request. winget-pkgs carries the unpatched `tonsky.FiraCode`; this is the Nerd Fonts patched build, which is a distinct package.

The identifier follows this repo's existing pattern for patched fonts (`yuru7.HackGen.NerdFont`, `subframe7536.MapleMono.NerdFont`), using the GitHub owner as the publisher segment.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive, not assumed — each Nerd Fonts archive carries the original font's licence, and they differ across families, so every package in this series is classified from its own archive.

Carries all 18 patched faces (Nerd Font, Nerd Font Mono, Nerd Font Propo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_