### PR TITLE
New package: ryanoasis.Hermit.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Hermit/NerdFont/3.5.1/ryanoasis.Hermit.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Hermit/NerdFont/3.5.1/ryanoasis.Hermit.NerdFont.installer.yaml
@@ -1,0 +1,32 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Hermit.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: HurmitNerdFont-Bold.otf
+- RelativeFilePath: HurmitNerdFont-BoldItalic.otf
+- RelativeFilePath: HurmitNerdFont-Italic.otf
+- RelativeFilePath: HurmitNerdFont-Light.otf
+- RelativeFilePath: HurmitNerdFont-LightItalic.otf
+- RelativeFilePath: HurmitNerdFont-Regular.otf
+- RelativeFilePath: HurmitNerdFontMono-Bold.otf
+- RelativeFilePath: HurmitNerdFontMono-BoldItalic.otf
+- RelativeFilePath: HurmitNerdFontMono-Italic.otf
+- RelativeFilePath: HurmitNerdFontMono-Light.otf
+- RelativeFilePath: HurmitNerdFontMono-LightItalic.otf
+- RelativeFilePath: HurmitNerdFontMono-Regular.otf
+- RelativeFilePath: HurmitNerdFontPropo-Bold.otf
+- RelativeFilePath: HurmitNerdFontPropo-BoldItalic.otf
+- RelativeFilePath: HurmitNerdFontPropo-Italic.otf
+- RelativeFilePath: HurmitNerdFontPropo-Light.otf
+- RelativeFilePath: HurmitNerdFontPropo-LightItalic.otf
+- RelativeFilePath: HurmitNerdFontPropo-Regular.otf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Hermit.zip
+  InstallerSha256: FD78D27E2A4F1B92182AE56D2A6833028BC1314F629D773790516C7489602F3E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Hermit/NerdFont/3.5.1/ryanoasis.Hermit.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Hermit/NerdFont/3.5.1/ryanoasis.Hermit.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Hermit.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Hermit Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Hermit patched with Nerd Fonts glyphs
+Moniker: hermit-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Hermit/NerdFont/3.5.1/ryanoasis.Hermit.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Hermit/NerdFont/3.5.1/ryanoasis.Hermit.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Hermit.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Hermit.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Hermit.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Hermit.zip"]
+}


### PR DESCRIPTION
Adds the Hermit Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_