### PR TITLE
New package: irusanov.ZenTimings version 1.39

### DIFF
--- a/manifests/i/irusanov/ZenTimings/1.39/irusanov.ZenTimings.installer.yaml
+++ b/manifests/i/irusanov/ZenTimings/1.39/irusanov.ZenTimings.installer.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: irusanov.ZenTimings
+PackageVersion: '1.39'
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: ZenTimings_v1.39/ZenTimings.exe
+ReleaseDate: 2026-05-28
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/irusanov/ZenTimings/releases/download/v1.39/ZenTimings_v1.39.zip
+  InstallerSha256: 2B350F44CD823BEF50C4F8D3F3E75A9E03CFB9EBE73BEA9D995B6A826A7BDFDF
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/i/irusanov/ZenTimings/1.39/irusanov.ZenTimings.locale.en-US.yaml
+++ b/manifests/i/irusanov/ZenTimings/1.39/irusanov.ZenTimings.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: irusanov.ZenTimings
+PackageVersion: '1.39'
+PackageLocale: en-US
+Publisher: Ivan Rusanov
+PublisherUrl: https://github.com/irusanov
+PublisherSupportUrl: https://github.com/irusanov/ZenTimings/issues
+PackageName: ZenTimings
+PackageUrl: https://github.com/irusanov/ZenTimings
+License: GPL-3.0-only
+LicenseUrl: https://github.com/irusanov/ZenTimings/blob/master/LICENSE
+ShortDescription: Reads AMD Ryzen memory timings and power tables
+Moniker: zentimings
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/i/irusanov/ZenTimings/1.39/irusanov.ZenTimings.yaml
+++ b/manifests/i/irusanov/ZenTimings/1.39/irusanov.ZenTimings.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: irusanov.ZenTimings
+PackageVersion: '1.39'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/irusanov.ZenTimings.json
+++ b/shards/json/irusanov.ZenTimings.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "irusanov", "repo": "ZenTimings" },
+	"urls": [
+		"https://github.com/irusanov/ZenTimings/releases/download/v{version}/ZenTimings_v{version}.zip"
+	]
+}


### PR DESCRIPTION
Adds ZenTimings, which reads AMD Ryzen memory timings and power tables.

Fixes microsoft/winget-pkgs#210655 — declined upstream under the `Hardware` label, since validation needs an AMD Ryzen system.

- Manifest generated with komac from the v1.39 release asset.
- Licence read from `LICENSE` in the source repo: GPL-3.0-only.
- Shard uses the `github-release` strategy against `irusanov/ZenTimings`.

Checked for an existing package before building: no match by identifier, by name token, or by source repository (`github.com/irusanov/ZenTimings`) in either winget-pkgs or winget-extras.

One thing a reviewer may want to weigh in on: `NestedInstallerFiles.RelativeFilePath` is `ZenTimings_v1.39/ZenTimings.exe`, which carries the version inside the archive path. A future version bump updates the URL but not that path, so it will likely need adjusting at the next bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_