### PR TITLE
New package: ryanoasis.GoogleSansCode.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/GoogleSansCode/NerdFont/3.5.1/ryanoasis.GoogleSansCode.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/GoogleSansCode/NerdFont/3.5.1/ryanoasis.GoogleSansCode.NerdFont.installer.yaml
@@ -1,0 +1,50 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.GoogleSansCode.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: GoogleSansCodeNerdFont-Bold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-BoldItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-ExtraBold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-ExtraBoldItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-Italic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-Light.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-LightItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-Medium.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-MediumItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-Regular.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-SemiBold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-Bold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-ExtraBold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-ExtraBoldItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-Italic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-Light.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-LightItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-Medium.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-Regular.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-SemiBold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-Bold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-ExtraBoldItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-Italic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-Light.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-Medium.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-Regular.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: GoogleSansCodeNerdFontPropo-SemiBoldItalic.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/GoogleSansCode.zip
+  InstallerSha256: B09B9A0410FE95D3720C48AA51BB34304AF19A0A06CACEFAB042D2CC709E1A76
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/GoogleSansCode/NerdFont/3.5.1/ryanoasis.GoogleSansCode.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/GoogleSansCode/NerdFont/3.5.1/ryanoasis.GoogleSansCode.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.GoogleSansCode.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: GoogleSansCode Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: GoogleSansCode patched with Nerd Fonts glyphs
+Moniker: googlesanscode-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/GoogleSansCode/NerdFont/3.5.1/ryanoasis.GoogleSansCode.NerdFont.yaml
+++ b/fonts/r/ryanoasis/GoogleSansCode/NerdFont/3.5.1/ryanoasis.GoogleSansCode.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.GoogleSansCode.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.GoogleSansCode.NerdFont.Font.json
+++ b/shards/json/ryanoasis.GoogleSansCode.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/GoogleSansCode.zip"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_