### PR TITLE
New package: ryanoasis.VictorMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/VictorMono/NerdFont/3.5.1/ryanoasis.VictorMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/VictorMono/NerdFont/3.5.1/ryanoasis.VictorMono.NerdFont.installer.yaml
@@ -1,0 +1,77 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.VictorMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: VictorMonoNerdFont-Bold.ttf
+- RelativeFilePath: VictorMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: VictorMonoNerdFont-BoldOblique.ttf
+- RelativeFilePath: VictorMonoNerdFont-ExtraLight.ttf
+- RelativeFilePath: VictorMonoNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: VictorMonoNerdFont-ExtraLightOblique.ttf
+- RelativeFilePath: VictorMonoNerdFont-Italic.ttf
+- RelativeFilePath: VictorMonoNerdFont-Light.ttf
+- RelativeFilePath: VictorMonoNerdFont-LightItalic.ttf
+- RelativeFilePath: VictorMonoNerdFont-LightOblique.ttf
+- RelativeFilePath: VictorMonoNerdFont-Medium.ttf
+- RelativeFilePath: VictorMonoNerdFont-MediumItalic.ttf
+- RelativeFilePath: VictorMonoNerdFont-MediumOblique.ttf
+- RelativeFilePath: VictorMonoNerdFont-Oblique.ttf
+- RelativeFilePath: VictorMonoNerdFont-Regular.ttf
+- RelativeFilePath: VictorMonoNerdFont-SemiBold.ttf
+- RelativeFilePath: VictorMonoNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: VictorMonoNerdFont-SemiBoldOblique.ttf
+- RelativeFilePath: VictorMonoNerdFont-Thin.ttf
+- RelativeFilePath: VictorMonoNerdFont-ThinItalic.ttf
+- RelativeFilePath: VictorMonoNerdFont-ThinOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-BoldOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-ExtraLightOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-Light.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-LightItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-LightOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-Medium.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-MediumOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-Oblique.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-SemiBold.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-SemiBoldOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-Thin.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-ThinItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontMono-ThinOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-BoldOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-ExtraLightOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-Light.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-LightOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-Medium.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-MediumOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-Oblique.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-Regular.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-SemiBoldOblique.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-Thin.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-ThinItalic.ttf
+- RelativeFilePath: VictorMonoNerdFontPropo-ThinOblique.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/VictorMono.zip
+  InstallerSha256: 81CF501F80581BC2E73F70264441CF96980736A4BBB07C090996AF6AB8F19013
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/VictorMono/NerdFont/3.5.1/ryanoasis.VictorMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/VictorMono/NerdFont/3.5.1/ryanoasis.VictorMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.VictorMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: VictorMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: VictorMono patched with Nerd Fonts glyphs
+Moniker: victormono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/VictorMono/NerdFont/3.5.1/ryanoasis.VictorMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/VictorMono/NerdFont/3.5.1/ryanoasis.VictorMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.VictorMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.VictorMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.VictorMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/VictorMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `rubjo.VictorMono` as a script shard; this is the Nerd Fonts patched build, a distinct package.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_