### PR TITLE
New package: ryanoasis.OpenDyslexic.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/OpenDyslexic/NerdFont/3.5.1/ryanoasis.OpenDyslexic.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/OpenDyslexic/NerdFont/3.5.1/ryanoasis.OpenDyslexic.NerdFont.installer.yaml
@@ -1,0 +1,33 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.OpenDyslexic.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: OpenDyslexicAltNerdFont-Bold.otf
+- RelativeFilePath: OpenDyslexicAltNerdFont-BoldItalic.otf
+- RelativeFilePath: OpenDyslexicAltNerdFont-Italic.otf
+- RelativeFilePath: OpenDyslexicAltNerdFont-Regular.otf
+- RelativeFilePath: OpenDyslexicAltNerdFontPropo-Bold.otf
+- RelativeFilePath: OpenDyslexicAltNerdFontPropo-BoldItalic.otf
+- RelativeFilePath: OpenDyslexicAltNerdFontPropo-Italic.otf
+- RelativeFilePath: OpenDyslexicAltNerdFontPropo-Regular.otf
+- RelativeFilePath: OpenDyslexicMNerdFont-Regular.otf
+- RelativeFilePath: OpenDyslexicMNerdFontMono-Regular.otf
+- RelativeFilePath: OpenDyslexicMNerdFontPropo-Regular.otf
+- RelativeFilePath: OpenDyslexicNerdFont-Bold.otf
+- RelativeFilePath: OpenDyslexicNerdFont-BoldItalic.otf
+- RelativeFilePath: OpenDyslexicNerdFont-Italic.otf
+- RelativeFilePath: OpenDyslexicNerdFont-Regular.otf
+- RelativeFilePath: OpenDyslexicNerdFontPropo-Bold.otf
+- RelativeFilePath: OpenDyslexicNerdFontPropo-BoldItalic.otf
+- RelativeFilePath: OpenDyslexicNerdFontPropo-Italic.otf
+- RelativeFilePath: OpenDyslexicNerdFontPropo-Regular.otf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/OpenDyslexic.zip
+  InstallerSha256: 3B03B18B5C2436490D4F4DF0D51F74CB0416EE74DDB189E3B698FD8B70807697
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/OpenDyslexic/NerdFont/3.5.1/ryanoasis.OpenDyslexic.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/OpenDyslexic/NerdFont/3.5.1/ryanoasis.OpenDyslexic.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.OpenDyslexic.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: OpenDyslexic Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Bitstream-Vera
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: OpenDyslexic patched with Nerd Fonts glyphs
+Moniker: opendyslexic-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/OpenDyslexic/NerdFont/3.5.1/ryanoasis.OpenDyslexic.NerdFont.yaml
+++ b/fonts/r/ryanoasis/OpenDyslexic/NerdFont/3.5.1/ryanoasis.OpenDyslexic.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.OpenDyslexic.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.OpenDyslexic.NerdFont.Font.json
+++ b/shards/json/ryanoasis.OpenDyslexic.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/OpenDyslexic.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. OpenDyslexic is designed to aid readers with dyslexia.

`License: Bitstream-Vera`, read from the archive. That is not a mistake: OpenDyslexic derives from Bitstream Vera and carries its licence, so it is the third font in this series under that identifier alongside `BitstreamVeraSansMono` and `DejaVuSansMono`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_