### PR TITLE
New package: ryanoasis.IosevkaTermSlab.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/IosevkaTermSlab/NerdFont/3.5.1/ryanoasis.IosevkaTermSlab.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/IosevkaTermSlab/NerdFont/3.5.1/ryanoasis.IosevkaTermSlab.NerdFont.installer.yaml
@@ -1,0 +1,59 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IosevkaTermSlab.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: IosevkaTermSlabNerdFont-Bold.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-BoldItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-BoldOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-ExtraBold.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-Italic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-Light.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-LightItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-LightOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-Medium.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-MediumItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-MediumOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-Oblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFont-Regular.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-Bold.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-BoldItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-BoldOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-ExtraBold.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-Italic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-Light.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-LightItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-LightOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-Medium.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-MediumItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-MediumOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-Oblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontMono-Regular.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-Bold.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-BoldItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-BoldOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-ExtraBoldItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-ExtraBoldOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-Italic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-Light.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-LightItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-LightOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-Medium.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-MediumItalic.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-MediumOblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-Oblique.ttf
+- RelativeFilePath: IosevkaTermSlabNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/IosevkaTermSlab.zip
+  InstallerSha256: 79E3E99E5F18E5E99EAD7B305C9AC2CC40DF1C3AE68495D518D6CA56B2732B03
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/IosevkaTermSlab/NerdFont/3.5.1/ryanoasis.IosevkaTermSlab.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/IosevkaTermSlab/NerdFont/3.5.1/ryanoasis.IosevkaTermSlab.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IosevkaTermSlab.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: IosevkaTermSlab Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: IosevkaTermSlab patched with Nerd Fonts glyphs
+Moniker: iosevkatermslab-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/IosevkaTermSlab/NerdFont/3.5.1/ryanoasis.IosevkaTermSlab.NerdFont.yaml
+++ b/fonts/r/ryanoasis/IosevkaTermSlab/NerdFont/3.5.1/ryanoasis.IosevkaTermSlab.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.IosevkaTermSlab.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.IosevkaTermSlab.NerdFont.Font.json
+++ b/shards/json/ryanoasis.IosevkaTermSlab.NerdFont.Font.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": [
+		"https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/IosevkaTermSlab.zip"
+	]
+}


### PR DESCRIPTION
Adds the IosevkaTermSlab Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_