### PR TITLE
New package: ryanoasis.UbuntuSans.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/UbuntuSans/NerdFont/3.5.1/ryanoasis.UbuntuSans.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/UbuntuSans/NerdFont/3.5.1/ryanoasis.UbuntuSans.NerdFont.installer.yaml
@@ -1,0 +1,54 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.UbuntuSans.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: UbuntuSansMonoNerdFont-Bold.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFont-Italic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFont-Medium.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFont-MediumItalic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFont-Regular.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFont-SemiBold.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontMono-Medium.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontMono-SemiBold.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontPropo-Medium.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontPropo-Regular.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: UbuntuSansMonoNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: UbuntuSansNerdFont-Bold.ttf
+- RelativeFilePath: UbuntuSansNerdFont-BoldItalic.ttf
+- RelativeFilePath: UbuntuSansNerdFont-Italic.ttf
+- RelativeFilePath: UbuntuSansNerdFont-Medium.ttf
+- RelativeFilePath: UbuntuSansNerdFont-MediumItalic.ttf
+- RelativeFilePath: UbuntuSansNerdFont-Regular.ttf
+- RelativeFilePath: UbuntuSansNerdFont-SemiBold.ttf
+- RelativeFilePath: UbuntuSansNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: UbuntuSansNerdFontPropo-Bold.ttf
+- RelativeFilePath: UbuntuSansNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: UbuntuSansNerdFontPropo-Italic.ttf
+- RelativeFilePath: UbuntuSansNerdFontPropo-Medium.ttf
+- RelativeFilePath: UbuntuSansNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: UbuntuSansNerdFontPropo-Regular.ttf
+- RelativeFilePath: UbuntuSansNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: UbuntuSansNerdFontPropo-SemiBoldItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/UbuntuSans.zip
+  InstallerSha256: 2E7DC2D1E116D1F4FD9D2FC65071F5C6C5C95AF0C1484379B06581161466AE0B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/UbuntuSans/NerdFont/3.5.1/ryanoasis.UbuntuSans.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/UbuntuSans/NerdFont/3.5.1/ryanoasis.UbuntuSans.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.UbuntuSans.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: UbuntuSans Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Ubuntu-font-1.0
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: UbuntuSans patched with Nerd Fonts glyphs
+Moniker: ubuntusans-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/UbuntuSans/NerdFont/3.5.1/ryanoasis.UbuntuSans.NerdFont.yaml
+++ b/fonts/r/ryanoasis/UbuntuSans/NerdFont/3.5.1/ryanoasis.UbuntuSans.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.UbuntuSans.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.UbuntuSans.NerdFont.Font.json
+++ b/shards/json/ryanoasis.UbuntuSans.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/UbuntuSans.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. Ubuntu Sans is Canonical's 2023 redesign, packaged separately from the original Ubuntu family.

`License: Ubuntu-font-1.0` is read from the archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_