### PR TITLE
New package: ryanoasis.JetBrainsMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/JetBrainsMono/NerdFont/3.5.1/ryanoasis.JetBrainsMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/JetBrainsMono/NerdFont/3.5.1/ryanoasis.JetBrainsMono.NerdFont.installer.yaml
@@ -1,0 +1,110 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.JetBrainsMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: JetBrainsMonoNLNerdFont-Bold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-BoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-ExtraBold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-ExtraBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-ExtraLight.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-Italic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-Light.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-LightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-Medium.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-MediumItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-Regular.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-SemiBold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-Thin.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFont-ThinItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-Bold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-ExtraBold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-ExtraBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-Italic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-Light.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-LightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-Medium.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-Regular.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-SemiBold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-Thin.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontMono-ThinItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-Bold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-ExtraBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-Italic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-Light.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-Medium.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-Regular.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-Thin.ttf
+- RelativeFilePath: JetBrainsMonoNLNerdFontPropo-ThinItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-Bold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-ExtraBold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-ExtraBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-ExtraLight.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-Italic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-Light.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-LightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-Medium.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-MediumItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-Regular.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-SemiBold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-Thin.ttf
+- RelativeFilePath: JetBrainsMonoNerdFont-ThinItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-ExtraBold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-ExtraBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-Light.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-LightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-Medium.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-SemiBold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-Thin.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontMono-ThinItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-ExtraBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-Light.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-Medium.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-Regular.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-Thin.ttf
+- RelativeFilePath: JetBrainsMonoNerdFontPropo-ThinItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/JetBrainsMono.zip
+  InstallerSha256: FAB782A66F7D3019DA64F6572DB9FC5D3A4BCB19F9FA13E2D8A62E3693D6396E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/JetBrainsMono/NerdFont/3.5.1/ryanoasis.JetBrainsMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/JetBrainsMono/NerdFont/3.5.1/ryanoasis.JetBrainsMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.JetBrainsMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: JetBrainsMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: JetBrainsMono patched with Nerd Fonts glyphs
+Moniker: jetbrainsmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/JetBrainsMono/NerdFont/3.5.1/ryanoasis.JetBrainsMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/JetBrainsMono/NerdFont/3.5.1/ryanoasis.JetBrainsMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.JetBrainsMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.JetBrainsMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.JetBrainsMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/JetBrainsMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

The identifier follows this repo's existing pattern for patched fonts (`yuru7.HackGen.NerdFont`, `subframe7536.MapleMono.NerdFont`), using the GitHub owner as the publisher segment.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed — Nerd Fonts archives carry the original font's licence and they differ across families.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_