### PR TITLE
New package: ryanoasis.CodeNewRoman.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/CodeNewRoman/NerdFont/3.5.1/ryanoasis.CodeNewRoman.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/CodeNewRoman/NerdFont/3.5.1/ryanoasis.CodeNewRoman.NerdFont.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CodeNewRoman.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: CodeNewRomanNerdFont-Bold.otf
+- RelativeFilePath: CodeNewRomanNerdFont-Italic.otf
+- RelativeFilePath: CodeNewRomanNerdFont-Regular.otf
+- RelativeFilePath: CodeNewRomanNerdFontMono-Bold.otf
+- RelativeFilePath: CodeNewRomanNerdFontMono-Italic.otf
+- RelativeFilePath: CodeNewRomanNerdFontMono-Regular.otf
+- RelativeFilePath: CodeNewRomanNerdFontPropo-Bold.otf
+- RelativeFilePath: CodeNewRomanNerdFontPropo-Italic.otf
+- RelativeFilePath: CodeNewRomanNerdFontPropo-Regular.otf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/CodeNewRoman.zip
+  InstallerSha256: 878CB2E310CBC3B9B58D748E69280F141488C27806E86321657AF2795D7207B4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/CodeNewRoman/NerdFont/3.5.1/ryanoasis.CodeNewRoman.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/CodeNewRoman/NerdFont/3.5.1/ryanoasis.CodeNewRoman.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CodeNewRoman.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: CodeNewRoman Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: CodeNewRoman patched with Nerd Fonts glyphs
+Moniker: codenewroman-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/CodeNewRoman/NerdFont/3.5.1/ryanoasis.CodeNewRoman.NerdFont.yaml
+++ b/fonts/r/ryanoasis/CodeNewRoman/NerdFont/3.5.1/ryanoasis.CodeNewRoman.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.CodeNewRoman.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.CodeNewRoman.NerdFont.Font.json
+++ b/shards/json/ryanoasis.CodeNewRoman.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/CodeNewRoman.zip"]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#17547

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Part of the Nerd Fonts patched families, from the long-standing upstream request.

`License: OFL-1.1` is read from the archive rather than assumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_