### PR TITLE
New package: ryanoasis.EnvyCodeR.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/EnvyCodeR/NerdFont/3.5.1/ryanoasis.EnvyCodeR.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/EnvyCodeR/NerdFont/3.5.1/ryanoasis.EnvyCodeR.NerdFont.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.EnvyCodeR.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: EnvyCodeRNerdFont-Bold.ttf
+- RelativeFilePath: EnvyCodeRNerdFont-Italic.ttf
+- RelativeFilePath: EnvyCodeRNerdFont-Regular.ttf
+- RelativeFilePath: EnvyCodeRNerdFontMono-Bold.ttf
+- RelativeFilePath: EnvyCodeRNerdFontMono-Italic.ttf
+- RelativeFilePath: EnvyCodeRNerdFontMono-Regular.ttf
+- RelativeFilePath: EnvyCodeRNerdFontPropo-Bold.ttf
+- RelativeFilePath: EnvyCodeRNerdFontPropo-Italic.ttf
+- RelativeFilePath: EnvyCodeRNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/EnvyCodeR.zip
+  InstallerSha256: B0BA67C06D821871D557935C1F845D2572708DD0768AA1A05641A53C89F73B47
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/EnvyCodeR/NerdFont/3.5.1/ryanoasis.EnvyCodeR.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/EnvyCodeR/NerdFont/3.5.1/ryanoasis.EnvyCodeR.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.EnvyCodeR.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: EnvyCodeR Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: EnvyCodeR patched with Nerd Fonts glyphs
+Moniker: envycoder-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/EnvyCodeR/NerdFont/3.5.1/ryanoasis.EnvyCodeR.NerdFont.yaml
+++ b/fonts/r/ryanoasis/EnvyCodeR/NerdFont/3.5.1/ryanoasis.EnvyCodeR.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.EnvyCodeR.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.EnvyCodeR.NerdFont.Font.json
+++ b/shards/json/ryanoasis.EnvyCodeR.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/EnvyCodeR.zip"]
+}


### PR DESCRIPTION
Adds the EnvyCodeR Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_