### PR TITLE
New package: ryanoasis.DaddyTimeMono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/DaddyTimeMono/NerdFont/3.5.1/ryanoasis.DaddyTimeMono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/DaddyTimeMono/NerdFont/3.5.1/ryanoasis.DaddyTimeMono.NerdFont.installer.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.DaddyTimeMono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: DaddyTimeMonoNerdFont-Regular.ttf
+- RelativeFilePath: DaddyTimeMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: DaddyTimeMonoNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/DaddyTimeMono.zip
+  InstallerSha256: 27916CD7A0C8452B131EEFCCDC78C1BEBFC942F4628ED777E378BD46F77367B4
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/DaddyTimeMono/NerdFont/3.5.1/ryanoasis.DaddyTimeMono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/DaddyTimeMono/NerdFont/3.5.1/ryanoasis.DaddyTimeMono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.DaddyTimeMono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: DaddyTimeMono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: DaddyTimeMono patched with Nerd Fonts glyphs
+Moniker: daddytimemono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/DaddyTimeMono/NerdFont/3.5.1/ryanoasis.DaddyTimeMono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/DaddyTimeMono/NerdFont/3.5.1/ryanoasis.DaddyTimeMono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.DaddyTimeMono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.DaddyTimeMono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.DaddyTimeMono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/DaddyTimeMono.zip"]
+}


### PR DESCRIPTION
Adds the DaddyTimeMono Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_