### PR TITLE
New package: ryanoasis.iA-Writer.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/iA-Writer/NerdFont/3.5.1/ryanoasis.iA-Writer.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/iA-Writer/NerdFont/3.5.1/ryanoasis.iA-Writer.NerdFont.installer.yaml
@@ -1,0 +1,42 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.iA-Writer.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: iMWritingDuoNerdFont-Bold.ttf
+- RelativeFilePath: iMWritingDuoNerdFont-BoldItalic.ttf
+- RelativeFilePath: iMWritingDuoNerdFont-Italic.ttf
+- RelativeFilePath: iMWritingDuoNerdFont-Regular.ttf
+- RelativeFilePath: iMWritingDuoNerdFontPropo-Bold.ttf
+- RelativeFilePath: iMWritingDuoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: iMWritingDuoNerdFontPropo-Italic.ttf
+- RelativeFilePath: iMWritingDuoNerdFontPropo-Regular.ttf
+- RelativeFilePath: iMWritingMonoNerdFont-Bold.ttf
+- RelativeFilePath: iMWritingMonoNerdFont-BoldItalic.ttf
+- RelativeFilePath: iMWritingMonoNerdFont-Italic.ttf
+- RelativeFilePath: iMWritingMonoNerdFont-Regular.ttf
+- RelativeFilePath: iMWritingMonoNerdFontMono-Bold.ttf
+- RelativeFilePath: iMWritingMonoNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: iMWritingMonoNerdFontMono-Italic.ttf
+- RelativeFilePath: iMWritingMonoNerdFontMono-Regular.ttf
+- RelativeFilePath: iMWritingMonoNerdFontPropo-Bold.ttf
+- RelativeFilePath: iMWritingMonoNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: iMWritingMonoNerdFontPropo-Italic.ttf
+- RelativeFilePath: iMWritingMonoNerdFontPropo-Regular.ttf
+- RelativeFilePath: iMWritingQuatNerdFont-Bold.ttf
+- RelativeFilePath: iMWritingQuatNerdFont-BoldItalic.ttf
+- RelativeFilePath: iMWritingQuatNerdFont-Italic.ttf
+- RelativeFilePath: iMWritingQuatNerdFont-Regular.ttf
+- RelativeFilePath: iMWritingQuatNerdFontPropo-Bold.ttf
+- RelativeFilePath: iMWritingQuatNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: iMWritingQuatNerdFontPropo-Italic.ttf
+- RelativeFilePath: iMWritingQuatNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/iA-Writer.zip
+  InstallerSha256: F2B0E17F138B8D827C0DCD0FC58988BFC6F60BAB8217FEE5679C4840EED5CB2A
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/iA-Writer/NerdFont/3.5.1/ryanoasis.iA-Writer.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/iA-Writer/NerdFont/3.5.1/ryanoasis.iA-Writer.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.iA-Writer.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: iA-Writer Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: iA-Writer patched with Nerd Fonts glyphs
+Moniker: ia-writer-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/iA-Writer/NerdFont/3.5.1/ryanoasis.iA-Writer.NerdFont.yaml
+++ b/fonts/r/ryanoasis/iA-Writer/NerdFont/3.5.1/ryanoasis.iA-Writer.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.iA-Writer.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.iA-Writer.NerdFont.Font.json
+++ b/shards/json/ryanoasis.iA-Writer.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/iA-Writer.zip"]
+}


### PR DESCRIPTION
Adds the iA-Writer Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_