### PR TITLE
New package: ryanoasis.RobotoMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/RobotoMono/NerdFont/3.5.1/ryanoasis.RobotoMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/RobotoMono/NerdFont/3.5.1/ryanoasis.RobotoMono.NerdFont.installer.yaml
@@ -1,0 +1,50 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.RobotoMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: RobotoMonoNerdFont-Bold.ttf
+- RelativeFilePath: RobotoMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFont-Italic.ttf
+- RelativeFilePath: RobotoMonoNerdFont-Light.ttf
+- RelativeFilePath: RobotoMonoNerdFont-LightItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFont-Medium.ttf
+- RelativeFilePath: RobotoMonoNerdFont-MediumItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFont-Regular.ttf
+- RelativeFilePath: RobotoMonoNerdFont-SemiBold.ttf
+- RelativeFilePath: RobotoMonoNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFont-Thin.ttf
+- RelativeFilePath: RobotoMonoNerdFont-ThinItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-Light.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-LightItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-Medium.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-SemiBold.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-Thin.ttf
+- RelativeFilePath: RobotoMonoNerdFontMono-ThinItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-Light.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-Medium.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-Regular.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-Thin.ttf
+- RelativeFilePath: RobotoMonoNerdFontPropo-ThinItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/RobotoMono.zip
+  InstallerSha256: B5DB570B0B2BF5A3A62911AEEFD2C8DF91A12DCB66261169E7353F984002D5B7
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/RobotoMono/NerdFont/3.5.1/ryanoasis.RobotoMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/RobotoMono/NerdFont/3.5.1/ryanoasis.RobotoMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.RobotoMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: RobotoMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Apache-2.0
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: RobotoMono patched with Nerd Fonts glyphs
+Moniker: robotomono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/RobotoMono/NerdFont/3.5.1/ryanoasis.RobotoMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/RobotoMono/NerdFont/3.5.1/ryanoasis.RobotoMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.RobotoMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.RobotoMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.RobotoMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/RobotoMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: Apache-2.0` is read from the `LICENSE` file inside the release archive rather than assumed — Roboto Mono predates Google's move to OFL for the Roboto family, so it differs from most of this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_