### PR TITLE
New package: ryanoasis.ProFont.NerdFont version 3.5.1

### DIFF
--- a/fonts/r/ryanoasis/ProFont/NerdFont/3.5.1/ryanoasis.ProFont.NerdFont.installer.yaml
+++ b/fonts/r/ryanoasis/ProFont/NerdFont/3.5.1/ryanoasis.ProFont.NerdFont.installer.yaml
@@ -1,0 +1,20 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ProFont.NerdFont
+PackageVersion: 3.5.1
+InstallerType: zip
+NestedInstallerType: font
+NestedInstallerFiles:
+- RelativeFilePath: ProFontIIxNerdFont-Regular.ttf
+- RelativeFilePath: ProFontIIxNerdFontMono-Regular.ttf
+- RelativeFilePath: ProFontIIxNerdFontPropo-Regular.ttf
+- RelativeFilePath: ProFontWindowsNerdFont-Regular.ttf
+- RelativeFilePath: ProFontWindowsNerdFontMono-Regular.ttf
+- RelativeFilePath: ProFontWindowsNerdFontPropo-Regular.ttf
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/ryanoasis/nerd-fonts/releases/download/v3.5.1/ProFont.zip
+  InstallerSha256: F32FFA773C067AE88E8D6C09B2A6FCA52A3D343D160D4DD1070FF05FDDC2AEDB
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/ProFont/NerdFont/3.5.1/ryanoasis.ProFont.NerdFont.locale.en-US.yaml
+++ b/fonts/r/ryanoasis/ProFont/NerdFont/3.5.1/ryanoasis.ProFont.NerdFont.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ProFont.NerdFont
+PackageVersion: 3.5.1
+PackageLocale: en-US
+Publisher: Nerd Fonts
+PublisherUrl: https://www.nerdfonts.com/
+PublisherSupportUrl: https://github.com/ryanoasis/nerd-fonts/issues
+PackageName: ProFont Nerd Font
+PackageUrl: https://www.nerdfonts.com/
+License: MIT
+LicenseUrl: https://github.com/ryanoasis/nerd-fonts/blob/master/LICENSE
+ShortDescription: ProFont patched with Nerd Fonts glyphs
+Moniker: profont-nf
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/fonts/r/ryanoasis/ProFont/NerdFont/3.5.1/ryanoasis.ProFont.NerdFont.yaml
+++ b/fonts/r/ryanoasis/ProFont/NerdFont/3.5.1/ryanoasis.ProFont.NerdFont.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: ryanoasis.ProFont.NerdFont
+PackageVersion: 3.5.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/ryanoasis.ProFont.NerdFont.Font.json
+++ b/shards/json/ryanoasis.ProFont.NerdFont.Font.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "ryanoasis", "repo": "nerd-fonts" },
+	"urls": ["https://github.com/ryanoasis/nerd-fonts/releases/download/v{version}/ProFont.zip"]
+}


### PR DESCRIPTION
Adds the ProFont Nerd Font from the [ryanoasis/nerd-fonts](https://github.com/ryanoasis/nerd-fonts) v3.5.1 release.

Relates to microsoft/winget-pkgs#17547 — Nerd Fonts are not accepted upstream.

- Manifest built with komac `--font` from the release archive.
- Licence read from the LICENSE file inside the archive: MIT.
- Shard uses the `github-release` strategy against `ryanoasis/nerd-fonts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_