### PR TITLE
New package: ryanoasis.D2Coding.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/D2Coding/NerdFont/3.5.1/ryanoasis.D2Coding.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/D2Coding/NerdFont/3.5.1/ryanoasis.D2Coding.NerdFont.installer.yaml
@@ -1,0 +1,20 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.D2Coding.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: D2KodingLigatureNerdFont-Bold.ttf
+- RelativeFilePath: D2KodingLigatureNerdFont-Regular.ttf
+- RelativeFilePath: D2KodingLigatureNerdFontMono-Bold.ttf
+- RelativeFilePath: D2KodingLigatureNerdFontMono-Regular.ttf
+- RelativeFilePath: D2KodingLigatureNerdFontPropo-Bold.ttf
+- RelativeFilePath: D2KodingLigatureNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/D2Coding.zip
+  InstallerSha256: 8D1597B1537AFDC8F2F7C75036A8224BC837E6C248062B80013A13258258541D
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/D2Coding/NerdFont/3.5.1/ryanoasis.D2Coding.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/D2Coding/NerdFont/3.5.1/ryanoasis.D2Coding.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.D2Coding.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: D2Coding Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: D2Coding patched with Nerd Fonts glyphs
+Moniker: d2coding-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/D2Coding/NerdFont/3.5.1/ryanoasis.D2Coding.NerdFont.yaml
+++ b/fonts/r/ryanoasis/D2Coding/NerdFont/3.5.1/ryanoasis.D2Coding.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.D2Coding.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.D2Coding.NerdFont.Font.json
+++ b/shards/json/ryanoasis.D2Coding.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/D2Coding.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request. D2Coding is Naver's Korean-capable coding font.

`License: OFL-1.1` is read from the archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_