### PR TITLE
New package: ryanoasis.Hasklig.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Hasklig/NerdFont/3.5.1/ryanoasis.Hasklig.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Hasklig/NerdFont/3.5.1/ryanoasis.Hasklig.NerdFont.installer.yaml
@@ -1,0 +1,56 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Hasklig.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: HasklugNerdFont-Black.otf
+- RelativeFilePath: HasklugNerdFont-BlackItalic.otf
+- RelativeFilePath: HasklugNerdFont-Bold.otf
+- RelativeFilePath: HasklugNerdFont-BoldItalic.otf
+- RelativeFilePath: HasklugNerdFont-ExtraLight.otf
+- RelativeFilePath: HasklugNerdFont-ExtraLightItalic.otf
+- RelativeFilePath: HasklugNerdFont-Italic.otf
+- RelativeFilePath: HasklugNerdFont-Light.otf
+- RelativeFilePath: HasklugNerdFont-LightItalic.otf
+- RelativeFilePath: HasklugNerdFont-Medium.otf
+- RelativeFilePath: HasklugNerdFont-MediumItalic.otf
+- RelativeFilePath: HasklugNerdFont-Regular.otf
+- RelativeFilePath: HasklugNerdFont-SemiBold.otf
+- RelativeFilePath: HasklugNerdFont-SemiBoldItalic.otf
+- RelativeFilePath: HasklugNerdFontMono-Black.otf
+- RelativeFilePath: HasklugNerdFontMono-BlackItalic.otf
+- RelativeFilePath: HasklugNerdFontMono-Bold.otf
+- RelativeFilePath: HasklugNerdFontMono-BoldItalic.otf
+- RelativeFilePath: HasklugNerdFontMono-ExtraLight.otf
+- RelativeFilePath: HasklugNerdFontMono-ExtraLightItalic.otf
+- RelativeFilePath: HasklugNerdFontMono-Italic.otf
+- RelativeFilePath: HasklugNerdFontMono-Light.otf
+- RelativeFilePath: HasklugNerdFontMono-LightItalic.otf
+- RelativeFilePath: HasklugNerdFontMono-Medium.otf
+- RelativeFilePath: HasklugNerdFontMono-MediumItalic.otf
+- RelativeFilePath: HasklugNerdFontMono-Regular.otf
+- RelativeFilePath: HasklugNerdFontMono-SemiBold.otf
+- RelativeFilePath: HasklugNerdFontMono-SemiBoldItalic.otf
+- RelativeFilePath: HasklugNerdFontPropo-Black.otf
+- RelativeFilePath: HasklugNerdFontPropo-BlackItalic.otf
+- RelativeFilePath: HasklugNerdFontPropo-Bold.otf
+- RelativeFilePath: HasklugNerdFontPropo-BoldItalic.otf
+- RelativeFilePath: HasklugNerdFontPropo-ExtraLight.otf
+- RelativeFilePath: HasklugNerdFontPropo-ExtraLightItalic.otf
+- RelativeFilePath: HasklugNerdFontPropo-Italic.otf
+- RelativeFilePath: HasklugNerdFontPropo-Light.otf
+- RelativeFilePath: HasklugNerdFontPropo-LightItalic.otf
+- RelativeFilePath: HasklugNerdFontPropo-Medium.otf
+- RelativeFilePath: HasklugNerdFontPropo-MediumItalic.otf
+- RelativeFilePath: HasklugNerdFontPropo-Regular.otf
+- RelativeFilePath: HasklugNerdFontPropo-SemiBold.otf
+- RelativeFilePath: HasklugNerdFontPropo-SemiBoldItalic.otf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Hasklig.zip
+  InstallerSha256: 91189C708F2404F5F08C89DAA4286E3C9BAC12065880C4CD311573A70E11B2E4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Hasklig/NerdFont/3.5.1/ryanoasis.Hasklig.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Hasklig/NerdFont/3.5.1/ryanoasis.Hasklig.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Hasklig.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Hasklig Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Hasklig patched with Nerd Fonts glyphs
+Moniker: hasklig-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Hasklig/NerdFont/3.5.1/ryanoasis.Hasklig.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Hasklig/NerdFont/3.5.1/ryanoasis.Hasklig.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Hasklig.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Hasklig.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Hasklig.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Hasklig.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_