### PR TITLE
New package: ryanoasis.CascadiaMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/CascadiaMono/NerdFont/3.5.1/ryanoasis.CascadiaMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/CascadiaMono/NerdFont/3.5.1/ryanoasis.CascadiaMono.NerdFont.installer.yaml
@@ -1,0 +1,50 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CascadiaMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: CaskaydiaMonoNerdFont-Bold.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-ExtraLight.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-Italic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-Light.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-LightItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-Regular.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-SemiBold.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-SemiLight.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFont-SemiLightItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-Light.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-LightItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-SemiBold.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-SemiLight.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontMono-SemiLightItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-Light.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-Regular.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-SemiLight.ttf
+- RelativeFilePath: CaskaydiaMonoNerdFontPropo-SemiLightItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/CascadiaMono.zip
+  InstallerSha256: DE0CF0969685720F958788400CCE5A065D6BB49FF1F865C964341A604B01CBD8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/CascadiaMono/NerdFont/3.5.1/ryanoasis.CascadiaMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/CascadiaMono/NerdFont/3.5.1/ryanoasis.CascadiaMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CascadiaMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: CascadiaMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: CascadiaMono patched with Nerd Fonts glyphs
+Moniker: cascadiamono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/CascadiaMono/NerdFont/3.5.1/ryanoasis.CascadiaMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/CascadiaMono/NerdFont/3.5.1/ryanoasis.CascadiaMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CascadiaMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.CascadiaMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.CascadiaMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/CascadiaMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. Cascadia Mono is the ligature-free sibling of Cascadia Code, packaged separately upstream and here.

`License: OFL-1.1` is read from the `LICENSE` file inside the release archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_