### PR TITLE
New package: ryanoasis.Agave.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Agave/NerdFont/3.5.1/ryanoasis.Agave.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Agave/NerdFont/3.5.1/ryanoasis.Agave.NerdFont.installer.yaml
@@ -1,0 +1,20 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Agave.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: AgaveNerdFont-Bold.ttf
+- RelativeFilePath: AgaveNerdFont-Regular.ttf
+- RelativeFilePath: AgaveNerdFontMono-Bold.ttf
+- RelativeFilePath: AgaveNerdFontMono-Regular.ttf
+- RelativeFilePath: AgaveNerdFontPropo-Bold.ttf
+- RelativeFilePath: AgaveNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Agave.zip
+  InstallerSha256: F53C8052BD117ADED74055FEDF41351F1CB61F0B26BCCB8B901A170385170837
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Agave/NerdFont/3.5.1/ryanoasis.Agave.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Agave/NerdFont/3.5.1/ryanoasis.Agave.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Agave.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Agave Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Agave patched with Nerd Fonts glyphs
+Moniker: agave-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Agave/NerdFont/3.5.1/ryanoasis.Agave.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Agave/NerdFont/3.5.1/ryanoasis.Agave.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Agave.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Agave.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Agave.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Agave.zip"]
+}


### PR DESCRIPTION
Adds the Agave Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_