### PR TITLE
New package: ryanoasis.IntelOneMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/IntelOneMono/NerdFont/3.5.1/ryanoasis.IntelOneMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/IntelOneMono/NerdFont/3.5.1/ryanoasis.IntelOneMono.NerdFont.installer.yaml
@@ -1,0 +1,38 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IntelOneMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: IntoneMonoNerdFont-Bold.ttf
+- RelativeFilePath: IntoneMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFont-Italic.ttf
+- RelativeFilePath: IntoneMonoNerdFont-Light.ttf
+- RelativeFilePath: IntoneMonoNerdFont-LightItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFont-Medium.ttf
+- RelativeFilePath: IntoneMonoNerdFont-MediumItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFont-Regular.ttf
+- RelativeFilePath: IntoneMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: IntoneMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: IntoneMonoNerdFontMono-Light.ttf
+- RelativeFilePath: IntoneMonoNerdFontMono-LightItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFontMono-Medium.ttf
+- RelativeFilePath: IntoneMonoNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: IntoneMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: IntoneMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: IntoneMonoNerdFontPropo-Light.ttf
+- RelativeFilePath: IntoneMonoNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFontPropo-Medium.ttf
+- RelativeFilePath: IntoneMonoNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: IntoneMonoNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/IntelOneMono.zip
+  InstallerSha256: 72258950F9338C41EB640DB9D6F4117026B95C47AFDF87A96BAAF106B7904B41
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/IntelOneMono/NerdFont/3.5.1/ryanoasis.IntelOneMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/IntelOneMono/NerdFont/3.5.1/ryanoasis.IntelOneMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IntelOneMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: IntelOneMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: IntelOneMono patched with Nerd Fonts glyphs
+Moniker: intelonemono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/IntelOneMono/NerdFont/3.5.1/ryanoasis.IntelOneMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/IntelOneMono/NerdFont/3.5.1/ryanoasis.IntelOneMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IntelOneMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.IntelOneMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.IntelOneMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/IntelOneMono.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the archive rather than assumed.

This one is worth a note on provenance: its first build attempt failed because the download truncated at 160 KB of 32 MB. The archive was re-fetched and its size verified against the server's `Content-Length` before hashing, so the `InstallerSha256` here corresponds to the complete file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_