### PR TITLE
New package: ryanoasis.MartianMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/MartianMono/NerdFont/3.5.1/ryanoasis.MartianMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/MartianMono/NerdFont/3.5.1/ryanoasis.MartianMono.NerdFont.installer.yaml
@@ -1,0 +1,32 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.MartianMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: MartianMonoNerdFont-Bold.ttf
+- RelativeFilePath: MartianMonoNerdFont-CondensedBold.ttf
+- RelativeFilePath: MartianMonoNerdFont-CondensedMedium.ttf
+- RelativeFilePath: MartianMonoNerdFont-CondensedRegular.ttf
+- RelativeFilePath: MartianMonoNerdFont-Medium.ttf
+- RelativeFilePath: MartianMonoNerdFont-Regular.ttf
+- RelativeFilePath: MartianMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: MartianMonoNerdFontMono-CondensedBold.ttf
+- RelativeFilePath: MartianMonoNerdFontMono-CondensedMedium.ttf
+- RelativeFilePath: MartianMonoNerdFontMono-CondensedRegular.ttf
+- RelativeFilePath: MartianMonoNerdFontMono-Medium.ttf
+- RelativeFilePath: MartianMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: MartianMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: MartianMonoNerdFontPropo-CondensedBold.ttf
+- RelativeFilePath: MartianMonoNerdFontPropo-CondensedMedium.ttf
+- RelativeFilePath: MartianMonoNerdFontPropo-CondensedRegular.ttf
+- RelativeFilePath: MartianMonoNerdFontPropo-Medium.ttf
+- RelativeFilePath: MartianMonoNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/MartianMono.zip
+  InstallerSha256: BF873EAA04794D003961BFC0A1629D93207A5CB7ABB5D7486E28ED6F316C5AFE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/MartianMono/NerdFont/3.5.1/ryanoasis.MartianMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/MartianMono/NerdFont/3.5.1/ryanoasis.MartianMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.MartianMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: MartianMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: MartianMono patched with Nerd Fonts glyphs
+Moniker: martianmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/MartianMono/NerdFont/3.5.1/ryanoasis.MartianMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/MartianMono/NerdFont/3.5.1/ryanoasis.MartianMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.MartianMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.MartianMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.MartianMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/MartianMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `EvilMartians.MartianMono`; this is the Nerd Fonts patched build, a distinct package.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_