### PR TITLE
New package: ryanoasis.IBMPlexMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/IBMPlexMono/NerdFont/3.5.1/ryanoasis.IBMPlexMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/IBMPlexMono/NerdFont/3.5.1/ryanoasis.IBMPlexMono.NerdFont.installer.yaml
@@ -1,0 +1,62 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IBMPlexMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: BlexMonoNerdFont-Bold.ttf
+- RelativeFilePath: BlexMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: BlexMonoNerdFont-ExtraLight.ttf
+- RelativeFilePath: BlexMonoNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: BlexMonoNerdFont-Italic.ttf
+- RelativeFilePath: BlexMonoNerdFont-Light.ttf
+- RelativeFilePath: BlexMonoNerdFont-LightItalic.ttf
+- RelativeFilePath: BlexMonoNerdFont-Medium.ttf
+- RelativeFilePath: BlexMonoNerdFont-MediumItalic.ttf
+- RelativeFilePath: BlexMonoNerdFont-Regular.ttf
+- RelativeFilePath: BlexMonoNerdFont-SemiBold.ttf
+- RelativeFilePath: BlexMonoNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: BlexMonoNerdFont-Text.ttf
+- RelativeFilePath: BlexMonoNerdFont-TextItalic.ttf
+- RelativeFilePath: BlexMonoNerdFont-Thin.ttf
+- RelativeFilePath: BlexMonoNerdFont-ThinItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-Light.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-LightItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-Medium.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-SemiBold.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-Text.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-TextItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-Thin.ttf
+- RelativeFilePath: BlexMonoNerdFontMono-ThinItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-Light.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-Medium.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-Regular.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-Text.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-TextItalic.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-Thin.ttf
+- RelativeFilePath: BlexMonoNerdFontPropo-ThinItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/IBMPlexMono.zip
+  InstallerSha256: 0D79B601877B33804CB633F466DEA9527B5CD1DF812F74D95E2D7417A0B1ADF4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/IBMPlexMono/NerdFont/3.5.1/ryanoasis.IBMPlexMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/IBMPlexMono/NerdFont/3.5.1/ryanoasis.IBMPlexMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IBMPlexMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: IBMPlexMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: IBMPlexMono patched with Nerd Fonts glyphs
+Moniker: ibmplexmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/IBMPlexMono/NerdFont/3.5.1/ryanoasis.IBMPlexMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/IBMPlexMono/NerdFont/3.5.1/ryanoasis.IBMPlexMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IBMPlexMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.IBMPlexMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.IBMPlexMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/IBMPlexMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `IBM.Plex.Mono`; this is the Nerd Fonts patched build, a distinct package.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_