### PR TITLE
New package: ryanoasis.Meslo.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Meslo/NerdFont/3.5.1/ryanoasis.Meslo.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Meslo/NerdFont/3.5.1/ryanoasis.Meslo.NerdFont.installer.yaml
@@ -1,0 +1,86 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Meslo.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: MesloLGLDZNerdFont-Bold.ttf
+- RelativeFilePath: MesloLGLDZNerdFont-BoldItalic.ttf
+- RelativeFilePath: MesloLGLDZNerdFont-Italic.ttf
+- RelativeFilePath: MesloLGLDZNerdFont-Regular.ttf
+- RelativeFilePath: MesloLGLDZNerdFontMono-Bold.ttf
+- RelativeFilePath: MesloLGLDZNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: MesloLGLDZNerdFontMono-Italic.ttf
+- RelativeFilePath: MesloLGLDZNerdFontMono-Regular.ttf
+- RelativeFilePath: MesloLGLDZNerdFontPropo-Bold.ttf
+- RelativeFilePath: MesloLGLDZNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: MesloLGLDZNerdFontPropo-Italic.ttf
+- RelativeFilePath: MesloLGLDZNerdFontPropo-Regular.ttf
+- RelativeFilePath: MesloLGLNerdFont-Bold.ttf
+- RelativeFilePath: MesloLGLNerdFont-BoldItalic.ttf
+- RelativeFilePath: MesloLGLNerdFont-Italic.ttf
+- RelativeFilePath: MesloLGLNerdFont-Regular.ttf
+- RelativeFilePath: MesloLGLNerdFontMono-Bold.ttf
+- RelativeFilePath: MesloLGLNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: MesloLGLNerdFontMono-Italic.ttf
+- RelativeFilePath: MesloLGLNerdFontMono-Regular.ttf
+- RelativeFilePath: MesloLGLNerdFontPropo-Bold.ttf
+- RelativeFilePath: MesloLGLNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: MesloLGLNerdFontPropo-Italic.ttf
+- RelativeFilePath: MesloLGLNerdFontPropo-Regular.ttf
+- RelativeFilePath: MesloLGMDZNerdFont-Bold.ttf
+- RelativeFilePath: MesloLGMDZNerdFont-BoldItalic.ttf
+- RelativeFilePath: MesloLGMDZNerdFont-Italic.ttf
+- RelativeFilePath: MesloLGMDZNerdFont-Regular.ttf
+- RelativeFilePath: MesloLGMDZNerdFontMono-Bold.ttf
+- RelativeFilePath: MesloLGMDZNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: MesloLGMDZNerdFontMono-Italic.ttf
+- RelativeFilePath: MesloLGMDZNerdFontMono-Regular.ttf
+- RelativeFilePath: MesloLGMDZNerdFontPropo-Bold.ttf
+- RelativeFilePath: MesloLGMDZNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: MesloLGMDZNerdFontPropo-Italic.ttf
+- RelativeFilePath: MesloLGMDZNerdFontPropo-Regular.ttf
+- RelativeFilePath: MesloLGMNerdFont-Bold.ttf
+- RelativeFilePath: MesloLGMNerdFont-BoldItalic.ttf
+- RelativeFilePath: MesloLGMNerdFont-Italic.ttf
+- RelativeFilePath: MesloLGMNerdFont-Regular.ttf
+- RelativeFilePath: MesloLGMNerdFontMono-Bold.ttf
+- RelativeFilePath: MesloLGMNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: MesloLGMNerdFontMono-Italic.ttf
+- RelativeFilePath: MesloLGMNerdFontMono-Regular.ttf
+- RelativeFilePath: MesloLGMNerdFontPropo-Bold.ttf
+- RelativeFilePath: MesloLGMNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: MesloLGMNerdFontPropo-Italic.ttf
+- RelativeFilePath: MesloLGMNerdFontPropo-Regular.ttf
+- RelativeFilePath: MesloLGSDZNerdFont-Bold.ttf
+- RelativeFilePath: MesloLGSDZNerdFont-BoldItalic.ttf
+- RelativeFilePath: MesloLGSDZNerdFont-Italic.ttf
+- RelativeFilePath: MesloLGSDZNerdFont-Regular.ttf
+- RelativeFilePath: MesloLGSDZNerdFontMono-Bold.ttf
+- RelativeFilePath: MesloLGSDZNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: MesloLGSDZNerdFontMono-Italic.ttf
+- RelativeFilePath: MesloLGSDZNerdFontMono-Regular.ttf
+- RelativeFilePath: MesloLGSDZNerdFontPropo-Bold.ttf
+- RelativeFilePath: MesloLGSDZNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: MesloLGSDZNerdFontPropo-Italic.ttf
+- RelativeFilePath: MesloLGSDZNerdFontPropo-Regular.ttf
+- RelativeFilePath: MesloLGSNerdFont-Bold.ttf
+- RelativeFilePath: MesloLGSNerdFont-BoldItalic.ttf
+- RelativeFilePath: MesloLGSNerdFont-Italic.ttf
+- RelativeFilePath: MesloLGSNerdFont-Regular.ttf
+- RelativeFilePath: MesloLGSNerdFontMono-Bold.ttf
+- RelativeFilePath: MesloLGSNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: MesloLGSNerdFontMono-Italic.ttf
+- RelativeFilePath: MesloLGSNerdFontMono-Regular.ttf
+- RelativeFilePath: MesloLGSNerdFontPropo-Bold.ttf
+- RelativeFilePath: MesloLGSNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: MesloLGSNerdFontPropo-Italic.ttf
+- RelativeFilePath: MesloLGSNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Meslo.zip
+  InstallerSha256: FB104893ECD8F57E8AFACBC0A7086B42657120448D056D6093C728A9AFB8E237
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Meslo/NerdFont/3.5.1/ryanoasis.Meslo.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Meslo/NerdFont/3.5.1/ryanoasis.Meslo.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Meslo.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Meslo Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Apache-2.0
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Meslo patched with Nerd Fonts glyphs
+Moniker: meslo-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Meslo/NerdFont/3.5.1/ryanoasis.Meslo.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Meslo/NerdFont/3.5.1/ryanoasis.Meslo.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Meslo.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Meslo.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Meslo.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Meslo.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: Apache-2.0` is read from the `LICENSE` file inside the release archive rather than assumed — Meslo derives from Bitstream Vera / DejaVu lineage via Apache-licensed sources, and differs from the OFL-1.1 used by most of this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_