### PR TITLE
New package: ryanoasis.LiberationMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/LiberationMono/NerdFont/3.5.1/ryanoasis.LiberationMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/LiberationMono/NerdFont/3.5.1/ryanoasis.LiberationMono.NerdFont.installer.yaml
@@ -1,0 +1,42 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.LiberationMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: LiterationMonoNerdFont-Bold.ttf
+- RelativeFilePath: LiterationMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: LiterationMonoNerdFont-Italic.ttf
+- RelativeFilePath: LiterationMonoNerdFont-Regular.ttf
+- RelativeFilePath: LiterationMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: LiterationMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: LiterationMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: LiterationMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: LiterationMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: LiterationMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: LiterationMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: LiterationMonoNerdFontPropo-Regular.ttf
+- RelativeFilePath: LiterationSansNerdFont-Bold.ttf
+- RelativeFilePath: LiterationSansNerdFont-BoldItalic.ttf
+- RelativeFilePath: LiterationSansNerdFont-Italic.ttf
+- RelativeFilePath: LiterationSansNerdFont-Regular.ttf
+- RelativeFilePath: LiterationSansNerdFontPropo-Bold.ttf
+- RelativeFilePath: LiterationSansNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: LiterationSansNerdFontPropo-Italic.ttf
+- RelativeFilePath: LiterationSansNerdFontPropo-Regular.ttf
+- RelativeFilePath: LiterationSerifNerdFont-Bold.ttf
+- RelativeFilePath: LiterationSerifNerdFont-BoldItalic.ttf
+- RelativeFilePath: LiterationSerifNerdFont-Italic.ttf
+- RelativeFilePath: LiterationSerifNerdFont-Regular.ttf
+- RelativeFilePath: LiterationSerifNerdFontPropo-Bold.ttf
+- RelativeFilePath: LiterationSerifNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: LiterationSerifNerdFontPropo-Italic.ttf
+- RelativeFilePath: LiterationSerifNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/LiberationMono.zip
+  InstallerSha256: AC948E1D68061CBF249EE20A42D5EE0140CA191935AC4B01CC1AA786752A76EE
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/LiberationMono/NerdFont/3.5.1/ryanoasis.LiberationMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/LiberationMono/NerdFont/3.5.1/ryanoasis.LiberationMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.LiberationMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: LiberationMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: LiberationMono patched with Nerd Fonts glyphs
+Moniker: liberationmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/LiberationMono/NerdFont/3.5.1/ryanoasis.LiberationMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/LiberationMono/NerdFont/3.5.1/ryanoasis.LiberationMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.LiberationMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.LiberationMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.LiberationMono.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/LiberationMono.zip"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_