### PR TITLE
New package: ryanoasis.MPlus.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/MPlus/NerdFont/3.5.1/ryanoasis.MPlus.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/MPlus/NerdFont/3.5.1/ryanoasis.MPlus.NerdFont.installer.yaml
@@ -1,0 +1,113 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.MPlus.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: M+1CodeNerdFont-Bold.ttf
+- RelativeFilePath: M+1CodeNerdFont-ExtraLight.ttf
+- RelativeFilePath: M+1CodeNerdFont-Light.ttf
+- RelativeFilePath: M+1CodeNerdFont-Medium.ttf
+- RelativeFilePath: M+1CodeNerdFont-Regular.ttf
+- RelativeFilePath: M+1CodeNerdFont-SemiBold.ttf
+- RelativeFilePath: M+1CodeNerdFont-Thin.ttf
+- RelativeFilePath: M+1CodeNerdFontMono-Bold.ttf
+- RelativeFilePath: M+1CodeNerdFontMono-ExtraLight.ttf
+- RelativeFilePath: M+1CodeNerdFontMono-Light.ttf
+- RelativeFilePath: M+1CodeNerdFontMono-Medium.ttf
+- RelativeFilePath: M+1CodeNerdFontMono-Regular.ttf
+- RelativeFilePath: M+1CodeNerdFontMono-SemiBold.ttf
+- RelativeFilePath: M+1CodeNerdFontMono-Thin.ttf
+- RelativeFilePath: M+1CodeNerdFontPropo-Bold.ttf
+- RelativeFilePath: M+1CodeNerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: M+1CodeNerdFontPropo-Light.ttf
+- RelativeFilePath: M+1CodeNerdFontPropo-Medium.ttf
+- RelativeFilePath: M+1CodeNerdFontPropo-Regular.ttf
+- RelativeFilePath: M+1CodeNerdFontPropo-SemiBold.ttf
+- RelativeFilePath: M+1CodeNerdFontPropo-Thin.ttf
+- RelativeFilePath: M+1NerdFont-Black.ttf
+- RelativeFilePath: M+1NerdFont-Bold.ttf
+- RelativeFilePath: M+1NerdFont-ExtraBold.ttf
+- RelativeFilePath: M+1NerdFont-ExtraLight.ttf
+- RelativeFilePath: M+1NerdFont-Light.ttf
+- RelativeFilePath: M+1NerdFont-Medium.ttf
+- RelativeFilePath: M+1NerdFont-Regular.ttf
+- RelativeFilePath: M+1NerdFont-SemiBold.ttf
+- RelativeFilePath: M+1NerdFont-Thin.ttf
+- RelativeFilePath: M+1NerdFontPropo-Black.ttf
+- RelativeFilePath: M+1NerdFontPropo-Bold.ttf
+- RelativeFilePath: M+1NerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: M+1NerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: M+1NerdFontPropo-Light.ttf
+- RelativeFilePath: M+1NerdFontPropo-Medium.ttf
+- RelativeFilePath: M+1NerdFontPropo-Regular.ttf
+- RelativeFilePath: M+1NerdFontPropo-SemiBold.ttf
+- RelativeFilePath: M+1NerdFontPropo-Thin.ttf
+- RelativeFilePath: M+2NerdFont-Black.ttf
+- RelativeFilePath: M+2NerdFont-Bold.ttf
+- RelativeFilePath: M+2NerdFont-ExtraBold.ttf
+- RelativeFilePath: M+2NerdFont-ExtraLight.ttf
+- RelativeFilePath: M+2NerdFont-Light.ttf
+- RelativeFilePath: M+2NerdFont-Medium.ttf
+- RelativeFilePath: M+2NerdFont-Regular.ttf
+- RelativeFilePath: M+2NerdFont-SemiBold.ttf
+- RelativeFilePath: M+2NerdFont-Thin.ttf
+- RelativeFilePath: M+2NerdFontPropo-Black.ttf
+- RelativeFilePath: M+2NerdFontPropo-Bold.ttf
+- RelativeFilePath: M+2NerdFontPropo-ExtraBold.ttf
+- RelativeFilePath: M+2NerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: M+2NerdFontPropo-Light.ttf
+- RelativeFilePath: M+2NerdFontPropo-Medium.ttf
+- RelativeFilePath: M+2NerdFontPropo-Regular.ttf
+- RelativeFilePath: M+2NerdFontPropo-SemiBold.ttf
+- RelativeFilePath: M+2NerdFontPropo-Thin.ttf
+- RelativeFilePath: M+CodeLat50NerdFont-Bold.ttf
+- RelativeFilePath: M+CodeLat50NerdFont-ExtraLight.ttf
+- RelativeFilePath: M+CodeLat50NerdFont-Light.ttf
+- RelativeFilePath: M+CodeLat50NerdFont-Medium.ttf
+- RelativeFilePath: M+CodeLat50NerdFont-Regular.ttf
+- RelativeFilePath: M+CodeLat50NerdFont-SemiBold.ttf
+- RelativeFilePath: M+CodeLat50NerdFont-Thin.ttf
+- RelativeFilePath: M+CodeLat50NerdFontMono-Bold.ttf
+- RelativeFilePath: M+CodeLat50NerdFontMono-ExtraLight.ttf
+- RelativeFilePath: M+CodeLat50NerdFontMono-Light.ttf
+- RelativeFilePath: M+CodeLat50NerdFontMono-Medium.ttf
+- RelativeFilePath: M+CodeLat50NerdFontMono-Regular.ttf
+- RelativeFilePath: M+CodeLat50NerdFontMono-SemiBold.ttf
+- RelativeFilePath: M+CodeLat50NerdFontMono-Thin.ttf
+- RelativeFilePath: M+CodeLat50NerdFontPropo-Bold.ttf
+- RelativeFilePath: M+CodeLat50NerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: M+CodeLat50NerdFontPropo-Light.ttf
+- RelativeFilePath: M+CodeLat50NerdFontPropo-Medium.ttf
+- RelativeFilePath: M+CodeLat50NerdFontPropo-Regular.ttf
+- RelativeFilePath: M+CodeLat50NerdFontPropo-SemiBold.ttf
+- RelativeFilePath: M+CodeLat50NerdFontPropo-Thin.ttf
+- RelativeFilePath: M+CodeLat60NerdFont-Bold.ttf
+- RelativeFilePath: M+CodeLat60NerdFont-ExtraLight.ttf
+- RelativeFilePath: M+CodeLat60NerdFont-Light.ttf
+- RelativeFilePath: M+CodeLat60NerdFont-Medium.ttf
+- RelativeFilePath: M+CodeLat60NerdFont-Regular.ttf
+- RelativeFilePath: M+CodeLat60NerdFont-SemiBold.ttf
+- RelativeFilePath: M+CodeLat60NerdFont-Thin.ttf
+- RelativeFilePath: M+CodeLat60NerdFontMono-Bold.ttf
+- RelativeFilePath: M+CodeLat60NerdFontMono-ExtraLight.ttf
+- RelativeFilePath: M+CodeLat60NerdFontMono-Light.ttf
+- RelativeFilePath: M+CodeLat60NerdFontMono-Medium.ttf
+- RelativeFilePath: M+CodeLat60NerdFontMono-Regular.ttf
+- RelativeFilePath: M+CodeLat60NerdFontMono-SemiBold.ttf
+- RelativeFilePath: M+CodeLat60NerdFontMono-Thin.ttf
+- RelativeFilePath: M+CodeLat60NerdFontPropo-Bold.ttf
+- RelativeFilePath: M+CodeLat60NerdFontPropo-ExtraLight.ttf
+- RelativeFilePath: M+CodeLat60NerdFontPropo-Light.ttf
+- RelativeFilePath: M+CodeLat60NerdFontPropo-Medium.ttf
+- RelativeFilePath: M+CodeLat60NerdFontPropo-Regular.ttf
+- RelativeFilePath: M+CodeLat60NerdFontPropo-SemiBold.ttf
+- RelativeFilePath: M+CodeLat60NerdFontPropo-Thin.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/MPlus.zip
+  InstallerSha256: C0EFAD350173D02C439C8C384DBB18206DCFCA4049C260A1E13879FEB6EA4981
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/MPlus/NerdFont/3.5.1/ryanoasis.MPlus.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/MPlus/NerdFont/3.5.1/ryanoasis.MPlus.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.MPlus.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: MPlus Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: OFL-1.1
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: MPlus patched with Nerd Fonts glyphs
+Moniker: mplus-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/MPlus/NerdFont/3.5.1/ryanoasis.MPlus.NerdFont.yaml
+++ b/fonts/r/ryanoasis/MPlus/NerdFont/3.5.1/ryanoasis.MPlus.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.MPlus.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.MPlus.NerdFont.Font.json
+++ b/shards/json/ryanoasis.MPlus.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/MPlus.zip"]
+}


### PR DESCRIPTION
Adds the MPlus Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: OFL-1.1.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_