### PR TITLE
New package: ryanoasis.0xProto.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/0xProto/NerdFont/3.5.1/ryanoasis.0xProto.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/0xProto/NerdFont/3.5.1/ryanoasis.0xProto.NerdFont.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.0xProto.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: 0xProtoNerdFont-Bold.ttf
+- RelativeFilePath: 0xProtoNerdFont-Italic.ttf
+- RelativeFilePath: 0xProtoNerdFont-Regular.ttf
+- RelativeFilePath: 0xProtoNerdFontMono-Bold.ttf
+- RelativeFilePath: 0xProtoNerdFontMono-Italic.ttf
+- RelativeFilePath: 0xProtoNerdFontMono-Regular.ttf
+- RelativeFilePath: 0xProtoNerdFontPropo-Bold.ttf
+- RelativeFilePath: 0xProtoNerdFontPropo-Italic.ttf
+- RelativeFilePath: 0xProtoNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/0xProto.zip
+  InstallerSha256: 8951412356611266734E2E9904173D437B804AF1FFCE4FE1804FEEF4FE9C8C3B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/0xProto/NerdFont/3.5.1/ryanoasis.0xProto.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/0xProto/NerdFont/3.5.1/ryanoasis.0xProto.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.0xProto.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: 0xProto Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: 0xProto patched with Nerd Fonts glyphs
+Moniker: 0xproto-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/0xProto/NerdFont/3.5.1/ryanoasis.0xProto.NerdFont.yaml
+++ b/fonts/r/ryanoasis/0xProto/NerdFont/3.5.1/ryanoasis.0xProto.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.0xProto.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.0xProto.NerdFont.Font.json
+++ b/shards/json/ryanoasis.0xProto.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/0xProto.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `0xType.0xProto`; this is the Nerd Fonts patched build, a distinct package.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_