### PR TITLE
New package: ryanoasis.Tinos.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Tinos/NerdFont/3.5.1/ryanoasis.Tinos.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Tinos/NerdFont/3.5.1/ryanoasis.Tinos.NerdFont.installer.yaml
@@ -1,0 +1,22 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Tinos.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: TinosNerdFont-Bold.ttf
+- RelativeFilePath: TinosNerdFont-BoldItalic.ttf
+- RelativeFilePath: TinosNerdFont-Italic.ttf
+- RelativeFilePath: TinosNerdFont-Regular.ttf
+- RelativeFilePath: TinosNerdFontPropo-Bold.ttf
+- RelativeFilePath: TinosNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: TinosNerdFontPropo-Italic.ttf
+- RelativeFilePath: TinosNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Tinos.zip
+  InstallerSha256: 9E418CE58A110A2915549981A5A4B86B830E12D44D597B2FE3CAB9C93C2402DE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Tinos/NerdFont/3.5.1/ryanoasis.Tinos.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Tinos/NerdFont/3.5.1/ryanoasis.Tinos.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Tinos.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Tinos Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Apache-2.0
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Tinos patched with Nerd Fonts glyphs
+Moniker: tinos-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Tinos/NerdFont/3.5.1/ryanoasis.Tinos.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Tinos/NerdFont/3.5.1/ryanoasis.Tinos.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Tinos.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Tinos.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Tinos.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Tinos.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: Apache-2.0`, read from the archive — and worth flagging, because Tinos does **not** match its siblings. Arimo (pl4nty/winget-extras#1296) and Cousine (pl4nty/winget-extras#1295) are the other two Chrome OS metric-compatible fonts and both ship OFL-1.1 in their archives, while Tinos still ships Apache-2.0. Three sibling fonts, two licences: this is precisely why each package in the series takes its licence from its own archive rather than from a family-level assumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_