### PR TITLE
New package: ryanoasis.BigBlueTerminal.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/BigBlueTerminal/NerdFont/3.5.1/ryanoasis.BigBlueTerminal.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/BigBlueTerminal/NerdFont/3.5.1/ryanoasis.BigBlueTerminal.NerdFont.installer.yaml
@@ -1,0 +1,20 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.BigBlueTerminal.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: BigBlueTerm437NerdFont-Regular.ttf
+- RelativeFilePath: BigBlueTerm437NerdFontMono-Regular.ttf
+- RelativeFilePath: BigBlueTerm437NerdFontPropo-Regular.ttf
+- RelativeFilePath: BigBlueTermPlusNerdFont-Regular.ttf
+- RelativeFilePath: BigBlueTermPlusNerdFontMono-Regular.ttf
+- RelativeFilePath: BigBlueTermPlusNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/BigBlueTerminal.zip
+  InstallerSha256: 2120240B167228C8A032236CA87EBA62EE33E39E1715559027387CB0D53FEA19
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/BigBlueTerminal/NerdFont/3.5.1/ryanoasis.BigBlueTerminal.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/BigBlueTerminal/NerdFont/3.5.1/ryanoasis.BigBlueTerminal.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.BigBlueTerminal.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: BigBlueTerminal Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: CC-BY-SA-4.0
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: BigBlueTerminal patched with Nerd Fonts glyphs
+Moniker: bigblueterminal-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/BigBlueTerminal/NerdFont/3.5.1/ryanoasis.BigBlueTerminal.NerdFont.yaml
+++ b/fonts/r/ryanoasis/BigBlueTerminal/NerdFont/3.5.1/ryanoasis.BigBlueTerminal.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.BigBlueTerminal.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.BigBlueTerminal.NerdFont.Font.json
+++ b/shards/json/ryanoasis.BigBlueTerminal.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/BigBlueTerminal.zip"
+	]
+}


### PR DESCRIPTION
Adds the BigBlueTerminal Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from `LICENSE.TXT` inside the archive: CC-BY-SA-4.0 (the file is the full Creative Commons Attribution-ShareAlike 4.0 International text).
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_