### PR TITLE
New package: Samsung.Magician version 9.0.1.950

### DIFF
--- a/manifests/s/Samsung/Magician/9.0.1.950/Samsung.Magician.installer.yaml
+++ b/manifests/s/Samsung/Magician/9.0.1.950/Samsung.Magician.installer.yaml
@@ -7,8 +7,6 @@ InstallerType: inno
 Scope: machine
 InstallModes:
 - interactive
-- silent
-- silentWithProgress
 ProductCode: '{29AE3F9F-7158-4ca7-B1ED-28A73ECDB215}_is1'
 ReleaseDate: 2026-03-30
 AppsAndFeaturesEntries:

--- a/manifests/s/Samsung/Magician/9.0.1.950/Samsung.Magician.installer.yaml
+++ b/manifests/s/Samsung/Magician/9.0.1.950/Samsung.Magician.installer.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Samsung.Magician
+PackageVersion: 9.0.1.950
+InstallerType: inno
+Scope: machine
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+ProductCode: '{29AE3F9F-7158-4ca7-B1ED-28A73ECDB215}_is1'
+ReleaseDate: 2026-03-30
+AppsAndFeaturesEntries:
+- ProductCode: '{29AE3F9F-7158-4ca7-B1ED-28A73ECDB215}_is1'
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Samsung\Samsung Magician'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://download.semiconductor.samsung.com/resources/software-resources/Samsung_Magician_Installer_Official_9.0.1.950.exe
+  InstallerSha256: D46CF61AA5B5073138E9D063E91F1861776315A14DFCA3FFD8724611C21588D8
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Samsung/Magician/9.0.1.950/Samsung.Magician.locale.en-US.yaml
+++ b/manifests/s/Samsung/Magician/9.0.1.950/Samsung.Magician.locale.en-US.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Samsung.Magician
+PackageVersion: 9.0.1.950
+PackageLocale: en-US
+Publisher: Samsung Electronics
+PublisherUrl: https://semiconductor.samsung.com/
+PublisherSupportUrl: https://semiconductor.samsung.com/consumer-storage/support/
+PackageName: Samsung Magician
+PackageUrl: https://semiconductor.samsung.com/consumer-storage/support/tools/
+License: Proprietary
+LicenseUrl: https://semiconductor.samsung.com/consumer-storage/support/tools/
+Copyright: © . 2026 SAMSUNG ELECTRONICS CO., LTD. ALL RIGHTS RESERVED.
+ShortDescription: Manages and monitors Samsung SSDs
+Moniker: samsung-magician
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Samsung/Magician/9.0.1.950/Samsung.Magician.yaml
+++ b/manifests/s/Samsung/Magician/9.0.1.950/Samsung.Magician.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Samsung.Magician
+PackageVersion: 9.0.1.950
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Samsung.Magician.json
+++ b/shards/json/Samsung.Magician.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://semiconductor.samsung.com/consumer-storage/support/tools/",
+		"regex": "Samsung_Magician_Installer_Official_(\\d+(?:\\.\\d+)+)\\.exe"
+	},
+	"urls": [
+		"https://download.semiconductor.samsung.com/resources/software-resources/Samsung_Magician_Installer_Official_{version}.exe"
+	]
+}


### PR DESCRIPTION
Adds Samsung Magician, which manages and monitors Samsung SSDs.

Fixes microsoft/winget-pkgs#306938, and also covers microsoft/winget-pkgs#148013 and microsoft/winget-pkgs#134001 — repeatedly declined upstream.

- Manifest generated with komac from the official Samsung download.
- Licence is `Proprietary`: Samsung ships it under its own EULA, free of charge but tied to Samsung drives.
- Shard uses `page-match` against the Samsung tools page, which carries the versioned installer filename. Verified the regex resolves to `9.0.1.950` against the live page and rebuilds exactly the manifest's URL.

Checked for an existing package before building: no match by identifier, by word-subset name match, or by source host (`download.semiconductor.samsung.com`) in either winget-pkgs or winget-extras. The only "magician" hits anywhere are `magicianhax.portscontroller` and `terrymacdonald.displaymagician`, both unrelated.

**Identifier.** The upstream issues proposed `Samsung.SamsungMagician` and `SamsungElectronics.SamsungMagician`. I used `Samsung.Magician` to match the convention in winget-pkgs, where the publisher prefix is not repeated in the product segment — `Samsung.EasyMigration`, `Samsung.EasySettingBox`, `Samsung.GalaxyBudsManager`. Happy to rename.

---

## Installation Validation cannot pass as CI is currently written

I believe the manifest is correct and I have stopped rather than bend it to get green. The detail matters, so here it is in full.

This installer refuses silent installation outright. Its own log:

```
Samsung Magician cannot be installed in silent mode. Remove silent mode and retry.
InitializeSetup returned False; aborting.
```

So `InstallModes: [interactive]` is factually right, and b06adf7 sets it — komac had inferred `silent` and `silentWithProgress`, the usual Inno default.

That does not make CI pass, because `InstallModes` describes what the package supports; it does not change how the harness invokes winget. `validate.ps1` always runs `winget install --silent`, so winget still passes `/VERYSILENT /SUPPRESSMSGBOXES /NORESTART` and setup still aborts. What `InstallModes` changes is only CI's *expectation*:

```powershell
if (-not $success) {           # timed out
    if ($expectTimeout) { return }          # pass
    throw 'Install timed out'
}
if ($expectTimeout) {
    throw "Interactive-only install exited with code $($installer.ExitCode) instead of timing out"
}
```

`$expectTimeout` assumes an interactive-only installer *hangs* waiting for input. This one declines in about ten seconds and exits 1. It therefore satisfies neither branch: too fast to time out, non-zero so it fails the exit-code check. Both configurations fail, for opposite reasons.

I could force green by declaring `InstallerType: exe` so winget stops passing Inno silent switches and the installer hangs into the expected timeout. That would be misdeclaring an Inno installer to satisfy a test, so I have not done it.

The honest fix is in the harness, not this manifest — allowing an interactive-only installer to refuse quickly as well as hang:

```powershell
if ($expectTimeout) {
    Write-Host "Interactive-only installer declined silent install with code $($installer.ExitCode)"
    return
}
```

That is a change to shared CI affecting every package, so it is your call rather than something I should slip into a package PR. Happy to open it separately if you want it.

Until then this PR stays red. Everything except Installation Validation passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry