### PR TITLE
New package: ryanoasis.AnnotationMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/AnnotationMono/NerdFont/3.5.1/ryanoasis.AnnotationMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/AnnotationMono/NerdFont/3.5.1/ryanoasis.AnnotationMono.NerdFont.installer.yaml
@@ -1,0 +1,62 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.AnnotationMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: AnnotationMNerdFont-Bold.ttf
+- RelativeFilePath: AnnotationMNerdFont-BoldItalic.ttf
+- RelativeFilePath: AnnotationMNerdFont-BoldItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFont-BoldOblique.ttf
+- RelativeFilePath: AnnotationMNerdFont-ExtraBold.ttf
+- RelativeFilePath: AnnotationMNerdFont-ExtraBoldItalic.ttf
+- RelativeFilePath: AnnotationMNerdFont-ExtraBoldItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFont-ExtraBoldOblique.ttf
+- RelativeFilePath: AnnotationMNerdFont-Italic.ttf
+- RelativeFilePath: AnnotationMNerdFont-ItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFont-Medium.ttf
+- RelativeFilePath: AnnotationMNerdFont-MediumItalic.ttf
+- RelativeFilePath: AnnotationMNerdFont-MediumItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFont-MediumOblique.ttf
+- RelativeFilePath: AnnotationMNerdFont-Regular.ttf
+- RelativeFilePath: AnnotationMNerdFont-RegularOblique.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-Bold.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-BoldItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-BoldOblique.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-ExtraBold.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-ExtraBoldItalic.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-ExtraBoldItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-ExtraBoldOblique.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-Italic.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-ItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-Medium.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-MediumItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-MediumOblique.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-Regular.ttf
+- RelativeFilePath: AnnotationMNerdFontMono-RegularOblique.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-Bold.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-BoldItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-BoldOblique.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-ExtraBoldItalic.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-ExtraBoldItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-ExtraBoldOblique.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-Italic.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-ItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-Medium.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-MediumItalicUpright.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-MediumOblique.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-Regular.ttf
+- RelativeFilePath: AnnotationMNerdFontPropo-RegularOblique.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/AnnotationMono.zip
+  InstallerSha256: CDE432BC5C30723F2431AC655964AD8E4C09877A5FCD176C4DDC38ED71C79FFD
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/AnnotationMono/NerdFont/3.5.1/ryanoasis.AnnotationMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AnnotationMono/NerdFont/3.5.1/ryanoasis.AnnotationMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.AnnotationMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: AnnotationMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: AnnotationMono patched with Nerd Fonts glyphs
+Moniker: annotationmono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/AnnotationMono/NerdFont/3.5.1/ryanoasis.AnnotationMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/AnnotationMono/NerdFont/3.5.1/ryanoasis.AnnotationMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.AnnotationMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.AnnotationMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.AnnotationMono.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/AnnotationMono.zip"
+	]
+}


### PR DESCRIPTION
Adds the AnnotationMono Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_