### PR TITLE
New package: ryanoasis.3270.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/3270/NerdFont/3.5.1/ryanoasis.3270.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/3270/NerdFont/3.5.1/ryanoasis.3270.NerdFont.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.3270.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: 3270NerdFont-Condensed.ttf
+- RelativeFilePath: 3270NerdFont-Regular.ttf
+- RelativeFilePath: 3270NerdFont-SemiCondensed.ttf
+- RelativeFilePath: 3270NerdFontMono-Condensed.ttf
+- RelativeFilePath: 3270NerdFontMono-Regular.ttf
+- RelativeFilePath: 3270NerdFontMono-SemiCondensed.ttf
+- RelativeFilePath: 3270NerdFontPropo-Condensed.ttf
+- RelativeFilePath: 3270NerdFontPropo-Regular.ttf
+- RelativeFilePath: 3270NerdFontPropo-SemiCondensed.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/3270.zip
+  InstallerSha256: 6EDB49851FBCC34326188529F36735913DF40AB79784E00AB89DB3AAA2E6ECBD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/3270/NerdFont/3.5.1/ryanoasis.3270.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/3270/NerdFont/3.5.1/ryanoasis.3270.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.3270.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: 3270 Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: 3270 patched with Nerd Fonts glyphs
+Moniker: 3270-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/3270/NerdFont/3.5.1/ryanoasis.3270.NerdFont.yaml
+++ b/fonts/r/ryanoasis/3270/NerdFont/3.5.1/ryanoasis.3270.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.3270.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.3270.NerdFont.Font.json
+++ b/shards/json/ryanoasis.3270.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/3270.zip"]
+}


### PR DESCRIPTION
Adds the 3270 Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_