### PR TITLE
New package: ryanoasis.InconsolataLGC.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/InconsolataLGC/NerdFont/3.5.1/ryanoasis.InconsolataLGC.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/InconsolataLGC/NerdFont/3.5.1/ryanoasis.InconsolataLGC.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.InconsolataLGC.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: InconsolataLGCNerdFont-Bold.ttf
+- RelativeFilePath: InconsolataLGCNerdFont-BoldItalic.ttf
+- RelativeFilePath: InconsolataLGCNerdFont-Italic.ttf
+- RelativeFilePath: InconsolataLGCNerdFont-Regular.ttf
+- RelativeFilePath: InconsolataLGCNerdFontMono-Bold.ttf
+- RelativeFilePath: InconsolataLGCNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: InconsolataLGCNerdFontMono-Italic.ttf
+- RelativeFilePath: InconsolataLGCNerdFontMono-Regular.ttf
+- RelativeFilePath: InconsolataLGCNerdFontPropo-Bold.ttf
+- RelativeFilePath: InconsolataLGCNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: InconsolataLGCNerdFontPropo-Italic.ttf
+- RelativeFilePath: InconsolataLGCNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/InconsolataLGC.zip
+  InstallerSha256: 5280DB97E435288D4665F9A6EA556E1B684794CAED248BA613E306734C95C998
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/InconsolataLGC/NerdFont/3.5.1/ryanoasis.InconsolataLGC.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/InconsolataLGC/NerdFont/3.5.1/ryanoasis.InconsolataLGC.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.InconsolataLGC.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: InconsolataLGC Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: InconsolataLGC patched with Nerd Fonts glyphs
+Moniker: inconsolatalgc-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/InconsolataLGC/NerdFont/3.5.1/ryanoasis.InconsolataLGC.NerdFont.yaml
+++ b/fonts/r/ryanoasis/InconsolataLGC/NerdFont/3.5.1/ryanoasis.InconsolataLGC.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.InconsolataLGC.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.InconsolataLGC.NerdFont.Font.json
+++ b/shards/json/ryanoasis.InconsolataLGC.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/InconsolataLGC.zip"
+	]
+}


### PR DESCRIPTION
Adds the InconsolataLGC Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_