### PR TITLE
New package: ryanoasis.IosevkaTerm.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/IosevkaTerm/NerdFont/3.5.1/ryanoasis.IosevkaTerm.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/IosevkaTerm/NerdFont/3.5.1/ryanoasis.IosevkaTerm.NerdFont.installer.yaml
@@ -1,0 +1,95 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IosevkaTerm.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: IosevkaTermNerdFont-Bold.ttf
+- RelativeFilePath: IosevkaTermNerdFont-BoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-BoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFont-ExtraBold.ttf
+- RelativeFilePath: IosevkaTermNerdFont-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFont-ExtraLight.ttf
+- RelativeFilePath: IosevkaTermNerdFont-ExtraLightItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-ExtraLightOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFont-Heavy.ttf
+- RelativeFilePath: IosevkaTermNerdFont-HeavyItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-HeavyOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFont-Italic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-Light.ttf
+- RelativeFilePath: IosevkaTermNerdFont-LightItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-LightOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFont-Medium.ttf
+- RelativeFilePath: IosevkaTermNerdFont-MediumItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-MediumOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFont-Oblique.ttf
+- RelativeFilePath: IosevkaTermNerdFont-Regular.ttf
+- RelativeFilePath: IosevkaTermNerdFont-SemiBold.ttf
+- RelativeFilePath: IosevkaTermNerdFont-SemiBoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-SemiBoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFont-Thin.ttf
+- RelativeFilePath: IosevkaTermNerdFont-ThinItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFont-ThinOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-Bold.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-BoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-ExtraBold.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-ExtraLightItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-ExtraLightOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-Heavy.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-HeavyItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-HeavyOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-Italic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-Light.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-LightItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-LightOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-Medium.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-MediumOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-Oblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-Regular.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-SemiBold.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-SemiBoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-SemiBoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-Thin.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-ThinItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontMono-ThinOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-Bold.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-BoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-ExtraLightItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-ExtraLightOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-Heavy.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-HeavyItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-HeavyOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-Italic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-Light.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-LightOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-Medium.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-MediumOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-Oblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-Regular.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-SemiBoldItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-SemiBoldOblique.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-Thin.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-ThinItalic.ttf
+- RelativeFilePath: IosevkaTermNerdFontPropo-ThinOblique.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/IosevkaTerm.zip
+  InstallerSha256: B0DFD98968B7C7743080431257BFD082C5EF7DD4D1C674D3CE16BC5520C10CDC
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/IosevkaTerm/NerdFont/3.5.1/ryanoasis.IosevkaTerm.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/IosevkaTerm/NerdFont/3.5.1/ryanoasis.IosevkaTerm.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IosevkaTerm.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: IosevkaTerm Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: IosevkaTerm patched with Nerd Fonts glyphs
+Moniker: iosevkaterm-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/IosevkaTerm/NerdFont/3.5.1/ryanoasis.IosevkaTerm.NerdFont.yaml
+++ b/fonts/r/ryanoasis/IosevkaTerm/NerdFont/3.5.1/ryanoasis.IosevkaTerm.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IosevkaTerm.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.IosevkaTerm.NerdFont.Font.json
+++ b/shards/json/ryanoasis.IosevkaTerm.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/IosevkaTerm.zip"]
+}


### PR DESCRIPTION
Adds the IosevkaTerm Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_