### PR TITLE
New package: ryanoasis.ProggyClean.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/ProggyClean/NerdFont/3.5.1/ryanoasis.ProggyClean.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/ProggyClean/NerdFont/3.5.1/ryanoasis.ProggyClean.NerdFont.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ProggyClean.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: ProggyCleanCENerdFont-Regular.ttf
+- RelativeFilePath: ProggyCleanCENerdFontMono-Regular.ttf
+- RelativeFilePath: ProggyCleanCENerdFontPropo-Regular.ttf
+- RelativeFilePath: ProggyCleanNerdFont-Regular.ttf
+- RelativeFilePath: ProggyCleanNerdFontMono-Regular.ttf
+- RelativeFilePath: ProggyCleanNerdFontPropo-Regular.ttf
+- RelativeFilePath: ProggyCleanSZNerdFont-Regular.ttf
+- RelativeFilePath: ProggyCleanSZNerdFontMono-Regular.ttf
+- RelativeFilePath: ProggyCleanSZNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/ProggyClean.zip
+  InstallerSha256: 156BA5DA70C88DDAB0151695F0D656F017A74D6663E7F54FDA00C421618E2EB2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/ProggyClean/NerdFont/3.5.1/ryanoasis.ProggyClean.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ProggyClean/NerdFont/3.5.1/ryanoasis.ProggyClean.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ProggyClean.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: ProggyClean Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: MIT
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: ProggyClean patched with Nerd Fonts glyphs
+Moniker: proggyclean-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/ProggyClean/NerdFont/3.5.1/ryanoasis.ProggyClean.NerdFont.yaml
+++ b/fonts/r/ryanoasis/ProggyClean/NerdFont/3.5.1/ryanoasis.ProggyClean.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ProggyClean.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.ProggyClean.NerdFont.Font.json
+++ b/shards/json/ryanoasis.ProggyClean.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/ProggyClean.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: MIT`, read from the archive. Proggy fonts were long described as public domain, so MIT is the archive's own statement rather than the reputation — another reason each package takes its licence from its own archive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_