### PR TITLE
New package: ryanoasis.GeistMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/GeistMono/NerdFont/3.5.1/ryanoasis.GeistMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/GeistMono/NerdFont/3.5.1/ryanoasis.GeistMono.NerdFont.installer.yaml
@@ -1,0 +1,68 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.GeistMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: GeistMonoNerdFont-Black.otf
+- RelativeFilePath: GeistMonoNerdFont-BlackItalic.otf
+- RelativeFilePath: GeistMonoNerdFont-Bold.otf
+- RelativeFilePath: GeistMonoNerdFont-BoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFont-ExtraBold.otf
+- RelativeFilePath: GeistMonoNerdFont-ExtraBoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFont-ExtraLight.otf
+- RelativeFilePath: GeistMonoNerdFont-ExtraLightItalic.otf
+- RelativeFilePath: GeistMonoNerdFont-Italic.otf
+- RelativeFilePath: GeistMonoNerdFont-Light.otf
+- RelativeFilePath: GeistMonoNerdFont-LightItalic.otf
+- RelativeFilePath: GeistMonoNerdFont-Medium.otf
+- RelativeFilePath: GeistMonoNerdFont-MediumItalic.otf
+- RelativeFilePath: GeistMonoNerdFont-Regular.otf
+- RelativeFilePath: GeistMonoNerdFont-SemiBold.otf
+- RelativeFilePath: GeistMonoNerdFont-SemiBoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFont-Thin.otf
+- RelativeFilePath: GeistMonoNerdFont-ThinItalic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-Black.otf
+- RelativeFilePath: GeistMonoNerdFontMono-BlackItalic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-Bold.otf
+- RelativeFilePath: GeistMonoNerdFontMono-BoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-ExtraBold.otf
+- RelativeFilePath: GeistMonoNerdFontMono-ExtraBoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-ExtraLight.otf
+- RelativeFilePath: GeistMonoNerdFontMono-ExtraLightItalic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-Italic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-Light.otf
+- RelativeFilePath: GeistMonoNerdFontMono-LightItalic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-Medium.otf
+- RelativeFilePath: GeistMonoNerdFontMono-MediumItalic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-Regular.otf
+- RelativeFilePath: GeistMonoNerdFontMono-SemiBold.otf
+- RelativeFilePath: GeistMonoNerdFontMono-SemiBoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFontMono-Thin.otf
+- RelativeFilePath: GeistMonoNerdFontMono-ThinItalic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-Black.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-BlackItalic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-Bold.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-BoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-ExtraBold.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-ExtraBoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-ExtraLight.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-ExtraLightItalic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-Italic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-Light.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-LightItalic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-Medium.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-MediumItalic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-Regular.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-SemiBold.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-SemiBoldItalic.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-Thin.otf
+- RelativeFilePath: GeistMonoNerdFontPropo-ThinItalic.otf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/GeistMono.zip
+  InstallerSha256: 4799A6C340F3993CEA7F59C256C723AFB3E70233471EA9042D92F153B87EF83E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/GeistMono/NerdFont/3.5.1/ryanoasis.GeistMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/GeistMono/NerdFont/3.5.1/ryanoasis.GeistMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.GeistMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: GeistMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: GeistMono patched with Nerd Fonts glyphs
+Moniker: geistmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/GeistMono/NerdFont/3.5.1/ryanoasis.GeistMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/GeistMono/NerdFont/3.5.1/ryanoasis.GeistMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.GeistMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.GeistMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.GeistMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/GeistMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_