### PR TITLE
New package: DSheirer.sdrtrunk version 0.6.1

### DIFF
--- a/manifests/d/DSheirer/sdrtrunk/0.6.1/DSheirer.sdrtrunk.installer.yaml
+++ b/manifests/d/DSheirer/sdrtrunk/0.6.1/DSheirer.sdrtrunk.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: DSheirer.sdrtrunk
+PackageVersion: 0.6.1
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2024-12-03
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: sdr-trunk-windows-x86_64-v0.6.1/bin/sdr-trunk.bat
+    PortableCommandAlias: sdr-trunk
+  InstallerUrl: https://github.com/DSheirer/sdrtrunk/releases/download/v0.6.1/sdr-trunk-windows-x86_64-v0.6.1.zip
+  InstallerSha256: 6CF68031034F52E95D29A3B699B8EE232E1C9BF290C724FB1F7B02325EA13C06
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: sdr-trunk-windows-aarch64-v0.6.1/bin/sdr-trunk.bat
+    PortableCommandAlias: sdr-trunk
+  InstallerUrl: https://github.com/DSheirer/sdrtrunk/releases/download/v0.6.1/sdr-trunk-windows-aarch64-v0.6.1.zip
+  InstallerSha256: 304C30D30F46AE131B36A5C5483328349FE4CAC59557C2F68F64171BAF23EE31
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/d/DSheirer/sdrtrunk/0.6.1/DSheirer.sdrtrunk.locale.en-US.yaml
+++ b/manifests/d/DSheirer/sdrtrunk/0.6.1/DSheirer.sdrtrunk.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: DSheirer.sdrtrunk
+PackageVersion: 0.6.1
+PackageLocale: en-US
+Publisher: Dennis Sheirer
+PublisherUrl: https://github.com/DSheirer
+PublisherSupportUrl: https://github.com/DSheirer/sdrtrunk/issues
+PackageName: sdrtrunk
+PackageUrl: https://github.com/DSheirer/sdrtrunk
+License: GPL-3.0-only
+LicenseUrl: https://github.com/DSheirer/sdrtrunk/blob/master/LICENSE
+ShortDescription: Decodes and monitors trunked radio systems using software defined radios
+Moniker: sdrtrunk
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/d/DSheirer/sdrtrunk/0.6.1/DSheirer.sdrtrunk.yaml
+++ b/manifests/d/DSheirer/sdrtrunk/0.6.1/DSheirer.sdrtrunk.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: DSheirer.sdrtrunk
+PackageVersion: 0.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/DSheirer.sdrtrunk.json
+++ b/shards/json/DSheirer.sdrtrunk.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "DSheirer", "repo": "sdrtrunk" },
+	"urls": [
+		"https://github.com/DSheirer/sdrtrunk/releases/download/v{version}/sdr-trunk-windows-x86_64-v{version}.zip",
+		"https://github.com/DSheirer/sdrtrunk/releases/download/v{version}/sdr-trunk-windows-aarch64-v{version}.zip"
+	]
+}


### PR DESCRIPTION
Adds sdrtrunk, which decodes and monitors trunked radio systems using software defined radios.

Fixes microsoft/winget-pkgs#318468 — declined upstream, and it also needs SDR hardware to exercise.

- Manifest generated with komac from the v0.6.1 release assets, carrying both Windows architectures (x64 and arm64) in one manifest.
- Licence read from `LICENSE` in the source repo: GPL-3.0-only.
- Shard uses the `github-release` strategy and lists both installer URLs.

Checked for an existing package before building: no match by identifier, by word-subset name match, or by source repository (`github.com/DSheirer/sdrtrunk`) in either winget-pkgs or winget-extras.

**One correction worth flagging for review.** komac populated `NestedInstallerFiles` with nine executables from the bundled JRE — `java.exe`, `javaw.exe`, `keytool.exe`, `kinit.exe`, `klist.exe`, `ktab.exe`, `jabswitch.exe`, `jaccessinspector.exe`, `jaccesswalker.exe`. Installing that would have put a JDK's tooling on the user's PATH under those names.

The archive contains no application `.exe` at all; sdrtrunk ships as a jar (`lib/sdr-trunk-0.6.1.jar`) launched by `bin/sdr-trunk.bat` against the bundled runtime. I replaced the list with that one launcher per architecture and set `PortableCommandAlias: sdr-trunk`, so the package exposes a single sensibly-named command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_