### PR TITLE
New package: ryanoasis.AtkinsonHyperlegibleMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/AtkinsonHyperlegibleMono/NerdFont/3.5.1/ryanoasis.AtkinsonHyperlegibleMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/AtkinsonHyperlegibleMono/NerdFont/3.5.1/ryanoasis.AtkinsonHyperlegibleMono.NerdFont.installer.yaml
@@ -1,0 +1,38 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.AtkinsonHyperlegibleMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: AtkynsonMonoNerdFont-Bold.otf
+- RelativeFilePath: AtkynsonMonoNerdFont-BoldItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFont-Italic.otf
+- RelativeFilePath: AtkynsonMonoNerdFont-Light.otf
+- RelativeFilePath: AtkynsonMonoNerdFont-LightItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFont-Medium.otf
+- RelativeFilePath: AtkynsonMonoNerdFont-MediumItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFont-Regular.otf
+- RelativeFilePath: AtkynsonMonoNerdFontMono-Bold.otf
+- RelativeFilePath: AtkynsonMonoNerdFontMono-BoldItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFontMono-Italic.otf
+- RelativeFilePath: AtkynsonMonoNerdFontMono-Light.otf
+- RelativeFilePath: AtkynsonMonoNerdFontMono-LightItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFontMono-Medium.otf
+- RelativeFilePath: AtkynsonMonoNerdFontMono-MediumItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFontMono-Regular.otf
+- RelativeFilePath: AtkynsonMonoNerdFontPropo-Bold.otf
+- RelativeFilePath: AtkynsonMonoNerdFontPropo-BoldItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFontPropo-Italic.otf
+- RelativeFilePath: AtkynsonMonoNerdFontPropo-Light.otf
+- RelativeFilePath: AtkynsonMonoNerdFontPropo-LightItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFontPropo-Medium.otf
+- RelativeFilePath: AtkynsonMonoNerdFontPropo-MediumItalic.otf
+- RelativeFilePath: AtkynsonMonoNerdFontPropo-Regular.otf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/AtkinsonHyperlegibleMono.zip
+  InstallerSha256: E68F8183F4FC475C55D85A3BE3260B24C6FFA423E4C4C0B4FA3ED2FF1F9BD69B
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/AtkinsonHyperlegibleMono/NerdFont/3.5.1/ryanoasis.AtkinsonHyperlegibleMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/AtkinsonHyperlegibleMono/NerdFont/3.5.1/ryanoasis.AtkinsonHyperlegibleMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.AtkinsonHyperlegibleMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: AtkinsonHyperlegibleMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: AtkinsonHyperlegibleMono patched with Nerd Fonts glyphs
+Moniker: atkinsonhyperlegiblemono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/AtkinsonHyperlegibleMono/NerdFont/3.5.1/ryanoasis.AtkinsonHyperlegibleMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/AtkinsonHyperlegibleMono/NerdFont/3.5.1/ryanoasis.AtkinsonHyperlegibleMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.AtkinsonHyperlegibleMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.AtkinsonHyperlegibleMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.AtkinsonHyperlegibleMono.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/AtkinsonHyperlegibleMono.zip"
+	]
+}


### PR DESCRIPTION
Adds the AtkinsonHyperlegibleMono Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_