### PR TITLE
New package: ryanoasis.BitstreamVeraSansMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/BitstreamVeraSansMono/NerdFont/3.5.1/ryanoasis.BitstreamVeraSansMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/BitstreamVeraSansMono/NerdFont/3.5.1/ryanoasis.BitstreamVeraSansMono.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.BitstreamVeraSansMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: BitstromWeraNerdFont-Bold.ttf
+- RelativeFilePath: BitstromWeraNerdFont-BoldOblique.ttf
+- RelativeFilePath: BitstromWeraNerdFont-Oblique.ttf
+- RelativeFilePath: BitstromWeraNerdFont-Regular.ttf
+- RelativeFilePath: BitstromWeraNerdFontMono-Bold.ttf
+- RelativeFilePath: BitstromWeraNerdFontMono-BoldOblique.ttf
+- RelativeFilePath: BitstromWeraNerdFontMono-Oblique.ttf
+- RelativeFilePath: BitstromWeraNerdFontMono-Regular.ttf
+- RelativeFilePath: BitstromWeraNerdFontPropo-Bold.ttf
+- RelativeFilePath: BitstromWeraNerdFontPropo-BoldOblique.ttf
+- RelativeFilePath: BitstromWeraNerdFontPropo-Oblique.ttf
+- RelativeFilePath: BitstromWeraNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/BitstreamVeraSansMono.zip
+  InstallerSha256: AC8881393A262F53DA48D9ABE3C3A5AA86DFFE581A556F94A09107532FDD62E1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/BitstreamVeraSansMono/NerdFont/3.5.1/ryanoasis.BitstreamVeraSansMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/BitstreamVeraSansMono/NerdFont/3.5.1/ryanoasis.BitstreamVeraSansMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.BitstreamVeraSansMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: BitstreamVeraSansMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Bitstream-Vera
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: BitstreamVeraSansMono patched with Nerd Fonts glyphs
+Moniker: bitstreamverasansmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/BitstreamVeraSansMono/NerdFont/3.5.1/ryanoasis.BitstreamVeraSansMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/BitstreamVeraSansMono/NerdFont/3.5.1/ryanoasis.BitstreamVeraSansMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.BitstreamVeraSansMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.BitstreamVeraSansMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.BitstreamVeraSansMono.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/BitstreamVeraSansMono.zip"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `Bitstream.Vera`; this is the Nerd Fonts patched build, a distinct package.

`License: Bitstream-Vera`, read from the archive. This is the font that prompted tightening the classifier in pl4nty/winget-extras#1280 — the Bitstream Vera licence begins "Permission is hereby granted, free of charge" and would otherwise have been misread as MIT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_