### PR TITLE
New package: ryanoasis.Recursive.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Recursive/NerdFont/3.5.1/ryanoasis.Recursive.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Recursive/NerdFont/3.5.1/ryanoasis.Recursive.NerdFont.installer.yaml
@@ -1,0 +1,62 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Recursive.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: RecMonoCasualNerdFont-Bold.ttf
+- RelativeFilePath: RecMonoCasualNerdFont-BoldItalic.ttf
+- RelativeFilePath: RecMonoCasualNerdFont-Italic.ttf
+- RelativeFilePath: RecMonoCasualNerdFont-Regular.ttf
+- RelativeFilePath: RecMonoCasualNerdFontMono-Bold.ttf
+- RelativeFilePath: RecMonoCasualNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: RecMonoCasualNerdFontMono-Italic.ttf
+- RelativeFilePath: RecMonoCasualNerdFontMono-Regular.ttf
+- RelativeFilePath: RecMonoCasualNerdFontPropo-Bold.ttf
+- RelativeFilePath: RecMonoCasualNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: RecMonoCasualNerdFontPropo-Italic.ttf
+- RelativeFilePath: RecMonoCasualNerdFontPropo-Regular.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFont-Bold.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFont-BoldItalic.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFont-Italic.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFont-Regular.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFontMono-Bold.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFontMono-Italic.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFontMono-Regular.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFontPropo-Bold.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFontPropo-Italic.ttf
+- RelativeFilePath: RecMonoDuotoneNerdFontPropo-Regular.ttf
+- RelativeFilePath: RecMonoLinearNerdFont-Bold.ttf
+- RelativeFilePath: RecMonoLinearNerdFont-BoldItalic.ttf
+- RelativeFilePath: RecMonoLinearNerdFont-Italic.ttf
+- RelativeFilePath: RecMonoLinearNerdFont-Regular.ttf
+- RelativeFilePath: RecMonoLinearNerdFontMono-Bold.ttf
+- RelativeFilePath: RecMonoLinearNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: RecMonoLinearNerdFontMono-Italic.ttf
+- RelativeFilePath: RecMonoLinearNerdFontMono-Regular.ttf
+- RelativeFilePath: RecMonoLinearNerdFontPropo-Bold.ttf
+- RelativeFilePath: RecMonoLinearNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: RecMonoLinearNerdFontPropo-Italic.ttf
+- RelativeFilePath: RecMonoLinearNerdFontPropo-Regular.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFont-Bold.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFont-BoldItalic.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFont-Italic.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFont-Regular.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFontMono-Bold.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFontMono-Italic.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFontMono-Regular.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFontPropo-Bold.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFontPropo-Italic.ttf
+- RelativeFilePath: RecMonoSmCasualNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Recursive.zip
+  InstallerSha256: 173F7231483B031ADBEBC540CF1A9AAFA255A303D5CDEF454BA75287C077245F
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Recursive/NerdFont/3.5.1/ryanoasis.Recursive.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Recursive/NerdFont/3.5.1/ryanoasis.Recursive.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Recursive.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Recursive Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Recursive patched with Nerd Fonts glyphs
+Moniker: recursive-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Recursive/NerdFont/3.5.1/ryanoasis.Recursive.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Recursive/NerdFont/3.5.1/ryanoasis.Recursive.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Recursive.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Recursive.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Recursive.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Recursive.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `ArrowType.Recursive`; this is the Nerd Fonts patched build, a distinct package.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_