### PR TITLE
New package: BeyondDimension.WattToolkit version 3.1.0

### DIFF
--- a/manifests/b/BeyondDimension/WattToolkit/3.1.0/BeyondDimension.WattToolkit.installer.yaml
+++ b/manifests/b/BeyondDimension/WattToolkit/3.1.0/BeyondDimension.WattToolkit.installer.yaml
@@ -1,0 +1,15 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BeyondDimension.WattToolkit
+PackageVersion: 3.1.0
+InstallerType: nullsoft
+Scope: machine
+ElevationRequirement: elevatesSelf
+ReleaseDate: 2026-03-11
+Installers:
+- Architecture: x64
+  InstallerUrl: https://github.com/BeyondDimension/SteamTools/releases/download/3.1.0/Steam++_v3.1.0_win_x64.exe
+  InstallerSha256: EDAC49338697EA4F3EBC0B5BADC7DDAA91EB1BF0C97ED16F4CBA37F8D543B911
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BeyondDimension/WattToolkit/3.1.0/BeyondDimension.WattToolkit.locale.en-US.yaml
+++ b/manifests/b/BeyondDimension/WattToolkit/3.1.0/BeyondDimension.WattToolkit.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BeyondDimension.WattToolkit
+PackageVersion: 3.1.0
+PackageLocale: en-US
+Publisher: BeyondDimension
+PublisherUrl: https://github.com/BeyondDimension
+PublisherSupportUrl: https://github.com/BeyondDimension/SteamTools/issues
+PackageName: Watt Toolkit
+PackageUrl: https://steampp.net/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/BeyondDimension/SteamTools/blob/develop/LICENSE
+Copyright: © ️ 江苏蒸汽凡星科技有限公司. All rights reserved.
+ShortDescription: Network acceleration and script tools for game platforms
+Moniker: watttoolkit
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BeyondDimension/WattToolkit/3.1.0/BeyondDimension.WattToolkit.yaml
+++ b/manifests/b/BeyondDimension/WattToolkit/3.1.0/BeyondDimension.WattToolkit.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BeyondDimension.WattToolkit
+PackageVersion: 3.1.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/BeyondDimension.WattToolkit.json
+++ b/shards/json/BeyondDimension.WattToolkit.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "BeyondDimension", "repo": "SteamTools" },
+	"urls": [
+		"https://github.com/BeyondDimension/SteamTools/releases/download/{version}/Steam++_v{version}_win_x64.exe"
+	]
+}


### PR DESCRIPTION
Adds Watt Toolkit (formerly Steam++), network acceleration and script tooling for game platforms.

Fixes microsoft/winget-pkgs#337557 — declined upstream under the `Interactive-Only-Installer` label.

- Manifest generated with komac from the 3.1.0 Windows release asset.
- Licence read from `LICENSE` in the source repo: GPL-3.0-only.
- Shard uses the `github-release` strategy against `BeyondDimension/SteamTools`.

Checked for an existing package before building: no match by identifier, by word-subset name match, or by source repository (`github.com/BeyondDimension/SteamTools`) in either winget-pkgs or winget-extras.

**One correction worth flagging for review.** komac detected the installer as `portable`. That is wrong — the binary carries the NSIS `.ndata` PE section and an embedded assembly manifest reading `Nullsoft Install System v2.46.5-Unicode`, with `requestedExecutionLevel level="requireAdministrator"`. I set `InstallerType: nullsoft` with `Scope: machine` and `ElevationRequirement: elevatesSelf` accordingly. Left as `portable` winget would have symlinked the installer rather than running it.

`AppsAndFeaturesEntries` is not set: determining the ARP key needs a Windows machine to install on, and I would only be guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_