### PR TITLE
New package: ryanoasis.Iosevka.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Iosevka/NerdFont/3.5.1/ryanoasis.Iosevka.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Iosevka/NerdFont/3.5.1/ryanoasis.Iosevka.NerdFont.installer.yaml
@@ -1,0 +1,95 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Iosevka.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: IosevkaNerdFont-Bold.ttf
+- RelativeFilePath: IosevkaNerdFont-BoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFont-BoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFont-ExtraBold.ttf
+- RelativeFilePath: IosevkaNerdFont-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFont-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFont-ExtraLight.ttf
+- RelativeFilePath: IosevkaNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: IosevkaNerdFont-ExtraLightOblique.ttf
+- RelativeFilePath: IosevkaNerdFont-Heavy.ttf
+- RelativeFilePath: IosevkaNerdFont-HeavyItalic.ttf
+- RelativeFilePath: IosevkaNerdFont-HeavyOblique.ttf
+- RelativeFilePath: IosevkaNerdFont-Italic.ttf
+- RelativeFilePath: IosevkaNerdFont-Light.ttf
+- RelativeFilePath: IosevkaNerdFont-LightItalic.ttf
+- RelativeFilePath: IosevkaNerdFont-LightOblique.ttf
+- RelativeFilePath: IosevkaNerdFont-Medium.ttf
+- RelativeFilePath: IosevkaNerdFont-MediumItalic.ttf
+- RelativeFilePath: IosevkaNerdFont-MediumOblique.ttf
+- RelativeFilePath: IosevkaNerdFont-Oblique.ttf
+- RelativeFilePath: IosevkaNerdFont-Regular.ttf
+- RelativeFilePath: IosevkaNerdFont-SemiBold.ttf
+- RelativeFilePath: IosevkaNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFont-SemiBoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFont-Thin.ttf
+- RelativeFilePath: IosevkaNerdFont-ThinItalic.ttf
+- RelativeFilePath: IosevkaNerdFont-ThinOblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-Bold.ttf
+- RelativeFilePath: IosevkaNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-BoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-ExtraBold.ttf
+- RelativeFilePath: IosevkaNerdFontMono-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: IosevkaNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-ExtraLightOblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-Heavy.ttf
+- RelativeFilePath: IosevkaNerdFontMono-HeavyItalic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-HeavyOblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-Italic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-Light.ttf
+- RelativeFilePath: IosevkaNerdFontMono-LightItalic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-LightOblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-Medium.ttf
+- RelativeFilePath: IosevkaNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-MediumOblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-Oblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-Regular.ttf
+- RelativeFilePath: IosevkaNerdFontMono-SemiBold.ttf
+- RelativeFilePath: IosevkaNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-SemiBoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFontMono-Thin.ttf
+- RelativeFilePath: IosevkaNerdFontMono-ThinItalic.ttf
+- RelativeFilePath: IosevkaNerdFontMono-ThinOblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-Bold.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-BoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-ExtraLightOblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-Heavy.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-HeavyItalic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-HeavyOblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-Italic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-Light.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-LightOblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-Medium.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-MediumOblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-Oblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-Regular.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-SemiBoldOblique.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-Thin.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-ThinItalic.ttf
+- RelativeFilePath: IosevkaNerdFontPropo-ThinOblique.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Iosevka.zip
+  InstallerSha256: 0512C8561FDCFED03C5CAE130D1C01F279CFAD19467337F9EAB98A2B730ECC50
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Iosevka/NerdFont/3.5.1/ryanoasis.Iosevka.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Iosevka/NerdFont/3.5.1/ryanoasis.Iosevka.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Iosevka.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Iosevka Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Iosevka patched with Nerd Fonts glyphs
+Moniker: iosevka-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Iosevka/NerdFont/3.5.1/ryanoasis.Iosevka.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Iosevka/NerdFont/3.5.1/ryanoasis.Iosevka.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Iosevka.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Iosevka.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Iosevka.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Iosevka.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_