### PR TITLE
New package: ryanoasis.ZedMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/ZedMono/NerdFont/3.5.1/ryanoasis.ZedMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/ZedMono/NerdFont/3.5.1/ryanoasis.ZedMono.NerdFont.installer.yaml
@@ -1,0 +1,104 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ZedMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: ZedMonoNerdFont-Bold.ttf
+- RelativeFilePath: ZedMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-BoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-Extended.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedBold.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedExtraBold.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedExtraBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedExtraBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedLight.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedLightItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedLightOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedMedium.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedMediumItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedMediumOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtendedOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtraBold.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtraBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-ExtraBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-Italic.ttf
+- RelativeFilePath: ZedMonoNerdFont-Light.ttf
+- RelativeFilePath: ZedMonoNerdFont-LightItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-LightOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-Medium.ttf
+- RelativeFilePath: ZedMonoNerdFont-MediumItalic.ttf
+- RelativeFilePath: ZedMonoNerdFont-MediumOblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-Oblique.ttf
+- RelativeFilePath: ZedMonoNerdFont-Regular.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-BoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-Extended.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedBold.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedExtraBold.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedExtraBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedExtraBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedLight.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedLightItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedLightOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedMedium.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedMediumItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedMediumOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtendedOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtraBold.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtraBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-ExtraBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-Light.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-LightItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-LightOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-Medium.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-MediumOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-Oblique.ttf
+- RelativeFilePath: ZedMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-BoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-Extended.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedBold.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedExtraBold.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedExtraBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedExtraBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedLight.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedLightItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedLightOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedMedium.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedMediumItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedMediumOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtendedOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtraBoldItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-ExtraBoldOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-Light.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-LightOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-Medium.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-MediumOblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-Oblique.ttf
+- RelativeFilePath: ZedMonoNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/ZedMono.zip
+  InstallerSha256: F7B7DACCA1D3B4D0548CE5FE0F97FF926B96F5AF9944224CEA8E6F0E36BFCF96
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/ZedMono/NerdFont/3.5.1/ryanoasis.ZedMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ZedMono/NerdFont/3.5.1/ryanoasis.ZedMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ZedMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: ZedMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: ZedMono patched with Nerd Fonts glyphs
+Moniker: zedmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/ZedMono/NerdFont/3.5.1/ryanoasis.ZedMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/ZedMono/NerdFont/3.5.1/ryanoasis.ZedMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ZedMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.ZedMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.ZedMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/ZedMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_