### PR TITLE
New package: ryanoasis.UbuntuMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/UbuntuMono/NerdFont/3.5.1/ryanoasis.UbuntuMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/UbuntuMono/NerdFont/3.5.1/ryanoasis.UbuntuMono.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.UbuntuMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: UbuntuMonoNerdFont-Bold.ttf
+- RelativeFilePath: UbuntuMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: UbuntuMonoNerdFont-Italic.ttf
+- RelativeFilePath: UbuntuMonoNerdFont-Regular.ttf
+- RelativeFilePath: UbuntuMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: UbuntuMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: UbuntuMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: UbuntuMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: UbuntuMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: UbuntuMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: UbuntuMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: UbuntuMonoNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/UbuntuMono.zip
+  InstallerSha256: E5EEE9529EE538CF30CAB268ABC4E877E0A57142D10FBF170F715C4636A336D1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/UbuntuMono/NerdFont/3.5.1/ryanoasis.UbuntuMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/UbuntuMono/NerdFont/3.5.1/ryanoasis.UbuntuMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.UbuntuMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: UbuntuMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Ubuntu-font-1.0
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: UbuntuMono patched with Nerd Fonts glyphs
+Moniker: ubuntumono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/UbuntuMono/NerdFont/3.5.1/ryanoasis.UbuntuMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/UbuntuMono/NerdFont/3.5.1/ryanoasis.UbuntuMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.UbuntuMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.UbuntuMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.UbuntuMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/UbuntuMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `Canonical.UbuntuFont.Mono`; this is the Nerd Fonts patched build, a distinct package.

`License: Ubuntu-font-1.0` is read from the `LICENCE` file inside the release archive rather than assumed. The Ubuntu Font Licence is neither OFL nor Apache, so this is a third distinct licence within this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_