### PR TITLE
New package: ryanoasis.CommitMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/CommitMono/NerdFont/3.5.1/ryanoasis.CommitMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/CommitMono/NerdFont/3.5.1/ryanoasis.CommitMono.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CommitMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: CommitMonoNerdFont-Bold.otf
+- RelativeFilePath: CommitMonoNerdFont-BoldItalic.otf
+- RelativeFilePath: CommitMonoNerdFont-Italic.otf
+- RelativeFilePath: CommitMonoNerdFont-Regular.otf
+- RelativeFilePath: CommitMonoNerdFontMono-Bold.otf
+- RelativeFilePath: CommitMonoNerdFontMono-BoldItalic.otf
+- RelativeFilePath: CommitMonoNerdFontMono-Italic.otf
+- RelativeFilePath: CommitMonoNerdFontMono-Regular.otf
+- RelativeFilePath: CommitMonoNerdFontPropo-Bold.otf
+- RelativeFilePath: CommitMonoNerdFontPropo-BoldItalic.otf
+- RelativeFilePath: CommitMonoNerdFontPropo-Italic.otf
+- RelativeFilePath: CommitMonoNerdFontPropo-Regular.otf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/CommitMono.zip
+  InstallerSha256: 9F26650F142D69B33522B9B2C67E3F8CA21EAFBDE5E143D842DEDBF2BB829BF5
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/CommitMono/NerdFont/3.5.1/ryanoasis.CommitMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/CommitMono/NerdFont/3.5.1/ryanoasis.CommitMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CommitMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: CommitMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: CommitMono patched with Nerd Fonts glyphs
+Moniker: commitmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/CommitMono/NerdFont/3.5.1/ryanoasis.CommitMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/CommitMono/NerdFont/3.5.1/ryanoasis.CommitMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CommitMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.CommitMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.CommitMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/CommitMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `EigilNikolajsen.CommitMono`; this is the Nerd Fonts patched build, a distinct package.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_