### PR TITLE
New package: xupefei.Locale-Emulator version 2.5.0.1

### DIFF
--- a/manifests/x/xupefei/Locale-Emulator/2.5.0.1/xupefei.Locale-Emulator.installer.yaml
+++ b/manifests/x/xupefei/Locale-Emulator/2.5.0.1/xupefei.Locale-Emulator.installer.yaml
@@ -1,0 +1,19 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: xupefei.Locale-Emulator
+PackageVersion: 2.5.0.1
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+- RelativeFilePath: LEGUI.exe
+- RelativeFilePath: LEInstaller.exe
+- RelativeFilePath: LEProc.exe
+- RelativeFilePath: LEUpdater.exe
+ReleaseDate: 2021-12-08
+Installers:
+- Architecture: neutral
+  InstallerUrl: https://github.com/xupefei/Locale-Emulator/releases/download/v2.5.0.1/Locale.Emulator.2.5.0.1.zip
+  InstallerSha256: 808FF584426D52CC775AD6406DA00622F454BE95BD4C8FBCA42EEF4B7235AD5C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/x/xupefei/Locale-Emulator/2.5.0.1/xupefei.Locale-Emulator.locale.en-US.yaml
+++ b/manifests/x/xupefei/Locale-Emulator/2.5.0.1/xupefei.Locale-Emulator.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: xupefei.Locale-Emulator
+PackageVersion: 2.5.0.1
+PackageLocale: en-US
+Publisher: xupefei
+PublisherUrl: https://github.com/xupefei
+PublisherSupportUrl: https://github.com/xupefei/Locale-Emulator/issues
+PackageName: Locale Emulator
+PackageUrl: https://github.com/xupefei/Locale-Emulator
+License: LGPL-3.0-only
+LicenseUrl: https://github.com/xupefei/Locale-Emulator/blob/master/COPYING.LESSER
+ShortDescription: Runs applications under a different system locale
+Moniker: locale-emulator
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/x/xupefei/Locale-Emulator/2.5.0.1/xupefei.Locale-Emulator.yaml
+++ b/manifests/x/xupefei/Locale-Emulator/2.5.0.1/xupefei.Locale-Emulator.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: xupefei.Locale-Emulator
+PackageVersion: 2.5.0.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/xupefei.Locale-Emulator.json
+++ b/shards/json/xupefei.Locale-Emulator.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "xupefei", "repo": "Locale-Emulator" },
+	"urls": [
+		"https://github.com/xupefei/Locale-Emulator/releases/download/v{version}/Locale.Emulator.{version}.zip"
+	]
+}


### PR DESCRIPTION
Adds Locale Emulator, which runs applications under a different system locale.

Fixes microsoft/winget-pkgs#332489 — declined upstream under the `Interactive-Only-Installer` label.

- Manifest generated with komac from the v2.5.0.1 release asset.
- Licence read from the source repo, which ships both `COPYING` (GPLv3) and `COPYING.LESSER` (LGPLv3) — the standard FSF layout for an LGPL project, so the manifest uses `LGPL-3.0-only`.
- Shard uses the `github-release` strategy against `xupefei/Locale-Emulator`.

Checked for an existing package before building: no match by identifier, by name token, or by source repository (`github.com/xupefei/Locale-Emulator`) in either winget-pkgs or winget-extras.

The archive holds four executables, so all four are listed as `NestedInstallerFiles`; `LEGUI.exe` is the entry point a user would launch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_