### PR TITLE
New package: ryanoasis.Cousine.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Cousine/NerdFont/3.5.1/ryanoasis.Cousine.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Cousine/NerdFont/3.5.1/ryanoasis.Cousine.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Cousine.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: CousineNerdFont-Bold.ttf
+- RelativeFilePath: CousineNerdFont-BoldItalic.ttf
+- RelativeFilePath: CousineNerdFont-Italic.ttf
+- RelativeFilePath: CousineNerdFont-Regular.ttf
+- RelativeFilePath: CousineNerdFontMono-Bold.ttf
+- RelativeFilePath: CousineNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: CousineNerdFontMono-Italic.ttf
+- RelativeFilePath: CousineNerdFontMono-Regular.ttf
+- RelativeFilePath: CousineNerdFontPropo-Bold.ttf
+- RelativeFilePath: CousineNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: CousineNerdFontPropo-Italic.ttf
+- RelativeFilePath: CousineNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Cousine.zip
+  InstallerSha256: 860DBB1494A83B0EC2331B9683BFE65C4CC4F9916E74C98935C0247D734E82CD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Cousine/NerdFont/3.5.1/ryanoasis.Cousine.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Cousine/NerdFont/3.5.1/ryanoasis.Cousine.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Cousine.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Cousine Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Cousine patched with Nerd Fonts glyphs
+Moniker: cousine-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Cousine/NerdFont/3.5.1/ryanoasis.Cousine.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Cousine/NerdFont/3.5.1/ryanoasis.Cousine.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Cousine.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Cousine.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Cousine.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Cousine.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1`, read from the archive. Worth noting for reviewers who remember otherwise: Cousine shipped under Apache-2.0 for years as a Chrome OS core font, and the archive confirms it is now OFL-1.1. The licence is read per archive precisely so stale assumptions like that do not end up in the manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_