### PR TITLE
New package: ryanoasis.Monofur.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Monofur/NerdFont/3.5.1/ryanoasis.Monofur.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Monofur/NerdFont/3.5.1/ryanoasis.Monofur.NerdFont.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Monofur.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: MonofurNerdFont-Bold.ttf
+- RelativeFilePath: MonofurNerdFont-Italic.ttf
+- RelativeFilePath: MonofurNerdFont-Regular.ttf
+- RelativeFilePath: MonofurNerdFontMono-Bold.ttf
+- RelativeFilePath: MonofurNerdFontMono-Italic.ttf
+- RelativeFilePath: MonofurNerdFontMono-Regular.ttf
+- RelativeFilePath: MonofurNerdFontPropo-Bold.ttf
+- RelativeFilePath: MonofurNerdFontPropo-Italic.ttf
+- RelativeFilePath: MonofurNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Monofur.zip
+  InstallerSha256: 96BBAEF53E69DCD3286D3226336531322F2AE07095A4F866B515FB2620D7D282
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Monofur/NerdFont/3.5.1/ryanoasis.Monofur.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Monofur/NerdFont/3.5.1/ryanoasis.Monofur.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Monofur.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Monofur Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Freeware
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Monofur patched with Nerd Fonts glyphs
+Moniker: monofur-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Monofur/NerdFont/3.5.1/ryanoasis.Monofur.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Monofur/NerdFont/3.5.1/ryanoasis.Monofur.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Monofur.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Monofur.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Monofur.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Monofur.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: Freeware` rather than an SPDX identifier, and this one was **not** classified automatically. Monofur ships a bespoke notice from its author rather than a standard licence:

> These fonts are freeware and can be distributed as long as they are together with this text file.

That matches no SPDX identifier, so the automated classifier declined to guess and refused to build the package; the value was set by hand after reading the terms. `Freeware` follows the convention already used in this repo for `TeXLive.TeXLive` and `ReVoltGL.RVGL`.

Note the redistribution condition: the archive's `LICENSE.txt` is required to travel with the fonts. WinGet installs only the `.ttf` files listed in `NestedInstallerFiles`, so the licence file is not placed on disk — flagging it in case that matters to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_