### PR TITLE
New package: ryanoasis.Overpass.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Overpass/NerdFont/3.5.1/ryanoasis.Overpass.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Overpass/NerdFont/3.5.1/ryanoasis.Overpass.NerdFont.installer.yaml
@@ -1,0 +1,58 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Overpass.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: OverpassMNerdFont-Bold.otf
+- RelativeFilePath: OverpassMNerdFont-Light.otf
+- RelativeFilePath: OverpassMNerdFont-Regular.otf
+- RelativeFilePath: OverpassMNerdFont-SemiBold.otf
+- RelativeFilePath: OverpassMNerdFontMono-Bold.otf
+- RelativeFilePath: OverpassMNerdFontMono-Light.otf
+- RelativeFilePath: OverpassMNerdFontMono-Regular.otf
+- RelativeFilePath: OverpassMNerdFontMono-SemiBold.otf
+- RelativeFilePath: OverpassMNerdFontPropo-Bold.otf
+- RelativeFilePath: OverpassMNerdFontPropo-Light.otf
+- RelativeFilePath: OverpassMNerdFontPropo-Regular.otf
+- RelativeFilePath: OverpassMNerdFontPropo-SemiBold.otf
+- RelativeFilePath: OverpassNerdFont-Bold.otf
+- RelativeFilePath: OverpassNerdFont-BoldItalic.otf
+- RelativeFilePath: OverpassNerdFont-ExtraBold.otf
+- RelativeFilePath: OverpassNerdFont-ExtraBoldItalic.otf
+- RelativeFilePath: OverpassNerdFont-ExtraLight.otf
+- RelativeFilePath: OverpassNerdFont-ExtraLightItalic.otf
+- RelativeFilePath: OverpassNerdFont-Heavy.otf
+- RelativeFilePath: OverpassNerdFont-HeavyItalic.otf
+- RelativeFilePath: OverpassNerdFont-Italic.otf
+- RelativeFilePath: OverpassNerdFont-Light.otf
+- RelativeFilePath: OverpassNerdFont-LightItalic.otf
+- RelativeFilePath: OverpassNerdFont-Regular.otf
+- RelativeFilePath: OverpassNerdFont-SemiBold.otf
+- RelativeFilePath: OverpassNerdFont-SemiBoldItalic.otf
+- RelativeFilePath: OverpassNerdFont-Thin.otf
+- RelativeFilePath: OverpassNerdFont-ThinItalic.otf
+- RelativeFilePath: OverpassNerdFontPropo-Bold.otf
+- RelativeFilePath: OverpassNerdFontPropo-BoldItalic.otf
+- RelativeFilePath: OverpassNerdFontPropo-ExtraBold.otf
+- RelativeFilePath: OverpassNerdFontPropo-ExtraBoldItalic.otf
+- RelativeFilePath: OverpassNerdFontPropo-ExtraLight.otf
+- RelativeFilePath: OverpassNerdFontPropo-ExtraLightItalic.otf
+- RelativeFilePath: OverpassNerdFontPropo-Heavy.otf
+- RelativeFilePath: OverpassNerdFontPropo-HeavyItalic.otf
+- RelativeFilePath: OverpassNerdFontPropo-Italic.otf
+- RelativeFilePath: OverpassNerdFontPropo-Light.otf
+- RelativeFilePath: OverpassNerdFontPropo-LightItalic.otf
+- RelativeFilePath: OverpassNerdFontPropo-Regular.otf
+- RelativeFilePath: OverpassNerdFontPropo-SemiBold.otf
+- RelativeFilePath: OverpassNerdFontPropo-SemiBoldItalic.otf
+- RelativeFilePath: OverpassNerdFontPropo-Thin.otf
+- RelativeFilePath: OverpassNerdFontPropo-ThinItalic.otf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Overpass.zip
+  InstallerSha256: DD9ABCBE80C68F51B6374BBBDB711BE3B8F6EB7E2BFB9667C7EC7E5DBDCC8452
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Overpass/NerdFont/3.5.1/ryanoasis.Overpass.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Overpass/NerdFont/3.5.1/ryanoasis.Overpass.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Overpass.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Overpass Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Overpass patched with Nerd Fonts glyphs
+Moniker: overpass-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Overpass/NerdFont/3.5.1/ryanoasis.Overpass.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Overpass/NerdFont/3.5.1/ryanoasis.Overpass.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Overpass.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Overpass.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Overpass.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Overpass.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_