### PR TITLE
New package: ryanoasis.Inconsolata.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Inconsolata/NerdFont/3.5.1/ryanoasis.Inconsolata.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Inconsolata/NerdFont/3.5.1/ryanoasis.Inconsolata.NerdFont.installer.yaml
@@ -1,0 +1,20 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Inconsolata.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: InconsolataNerdFont-Bold.ttf
+- RelativeFilePath: InconsolataNerdFont-Regular.ttf
+- RelativeFilePath: InconsolataNerdFontMono-Bold.ttf
+- RelativeFilePath: InconsolataNerdFontMono-Regular.ttf
+- RelativeFilePath: InconsolataNerdFontPropo-Bold.ttf
+- RelativeFilePath: InconsolataNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Inconsolata.zip
+  InstallerSha256: DE7BF85382DAD8C239696B7CCDDD3E69C5A79B77C6D18C6ABE9D6676D28A8764
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Inconsolata/NerdFont/3.5.1/ryanoasis.Inconsolata.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Inconsolata/NerdFont/3.5.1/ryanoasis.Inconsolata.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Inconsolata.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Inconsolata Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Inconsolata patched with Nerd Fonts glyphs
+Moniker: inconsolata-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Inconsolata/NerdFont/3.5.1/ryanoasis.Inconsolata.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Inconsolata/NerdFont/3.5.1/ryanoasis.Inconsolata.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Inconsolata.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Inconsolata.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Inconsolata.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Inconsolata.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_