### PR TITLE
New package: ryanoasis.SourceCodePro.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/SourceCodePro/NerdFont/3.5.1/ryanoasis.SourceCodePro.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/SourceCodePro/NerdFont/3.5.1/ryanoasis.SourceCodePro.NerdFont.installer.yaml
@@ -1,0 +1,56 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.SourceCodePro.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: SauceCodeProNerdFont-Black.ttf
+- RelativeFilePath: SauceCodeProNerdFont-BlackItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFont-Bold.ttf
+- RelativeFilePath: SauceCodeProNerdFont-BoldItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFont-ExtraLight.ttf
+- RelativeFilePath: SauceCodeProNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFont-Italic.ttf
+- RelativeFilePath: SauceCodeProNerdFont-Light.ttf
+- RelativeFilePath: SauceCodeProNerdFont-LightItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFont-Medium.ttf
+- RelativeFilePath: SauceCodeProNerdFont-MediumItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFont-Regular.ttf
+- RelativeFilePath: SauceCodeProNerdFont-SemiBold.ttf
+- RelativeFilePath: SauceCodeProNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-Black.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-BlackItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-Bold.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-Italic.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-Light.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-LightItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-Medium.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-Regular.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-SemiBold.ttf
+- RelativeFilePath: SauceCodeProNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-Black.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-BlackItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-Bold.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-Italic.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-Light.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-Medium.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-Regular.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: SauceCodeProNerdFontPropo-SemiBoldItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/SourceCodePro.zip
+  InstallerSha256: E0000BC77CD77279840D8613E98727548F81F291A571BE0BE8699C8E3BE36FD3
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/SourceCodePro/NerdFont/3.5.1/ryanoasis.SourceCodePro.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/SourceCodePro/NerdFont/3.5.1/ryanoasis.SourceCodePro.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.SourceCodePro.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: SourceCodePro Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: SourceCodePro patched with Nerd Fonts glyphs
+Moniker: sourcecodepro-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/SourceCodePro/NerdFont/3.5.1/ryanoasis.SourceCodePro.NerdFont.yaml
+++ b/fonts/r/ryanoasis/SourceCodePro/NerdFont/3.5.1/ryanoasis.SourceCodePro.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.SourceCodePro.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.SourceCodePro.NerdFont.Font.json
+++ b/shards/json/ryanoasis.SourceCodePro.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/SourceCodePro.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `Adobe.SourceCodePro` as a script shard; this is the Nerd Fonts patched build, a distinct package.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_