### PR TITLE
New package: ryanoasis.Ubuntu.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Ubuntu/NerdFont/3.5.1/ryanoasis.Ubuntu.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/NerdFont/3.5.1/ryanoasis.Ubuntu.NerdFont.installer.yaml
@@ -1,0 +1,32 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Ubuntu.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: UbuntuNerdFont-Bold.ttf
+- RelativeFilePath: UbuntuNerdFont-BoldItalic.ttf
+- RelativeFilePath: UbuntuNerdFont-Condensed.ttf
+- RelativeFilePath: UbuntuNerdFont-Italic.ttf
+- RelativeFilePath: UbuntuNerdFont-Light.ttf
+- RelativeFilePath: UbuntuNerdFont-LightItalic.ttf
+- RelativeFilePath: UbuntuNerdFont-Medium.ttf
+- RelativeFilePath: UbuntuNerdFont-MediumItalic.ttf
+- RelativeFilePath: UbuntuNerdFont-Regular.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-Bold.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-Condensed.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-Italic.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-Light.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-Medium.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: UbuntuNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Ubuntu.zip
+  InstallerSha256: 57EE0D7B5E41853E8DABECF7B99129B250CEA0B2E324DBCF4B4E088848AB221E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Ubuntu/NerdFont/3.5.1/ryanoasis.Ubuntu.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/NerdFont/3.5.1/ryanoasis.Ubuntu.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Ubuntu.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Ubuntu Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Ubuntu-font-1.0
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Ubuntu patched with Nerd Fonts glyphs
+Moniker: ubuntu-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Ubuntu/NerdFont/3.5.1/ryanoasis.Ubuntu.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Ubuntu/NerdFont/3.5.1/ryanoasis.Ubuntu.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Ubuntu.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Ubuntu.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Ubuntu.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Ubuntu.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. This repo already carries the unpatched `Canonical.UbuntuFont`; this is the Nerd Fonts patched build, a distinct package.

`License: Ubuntu-font-1.0` is read from the archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_