### PR TITLE
New package: Cockos.ReaPlugs version 2.36

### DIFF
--- a/manifests/c/Cockos/ReaPlugs/2.36/Cockos.ReaPlugs.installer.yaml
+++ b/manifests/c/Cockos/ReaPlugs/2.36/Cockos.ReaPlugs.installer.yaml
@@ -1,0 +1,22 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Cockos.ReaPlugs
+PackageVersion: '2.36'
+InstallerType: nullsoft
+Scope: machine
+ProductCode: ReaPlugs
+ReleaseDate: 2016-01-03
+AppsAndFeaturesEntries:
+- ProductCode: ReaPlugs
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles(x86)%\VSTPlugins\ReaPlugs'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://www.reaper.fm/reaplugs/reaplugs236-install.exe
+  InstallerSha256: 511DBC77E24EDFDC90D08E07DEFCA40063F46F5A1F8E9E6C75F6FFBD161B3E3B
+- Architecture: x64
+  InstallerUrl: https://www.reaper.fm/reaplugs/reaplugs236_x64-install.exe
+  InstallerSha256: 1654F1F78D746FC87A6F6D078A8F928EA61C7B49997B1F2C07DFC870F8FA6C10
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/c/Cockos/ReaPlugs/2.36/Cockos.ReaPlugs.installer.yaml
+++ b/manifests/c/Cockos/ReaPlugs/2.36/Cockos.ReaPlugs.installer.yaml
@@ -5,6 +5,8 @@ PackageIdentifier: Cockos.ReaPlugs
 PackageVersion: '2.36'
 InstallerType: nullsoft
 Scope: machine
+InstallModes:
+- interactive
 ProductCode: ReaPlugs
 ReleaseDate: 2016-01-03
 AppsAndFeaturesEntries:

--- a/manifests/c/Cockos/ReaPlugs/2.36/Cockos.ReaPlugs.locale.en-US.yaml
+++ b/manifests/c/Cockos/ReaPlugs/2.36/Cockos.ReaPlugs.locale.en-US.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Cockos.ReaPlugs
+PackageVersion: '2.36'
+PackageLocale: en-US
+Publisher: Cockos Incorporated
+PublisherUrl: https://www.cockos.com/
+PublisherSupportUrl: https://forum.cockos.com/
+PackageName: ReaPlugs
+PackageUrl: https://www.reaper.fm/reaplugs/
+License: Freeware
+LicenseUrl: https://www.reaper.fm/reaplugs/
+ShortDescription: Cockos VST plug-in bundle
+Moniker: reaplugs
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/c/Cockos/ReaPlugs/2.36/Cockos.ReaPlugs.yaml
+++ b/manifests/c/Cockos/ReaPlugs/2.36/Cockos.ReaPlugs.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Cockos.ReaPlugs
+PackageVersion: '2.36'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Cockos.ReaPlugs.json
+++ b/shards/json/Cockos.ReaPlugs.json
@@ -1,0 +1,12 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://www.reaper.fm/reaplugs/",
+		"regex": "reaplugs\\d+_x64-install\\.exe\">ReaPlugs VST v(\\d+\\.\\d+)"
+	},
+	"urls": [
+		"https://www.reaper.fm/reaplugs/reaplugs{version|.|}_x64-install.exe",
+		"https://www.reaper.fm/reaplugs/reaplugs{version|.|}-install.exe"
+	]
+}


### PR DESCRIPTION
Adds ReaPlugs, Cockos' VST plug-in bundle.

Fixes microsoft/winget-pkgs#118525 — declined upstream under the `Interactive-Only-Installer` label.

- Manifest generated with komac from the vendor downloads, carrying both architectures (x86 and x64) in one manifest.
- Licence is `Freeware`: Cockos distributes ReaPlugs free of charge with no SPDX licence.
- komac's installer detection needed no adjustment — NSIS, `ProductCode: ReaPlugs` and the `%ProgramFiles(x86)%\VSTPlugins\ReaPlugs` install location all came through.

Checked for an existing package before building: no match by identifier, by word-subset name match, or by source host (`www.reaper.fm`) in either winget-pkgs or winget-extras.

**Shard note.** The download filenames encode the version with the dot stripped — 2.36 is `reaplugs236_x64-install.exe` — so a plain `{version}` substitution does not work. The shard uses `page-match` to read the version from the download page and the existing `{version|.|}` transform to rebuild the filename. I verified end to end that the regex matches `2.36` against the live page and that the transform reproduces exactly the two URLs in the manifest.

The regex is anchored on the x64 link so it picks up the newest entry; the page lists every historical release in descending order.

**Installation Validation failed on the first push; fixed in 4346af4.** The installer timed out at five minutes with no exit code, the same signature as MegaGlest in this batch: winget's default NSIS `/S` does not carry it to completion. I added `InstallModes: [interactive]`, which matches the upstream `Interactive-Only-Installer` label and is the case `validate.ps1` expects to time out.

Worth knowing: 2.36 dates from January 2016 and is the current release, so this package is unlikely to see version churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry