### PR TITLE
New package: ryanoasis.Lilex.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Lilex/NerdFont/3.5.1/ryanoasis.Lilex.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Lilex/NerdFont/3.5.1/ryanoasis.Lilex.NerdFont.installer.yaml
@@ -1,0 +1,44 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Lilex.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: LilexNerdFont-Bold.ttf
+- RelativeFilePath: LilexNerdFont-BoldItalic.ttf
+- RelativeFilePath: LilexNerdFont-ExtraLight.ttf
+- RelativeFilePath: LilexNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: LilexNerdFont-Italic.ttf
+- RelativeFilePath: LilexNerdFont-Medium.ttf
+- RelativeFilePath: LilexNerdFont-MediumItalic.ttf
+- RelativeFilePath: LilexNerdFont-Regular.ttf
+- RelativeFilePath: LilexNerdFont-Thin.ttf
+- RelativeFilePath: LilexNerdFont-ThinItalic.ttf
+- RelativeFilePath: LilexNerdFontMono-Bold.ttf
+- RelativeFilePath: LilexNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: LilexNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: LilexNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: LilexNerdFontMono-Italic.ttf
+- RelativeFilePath: LilexNerdFontMono-Medium.ttf
+- RelativeFilePath: LilexNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: LilexNerdFontMono-Regular.ttf
+- RelativeFilePath: LilexNerdFontMono-Thin.ttf
+- RelativeFilePath: LilexNerdFontMono-ThinItalic.ttf
+- RelativeFilePath: LilexNerdFontPropo-Bold.ttf
+- RelativeFilePath: LilexNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: LilexNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: LilexNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: LilexNerdFontPropo-Italic.ttf
+- RelativeFilePath: LilexNerdFontPropo-Medium.ttf
+- RelativeFilePath: LilexNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: LilexNerdFontPropo-Regular.ttf
+- RelativeFilePath: LilexNerdFontPropo-Thin.ttf
+- RelativeFilePath: LilexNerdFontPropo-ThinItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Lilex.zip
+  InstallerSha256: 07645C3A839FA8F74E8555C6C1C45187BF27D49FB27410992715F124311609E4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Lilex/NerdFont/3.5.1/ryanoasis.Lilex.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Lilex/NerdFont/3.5.1/ryanoasis.Lilex.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Lilex.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Lilex Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Lilex patched with Nerd Fonts glyphs
+Moniker: lilex-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Lilex/NerdFont/3.5.1/ryanoasis.Lilex.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Lilex/NerdFont/3.5.1/ryanoasis.Lilex.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Lilex.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Lilex.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Lilex.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Lilex.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_