### PR TITLE
New package: ryanoasis.Arimo.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Arimo/NerdFont/3.5.1/ryanoasis.Arimo.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Arimo/NerdFont/3.5.1/ryanoasis.Arimo.NerdFont.installer.yaml
@@ -1,0 +1,22 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Arimo.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: ArimoNerdFont-Bold.ttf
+- RelativeFilePath: ArimoNerdFont-BoldItalic.ttf
+- RelativeFilePath: ArimoNerdFont-Italic.ttf
+- RelativeFilePath: ArimoNerdFont-Regular.ttf
+- RelativeFilePath: ArimoNerdFontPropo-Bold.ttf
+- RelativeFilePath: ArimoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: ArimoNerdFontPropo-Italic.ttf
+- RelativeFilePath: ArimoNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Arimo.zip
+  InstallerSha256: 333D56A85FC66F691952417FEFB06E04CF07558ED968B517FB91902656979E37
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Arimo/NerdFont/3.5.1/ryanoasis.Arimo.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Arimo/NerdFont/3.5.1/ryanoasis.Arimo.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Arimo.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Arimo Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Arimo patched with Nerd Fonts glyphs
+Moniker: arimo-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Arimo/NerdFont/3.5.1/ryanoasis.Arimo.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Arimo/NerdFont/3.5.1/ryanoasis.Arimo.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Arimo.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Arimo.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Arimo.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Arimo.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1`, read from the archive — like Cousine, Arimo was an Apache-2.0 Chrome OS core font before Google relicensed the family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_