### PR TITLE
New package: ryanoasis.Gohu.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Gohu/NerdFont/3.5.1/ryanoasis.Gohu.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Gohu/NerdFont/3.5.1/ryanoasis.Gohu.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Gohu.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: GohuFont11NerdFont-Regular.ttf
+- RelativeFilePath: GohuFont11NerdFontMono-Regular.ttf
+- RelativeFilePath: GohuFont11NerdFontPropo-Regular.ttf
+- RelativeFilePath: GohuFont14NerdFont-Regular.ttf
+- RelativeFilePath: GohuFont14NerdFontMono-Regular.ttf
+- RelativeFilePath: GohuFont14NerdFontPropo-Regular.ttf
+- RelativeFilePath: GohuFontuni11NerdFont-Regular.ttf
+- RelativeFilePath: GohuFontuni11NerdFontMono-Regular.ttf
+- RelativeFilePath: GohuFontuni11NerdFontPropo-Regular.ttf
+- RelativeFilePath: GohuFontuni14NerdFont-Regular.ttf
+- RelativeFilePath: GohuFontuni14NerdFontMono-Regular.ttf
+- RelativeFilePath: GohuFontuni14NerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Gohu.zip
+  InstallerSha256: C7E22CDCB769F854B33ADD309C05EED136F724432D601ED85194028A148E11C1
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Gohu/NerdFont/3.5.1/ryanoasis.Gohu.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Gohu/NerdFont/3.5.1/ryanoasis.Gohu.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Gohu.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Gohu Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: WTFPL
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Gohu patched with Nerd Fonts glyphs
+Moniker: gohu-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Gohu/NerdFont/3.5.1/ryanoasis.Gohu.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Gohu/NerdFont/3.5.1/ryanoasis.Gohu.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Gohu.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Gohu.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Gohu.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Gohu.zip"]
+}


### PR DESCRIPTION
Adds the Gohu Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: WTFPL.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_