### PR TITLE
New package: ryanoasis.HeavyData.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/HeavyData/NerdFont/3.5.1/ryanoasis.HeavyData.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/HeavyData/NerdFont/3.5.1/ryanoasis.HeavyData.NerdFont.installer.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.HeavyData.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: HeavyDataNerdFont-Regular.ttf
+- RelativeFilePath: HeavyDataNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/HeavyData.zip
+  InstallerSha256: D8A15E63EBC3AA433FE4D11DFAE10E06BD53060E2D9DEC0F25043C0EE4507907
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/HeavyData/NerdFont/3.5.1/ryanoasis.HeavyData.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/HeavyData/NerdFont/3.5.1/ryanoasis.HeavyData.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.HeavyData.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: HeavyData Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: Freeware
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: HeavyData patched with Nerd Fonts glyphs
+Moniker: heavydata-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/HeavyData/NerdFont/3.5.1/ryanoasis.HeavyData.NerdFont.yaml
+++ b/fonts/r/ryanoasis/HeavyData/NerdFont/3.5.1/ryanoasis.HeavyData.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.HeavyData.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.HeavyData.NerdFont.Font.json
+++ b/shards/json/ryanoasis.HeavyData.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/HeavyData.zip"]
+}


### PR DESCRIPTION
Adds the HeavyData Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from `Vic Fieger License.txt` inside the archive. It grants free use without conditions but is not an SPDX-listed licence, so the manifest uses `Freeware`.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_