### PR TITLE
New package: ryanoasis.Monoid.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/Monoid/NerdFont/3.5.1/ryanoasis.Monoid.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/Monoid/NerdFont/3.5.1/ryanoasis.Monoid.NerdFont.installer.yaml
@@ -1,0 +1,26 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Monoid.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: MonoidNerdFont-Bold.ttf
+- RelativeFilePath: MonoidNerdFont-Italic.ttf
+- RelativeFilePath: MonoidNerdFont-Regular.ttf
+- RelativeFilePath: MonoidNerdFont-Retina.ttf
+- RelativeFilePath: MonoidNerdFontMono-Bold.ttf
+- RelativeFilePath: MonoidNerdFontMono-Italic.ttf
+- RelativeFilePath: MonoidNerdFontMono-Regular.ttf
+- RelativeFilePath: MonoidNerdFontMono-Retina.ttf
+- RelativeFilePath: MonoidNerdFontPropo-Bold.ttf
+- RelativeFilePath: MonoidNerdFontPropo-Italic.ttf
+- RelativeFilePath: MonoidNerdFontPropo-Regular.ttf
+- RelativeFilePath: MonoidNerdFontPropo-Retina.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/Monoid.zip
+  InstallerSha256: 32FC636878631C51BD8BF277A56B691466F43164F006409886D45E7FF425DC20
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Monoid/NerdFont/3.5.1/ryanoasis.Monoid.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/Monoid/NerdFont/3.5.1/ryanoasis.Monoid.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Monoid.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: Monoid Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: Monoid patched with Nerd Fonts glyphs
+Moniker: monoid-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/Monoid/NerdFont/3.5.1/ryanoasis.Monoid.NerdFont.yaml
+++ b/fonts/r/ryanoasis/Monoid/NerdFont/3.5.1/ryanoasis.Monoid.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.Monoid.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.Monoid.NerdFont.Font.json
+++ b/shards/json/ryanoasis.Monoid.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/Monoid.zip"]
+}


### PR DESCRIPTION
Adds the Monoid Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_