### PR TITLE
New package: ryanoasis.CascadiaCode.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/CascadiaCode/NerdFont/3.5.1/ryanoasis.CascadiaCode.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/CascadiaCode/NerdFont/3.5.1/ryanoasis.CascadiaCode.NerdFont.installer.yaml
@@ -1,0 +1,50 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CascadiaCode.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: CaskaydiaCoveNerdFont-Bold.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-BoldItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-ExtraLight.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-Italic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-Light.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-LightItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-Regular.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-SemiBold.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-SemiLight.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFont-SemiLightItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-Bold.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-Italic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-Light.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-LightItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-Regular.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-SemiBold.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-SemiLight.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontMono-SemiLightItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-Bold.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-Italic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-Light.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-Regular.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-SemiLight.ttf
+- RelativeFilePath: CaskaydiaCoveNerdFontPropo-SemiLightItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/CascadiaCode.zip
+  InstallerSha256: 1298BF92698AFA06185CF1D05E6AE05F2D8A1E8C3CB45DDF4C3035168AB342A1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/CascadiaCode/NerdFont/3.5.1/ryanoasis.CascadiaCode.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/CascadiaCode/NerdFont/3.5.1/ryanoasis.CascadiaCode.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CascadiaCode.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: CascadiaCode Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: CascadiaCode patched with Nerd Fonts glyphs
+Moniker: cascadiacode-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/CascadiaCode/NerdFont/3.5.1/ryanoasis.CascadiaCode.NerdFont.yaml
+++ b/fonts/r/ryanoasis/CascadiaCode/NerdFont/3.5.1/ryanoasis.CascadiaCode.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CascadiaCode.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.CascadiaCode.NerdFont.Font.json
+++ b/shards/json/ryanoasis.CascadiaCode.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/CascadiaCode.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. winget-pkgs carries the unpatched Cascadia Code from Microsoft; this is the Nerd Fonts patched build.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_