### PR TITLE
New package: ryanoasis.DejaVuSansMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/DejaVuSansMono/NerdFont/3.5.1/ryanoasis.DejaVuSansMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/DejaVuSansMono/NerdFont/3.5.1/ryanoasis.DejaVuSansMono.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.DejaVuSansMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: DejaVuSansMNerdFont-Bold.ttf
+- RelativeFilePath: DejaVuSansMNerdFont-BoldOblique.ttf
+- RelativeFilePath: DejaVuSansMNerdFont-Oblique.ttf
+- RelativeFilePath: DejaVuSansMNerdFont-Regular.ttf
+- RelativeFilePath: DejaVuSansMNerdFontMono-Bold.ttf
+- RelativeFilePath: DejaVuSansMNerdFontMono-BoldOblique.ttf
+- RelativeFilePath: DejaVuSansMNerdFontMono-Oblique.ttf
+- RelativeFilePath: DejaVuSansMNerdFontMono-Regular.ttf
+- RelativeFilePath: DejaVuSansMNerdFontPropo-Bold.ttf
+- RelativeFilePath: DejaVuSansMNerdFontPropo-BoldOblique.ttf
+- RelativeFilePath: DejaVuSansMNerdFontPropo-Oblique.ttf
+- RelativeFilePath: DejaVuSansMNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/DejaVuSansMono.zip
+  InstallerSha256: 45D26B54728E01A665DE4A1899EC146C79EA0752F6A0B09E1335E49187D04652
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/DejaVuSansMono/NerdFont/3.5.1/ryanoasis.DejaVuSansMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DejaVuSansMono/NerdFont/3.5.1/ryanoasis.DejaVuSansMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.DejaVuSansMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: DejaVuSansMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: MIT
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: DejaVuSansMono patched with Nerd Fonts glyphs
+Moniker: dejavusansmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/DejaVuSansMono/NerdFont/3.5.1/ryanoasis.DejaVuSansMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DejaVuSansMono/NerdFont/3.5.1/ryanoasis.DejaVuSansMono.NerdFont.locale.en-US.yaml
@@ -9,7 +9,7 @@ PublisherUrl: https://www.nerdfonts.com/
 PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
 PackageName: DejaVuSansMono Nerd Font
 PackageUrl: https://www.nerdfonts.com/
-License: MIT
+License: Bitstream-Vera
 LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
 ShortDescription: DejaVuSansMono patched with Nerd Fonts glyphs
 Moniker: dejavusansmono-nf

--- a/fonts/r/ryanoasis/DejaVuSansMono/NerdFont/3.5.1/ryanoasis.DejaVuSansMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/DejaVuSansMono/NerdFont/3.5.1/ryanoasis.DejaVuSansMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.DejaVuSansMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.DejaVuSansMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.DejaVuSansMono.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/DejaVuSansMono.zip"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `DejaVuFonts.DejaVu`; this is the Nerd Fonts patched build, a distinct package.

`License: Bitstream-Vera`, matching the existing `DejaVuFonts.DejaVu` package. Worth noting how this was caught: the archive's `LICENSE.txt` is the Bitstream Vera Fonts licence, which opens with "Permission is hereby granted, free of charge" and was therefore first classified as MIT. Bitstream-Vera is a distinct SPDX identifier, so the classification was corrected here and the rule tightened for the rest of the series — `BitstreamVeraSansMono` would have hit the same trap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_