### PR TITLE
New package: Solicus.InstallForge version 1.6.1

### DIFF
--- a/manifests/s/Solicus/InstallForge/1.6.1/Solicus.InstallForge.installer.yaml
+++ b/manifests/s/Solicus/InstallForge/1.6.1/Solicus.InstallForge.installer.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Solicus.InstallForge
+PackageVersion: 1.6.1
+InstallerType: exe
+Scope: machine
+InstallModes:
+- interactive
+ElevationRequirement: elevatesSelf
+ReleaseDate: 2025-12-23
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/soner-boztas/installforge/releases/download/v1.6.1/IFInst.exe
+  InstallerSha256: B0839A6426ACB3563CBBB1701179BEB7B0714ABC46C3FA79E896A6CBECD72E67
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Solicus/InstallForge/1.6.1/Solicus.InstallForge.locale.en-US.yaml
+++ b/manifests/s/Solicus/InstallForge/1.6.1/Solicus.InstallForge.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Solicus.InstallForge
+PackageVersion: 1.6.1
+PackageLocale: en-US
+Publisher: Solicus
+PublisherUrl: https://installforge.net/
+PublisherSupportUrl: https://github.com/soner-boztas/installforge/issues
+PackageName: InstallForge
+PackageUrl: https://installforge.net/
+License: Freeware
+LicenseUrl: https://docs.installforge.net/license/
+ShortDescription: Builds Windows installers
+Moniker: installforge
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Solicus/InstallForge/1.6.1/Solicus.InstallForge.yaml
+++ b/manifests/s/Solicus/InstallForge/1.6.1/Solicus.InstallForge.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Solicus.InstallForge
+PackageVersion: 1.6.1
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Solicus.InstallForge.json
+++ b/shards/json/Solicus.InstallForge.json
@@ -1,0 +1,6 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "soner-boztas", "repo": "installforge" },
+	"urls": ["https://github.com/soner-boztas/installforge/releases/download/v{version}/IFInst.exe"]
+}


### PR DESCRIPTION
Adds InstallForge, a tool for building Windows installers.

Fixes microsoft/winget-pkgs#156216 — declined upstream under the `Interactive-Only-Installer` label.

- Manifest generated with komac from the v1.6.1 release asset.
- Shard uses the `github-release` strategy against `soner-boztas/installforge`.

Checked for an existing package before building: no match by identifier, by word-subset name match, or by source repository (`github.com/soner-boztas/installforge`) in either winget-pkgs or winget-extras.

**Licence.** There is no SPDX licence and no licence file in the repo. https://docs.installforge.net/license/ makes it free for personal and commercial use, so the manifest uses `Freeware`. Note that the bundled Visual Update module requires a paid licence in a commercial context under a separate EULA — that nuance is not expressible in the manifest.

**Publisher.** The identifier follows the upstream request. Confirmed against the site footer: "Copyright © 2007-2026 solicus. Soner Boztas & Contributors." — `solicus` is the publisher; the code now lives under the `soner-boztas` GitHub account.

**Installer type — changed from komac's output, with a caveat.** komac detected `portable`. The binary requests `requireAdministrator` and is published as the InstallForge download (`IFInst.exe`), so it is an installer rather than a portable app, and left as `portable` winget would have symlinked it instead of running it. I set `InstallerType: exe`.

I could not establish a silent switch. The binary carries no NSIS, Inno, InstallShield or WiX Burn signature — sections are `.text .rdata .data .eh_fram .rsrc .reloc`, consistent with a plain compiled binary rather than a known installer framework — and the `/S` strings in it belong to unrelated library text. Rather than guess a switch, I marked it `InstallModes: [interactive]`, which is both accurate to the upstream rejection reason and the case `validate.ps1` expects to time out.

Someone on Windows should confirm the interactive-only classification and whether a silent switch exists; if one does, adding it would be a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_