### PR TITLE
New package: ryanoasis.Go-Mono.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Go-Mono/NerdFont/3.5.1/ryanoasis.Go-Mono.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Go-Mono/NerdFont/3.5.1/ryanoasis.Go-Mono.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Go-Mono.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: GoMonoNerdFont-Bold.ttf
+- RelativeFilePath: GoMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: GoMonoNerdFont-Italic.ttf
+- RelativeFilePath: GoMonoNerdFont-Regular.ttf
+- RelativeFilePath: GoMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: GoMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: GoMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: GoMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: GoMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: GoMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: GoMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: GoMonoNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Go-Mono.zip
+  InstallerSha256: 7B507440809CEC7221AA455CF03A289CD8754C34F994CA1CF7A595E4D8CDC42A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Go-Mono/NerdFont/3.5.1/ryanoasis.Go-Mono.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Go-Mono/NerdFont/3.5.1/ryanoasis.Go-Mono.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Go-Mono.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Go-Mono Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: BSD-3-Clause
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Go-Mono patched with Nerd Fonts glyphs
+Moniker: go-mono-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Go-Mono/NerdFont/3.5.1/ryanoasis.Go-Mono.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Go-Mono/NerdFont/3.5.1/ryanoasis.Go-Mono.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Go-Mono.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Go-Mono.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Go-Mono.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Go-Mono.zip"]
+}


### PR DESCRIPTION
Adds the Go-Mono Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from `LICENSE.txt` inside the archive: BSD-3-Clause (the Go project licence, © 2016 Bigelow & Holmes Inc.).
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_