### PR TITLE
New package: ryanoasis.Mononoki.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Mononoki/NerdFont/3.5.1/ryanoasis.Mononoki.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Mononoki/NerdFont/3.5.1/ryanoasis.Mononoki.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Mononoki.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: MononokiNerdFont-Bold.ttf
+- RelativeFilePath: MononokiNerdFont-BoldItalic.ttf
+- RelativeFilePath: MononokiNerdFont-Italic.ttf
+- RelativeFilePath: MononokiNerdFont-Regular.ttf
+- RelativeFilePath: MononokiNerdFontMono-Bold.ttf
+- RelativeFilePath: MononokiNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: MononokiNerdFontMono-Italic.ttf
+- RelativeFilePath: MononokiNerdFontMono-Regular.ttf
+- RelativeFilePath: MononokiNerdFontPropo-Bold.ttf
+- RelativeFilePath: MononokiNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: MononokiNerdFontPropo-Italic.ttf
+- RelativeFilePath: MononokiNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Mononoki.zip
+  InstallerSha256: 6F091B7380EB6E22999D36D758A4C9495D16AE694284F8F718182B7B15CE1874
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Mononoki/NerdFont/3.5.1/ryanoasis.Mononoki.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Mononoki/NerdFont/3.5.1/ryanoasis.Mononoki.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Mononoki.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Mononoki Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Mononoki patched with Nerd Fonts glyphs
+Moniker: mononoki-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Mononoki/NerdFont/3.5.1/ryanoasis.Mononoki.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Mononoki/NerdFont/3.5.1/ryanoasis.Mononoki.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Mononoki.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Mononoki.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Mononoki.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Mononoki.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_