### PR TITLE
New package: MegaGlest.MegaGlest version 3.13.0

### DIFF
--- a/manifests/m/MegaGlest/MegaGlest/3.13.0/MegaGlest.MegaGlest.installer.yaml
+++ b/manifests/m/MegaGlest/MegaGlest/3.13.0/MegaGlest.MegaGlest.installer.yaml
@@ -1,0 +1,22 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: MegaGlest.MegaGlest
+PackageVersion: 3.13.0
+InstallerType: nullsoft
+Scope: machine
+ProductCode: MegaGlest
+ReleaseDate: 2021-12-07
+AppsAndFeaturesEntries:
+- ProductCode: MegaGlest
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles(x86)%\MegaGlest'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/MegaGlest/megaglest-source/releases/download/3.13.0/MegaGlest-Installer-3.13.0_windows_32bit.exe
+  InstallerSha256: 84EADE59226FE52F8349BFCFFEC1B71A4D45760671F59E4D7D25C1C991A9610D
+- Architecture: x64
+  InstallerUrl: https://github.com/MegaGlest/megaglest-source/releases/download/3.13.0/MegaGlest-Installer-3.13.0_windows_64bit.exe
+  InstallerSha256: D08D6248B1D9EDADB5709D84EB39AF61FBCD2FBB8EDD649CCEBE3E96541E3847
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/MegaGlest/MegaGlest/3.13.0/MegaGlest.MegaGlest.installer.yaml
+++ b/manifests/m/MegaGlest/MegaGlest/3.13.0/MegaGlest.MegaGlest.installer.yaml
@@ -5,6 +5,8 @@ PackageIdentifier: MegaGlest.MegaGlest
 PackageVersion: 3.13.0
 InstallerType: nullsoft
 Scope: machine
+InstallModes:
+- interactive
 ProductCode: MegaGlest
 ReleaseDate: 2021-12-07
 AppsAndFeaturesEntries:

--- a/manifests/m/MegaGlest/MegaGlest/3.13.0/MegaGlest.MegaGlest.locale.en-US.yaml
+++ b/manifests/m/MegaGlest/MegaGlest/3.13.0/MegaGlest.MegaGlest.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: MegaGlest.MegaGlest
+PackageVersion: 3.13.0
+PackageLocale: en-US
+Publisher: MegaGlest Team
+PublisherUrl: https://megaglest.org/
+PublisherSupportUrl: https://github.com/MegaGlest/megaglest-source/issues
+PackageName: MegaGlest
+PackageUrl: https://megaglest.org/
+License: GPL-3.0-only
+LicenseUrl: https://github.com/MegaGlest/megaglest-source/blob/master/docs/gnu_gpl_3.0.txt
+ShortDescription: Free real-time strategy game
+Moniker: megaglest
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/MegaGlest/MegaGlest/3.13.0/MegaGlest.MegaGlest.yaml
+++ b/manifests/m/MegaGlest/MegaGlest/3.13.0/MegaGlest.MegaGlest.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: MegaGlest.MegaGlest
+PackageVersion: 3.13.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/MegaGlest.MegaGlest.json
+++ b/shards/json/MegaGlest.MegaGlest.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "MegaGlest", "repo": "megaglest-source" },
+	"urls": [
+		"https://github.com/MegaGlest/megaglest-source/releases/download/{version}/MegaGlest-Installer-{version}_windows_64bit.exe",
+		"https://github.com/MegaGlest/megaglest-source/releases/download/{version}/MegaGlest-Installer-{version}_windows_32bit.exe"
+	]
+}


### PR DESCRIPTION
Adds MegaGlest, a free real-time strategy game.

Fixes microsoft/winget-pkgs#107172 — declined upstream under the `Interactive-Only-Installer` label.

- Manifest generated with komac from the 3.13.0 release assets, carrying both Windows architectures (x86 and x64) in one manifest.
- Shard uses the `github-release` strategy and lists both installer URLs.

Checked for an existing package before building: no match by identifier, by word-subset name match, or by source repository (`github.com/MegaGlest/megaglest-source`) in either winget-pkgs or winget-extras.

On the licence: the repository has no `LICENSE` file at its root, so `GPL-3.0-only` is taken from `docs/gnu_gpl_3.0.txt`, which is the full GPLv3 text. That is weaker evidence than the other packages in this batch, where I read a root licence file. Worth noting that the GPL covers the engine; MegaGlest's game data ships under its own separate terms, which this manifest does not attempt to express.

komac's installer detection was correct with no adjustment needed — NSIS, `ProductCode: MegaGlest`, and the default install location all came through.

**Installation Validation failed on the first push; fixed in d7a8f5e.** Both architectures timed out at exactly five minutes, with the log showing `Starting package install...` and then nothing — no exit code, no error. The download and hash verified fine, so this is the installer waiting on input rather than installing slowly; 250MB of game data would not take five minutes to extract on a runner.

That is the same conclusion upstream reached when they applied the `Interactive-Only-Installer` label, so I added `InstallModes: [interactive]`. `validate.ps1` treats a timeout as the expected outcome when that is the only install mode, which is the path this repository provides for exactly this category of package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry