### PR TITLE
Add a linter rule for stale Apps and Features display names

### DIFF
--- a/scripts/manifest-linter/rules/index.ts
+++ b/scripts/manifest-linter/rules/index.ts
@@ -5,6 +5,7 @@ import { githubHostRule } from '@/scripts/manifest-linter/rules/installer/github
 import { githubPinningRule } from '@/scripts/manifest-linter/rules/installer/github-pinning';
 import { installerMetadataRule } from '@/scripts/manifest-linter/rules/installer/metadata';
 import { switchesRule } from '@/scripts/manifest-linter/rules/installer/switches';
+import { arpDisplayNameVersionRule } from '@/scripts/manifest-linter/rules/repository/arp-display-name-version';
 import { arpVersionRangesRule } from '@/scripts/manifest-linter/rules/repository/arp-version-ranges';
 import { repositoryContentsRule } from '@/scripts/manifest-linter/rules/repository/contents';
 import { copyrightFormatRule } from '@/scripts/manifest-linter/rules/repository/copyright-format';
@@ -34,6 +35,7 @@ export const defaultRules: readonly Rule[] = [
 	packageKindRule,
 	repositoryContentsRule,
 	arpVersionRangesRule,
+	arpDisplayNameVersionRule,
 	shardCoverageRule,
 	licenseSpdxRule,
 	copyrightFormatRule,

--- a/scripts/manifest-linter/rules/repository/arp-display-name-version.test.ts
+++ b/scripts/manifest-linter/rules/repository/arp-display-name-version.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from 'bun:test';
+
+import { arpDisplayNameVersionRule } from '@/scripts/manifest-linter/rules/repository/arp-display-name-version';
+import {
+	checkRule,
+	installerManifest,
+	messages,
+	record,
+} from '@/scripts/manifest-linter/rules/test-utils';
+
+function installerRecord(version: string, displayNames: string[], identifier = 'Acme.App') {
+	return record('installer', {
+		directory: `manifests/a/Acme/App/${version}`,
+		file: `manifests/a/Acme/App/${version}/${identifier}.installer.yaml`,
+		manifest: installerManifest({
+			PackageIdentifier: identifier,
+			PackageVersion: version,
+			InstallerType: 'exe',
+			Installers: displayNames.map((DisplayName) => ({
+				Architecture: 'x64',
+				AppsAndFeaturesEntries: [{ DisplayName }],
+			})),
+		}),
+	});
+}
+
+describe('ARP display name version rule', () => {
+	test('accepts a name holding its own version', async () => {
+		const issues = await checkRule(arpDisplayNameVersionRule, {
+			records: [installerRecord('1.0', ['Acme App 1.0']), installerRecord('1.1', ['Acme App 1.1'])],
+		});
+		expect(issues).toEqual([]);
+	});
+
+	test('accepts a product number', async () => {
+		const issues = await checkRule(arpDisplayNameVersionRule, {
+			records: [
+				installerRecord('10.0.2001.0', ['IIS 10.0 Express']),
+				installerRecord('10.0.2002.0', ['IIS 10.0 Express']),
+			],
+		});
+		expect(issues).toEqual([]);
+	});
+
+	test('rejects a name copied from an earlier version', async () => {
+		const issues = await checkRule(arpDisplayNameVersionRule, {
+			records: [installerRecord('1.0', ['Acme App 1.0']), installerRecord('1.1', ['Acme App 1.0'])],
+		});
+		expect(messages(issues)).toEqual(['DisplayName must be written as: Acme App 1.1']);
+		expect(issues[0]).toMatchObject({
+			level: 'warning',
+			search: 'Acme App 1.0',
+			hints: ['copied from manifests/a/Acme/App/1.0/Acme.App.installer.yaml'],
+			fix: { kind: 'replacement', from: 'Acme App 1.0', to: 'Acme App 1.1' },
+		});
+	});
+
+	test('reports each occurrence of a repeated name', async () => {
+		const issues = await checkRule(arpDisplayNameVersionRule, {
+			records: [
+				installerRecord('1.0', ['Acme App 1.0']),
+				installerRecord('1.1', ['Acme App 1.0', 'Acme App 1.0', 'Acme App 1.0']),
+			],
+		});
+		expect(messages(issues)).toHaveLength(3);
+	});
+
+	test('reads a root entry once', async () => {
+		const issues = await checkRule(arpDisplayNameVersionRule, {
+			records: [
+				installerRecord('1.0', ['Acme App 1.0']),
+				record('installer', {
+					manifest: installerManifest({
+						PackageVersion: '1.1',
+						InstallerType: 'exe',
+						AppsAndFeaturesEntries: [{ DisplayName: 'Acme App 1.0' }],
+						Installers: [{ Architecture: 'x64' }, { Architecture: 'x86' }],
+					}),
+				}),
+			],
+		});
+		expect(messages(issues)).toHaveLength(1);
+	});
+
+	test('accepts a name no other version of the package wrote', async () => {
+		const issues = await checkRule(arpDisplayNameVersionRule, {
+			records: [
+				installerRecord('1.1', ['Acme App 1.0']),
+				installerRecord('1.0', ['Acme 1.0']),
+				installerRecord('1.0', ['Acme App 1.0'], 'Acme.Other'),
+			],
+		});
+		expect(issues).toEqual([]);
+	});
+
+	test('ignores manifests without Apps and Features entries', async () => {
+		const issues = await checkRule(arpDisplayNameVersionRule, {
+			records: [record('defaultLocale'), record('version'), installerRecord('1.0', [])],
+		});
+		expect(issues).toEqual([]);
+	});
+});

--- a/scripts/manifest-linter/rules/repository/arp-display-name-version.ts
+++ b/scripts/manifest-linter/rules/repository/arp-display-name-version.ts
@@ -1,0 +1,59 @@
+import type { InstallerManifest } from '@/scripts/manifest-linter/manifest-schemas';
+import { defineRule } from '@/scripts/manifest-linter/rules/helpers';
+
+// A dotted number such as `616.64`. A bare number is usually part of the name,
+// as in `IIS 10 Express`.
+const VERSION = /\d+(?:\.\d+)+/g;
+
+// Every DisplayName the manifest writes, at the root and per installer. Nothing
+// is resolved or deduplicated: a name written three times gets three
+// diagnostics, because a replacement fix rewrites one occurrence.
+function displayNames(manifest: InstallerManifest): string[] {
+	const entries = [
+		...(manifest.AppsAndFeaturesEntries ?? []),
+		...manifest.Installers.flatMap((installer) => installer.AppsAndFeaturesEntries ?? []),
+	];
+	return entries.flatMap((entry) => (entry.DisplayName ? [entry.DisplayName] : []));
+}
+
+function key(identifier: string, version: string, name: string): string {
+	return JSON.stringify([identifier.toLowerCase(), version, name]);
+}
+
+// Komac only reads Apps and Features entries out of installer formats it can
+// unpack. For the rest, such as the NVIDIA driver, an update copies the previous
+// manifest's entries, so a DisplayName that names its version keeps naming the
+// previous one. The copied name is still written by that previous manifest,
+// which is how it is told apart from a product number: no other version writes
+// `IIS 10.0 Express`.
+export const arpDisplayNameVersionRule = defineRule({
+	id: 'repository/arp-display-name-version',
+	check({ records, report }) {
+		const names: { file: string; identifier: string; version: string; name: string }[] = [];
+		for (const { file, manifest } of records) {
+			if (manifest.ManifestType !== 'installer') continue;
+			const { PackageIdentifier: identifier, PackageVersion: version } = manifest;
+			for (const name of displayNames(manifest)) names.push({ file, identifier, version, name });
+		}
+		const writtenBy = new Map(
+			names.map((entry) => [key(entry.identifier, entry.version, entry.name), entry.file]),
+		);
+
+		for (const { file, identifier, version, name } of names) {
+			for (const found of new Set(name.match(VERSION))) {
+				if (found === version) continue;
+				const origin = writtenBy.get(key(identifier, found, name));
+				if (!origin) continue;
+				const expected = name.replace(VERSION, (match) => (match === found ? version : match));
+				report({
+					file,
+					level: 'warning',
+					message: `DisplayName must be written as: ${expected}`,
+					search: name,
+					hints: [`copied from ${origin}`],
+					fix: { kind: 'replacement', from: name, to: expected },
+				});
+			}
+		}
+	},
+});


### PR DESCRIPTION
Adds `repository/arp-display-name-version`, a manifest-linter rule with a fix.

Komac only reads Apps and Features entries out of installer formats it can unpack. For the rest, such as the NVIDIA driver, an update copies the previous manifest's entries, so a `DisplayName` that names its version keeps naming the previous one: https://github.com/pl4nty/winget-extras/pull/1380 writes 616.92 with `NVIDIA Graphics Driver 616.64`.

The rule reports a `DisplayName` that another version of the same package wrote for itself, and fixes it by substituting this manifest's `PackageVersion`. A product number such as `IIS 10.0 Express` is not written by a manifest at version 10.0, so it is left alone. `DisplayVersion` needs no equivalent: a copied one overlaps the previous version's range, which `repository/arp-version-ranges` already reports.

Against the head of https://github.com/pl4nty/winget-extras/pull/1380:

```
warning[repository/arp-display-name-version] --> manifests/n/Nvidia/Driver/GeForceGameReady/616.92/Nvidia.Driver.GeForceGameReady.installer.yaml:19:16
  18 | AppsAndFeaturesEntries:
> 19 | - DisplayName: NVIDIA Graphics Driver 616.64
>    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ DisplayName must be written as: NVIDIA Graphics Driver 616.92
  20 |   ProductCode: '{B2FE1952-0186-46C3-BAEC-A80AA35AC5B8}_Display.Driver'
  21 | ElevationRequirement: elevationRequired
  help: copied from manifests/n/Nvidia/Driver/GeForceGameReady/616.64/Nvidia.Driver.GeForceGameReady.installer.yaml
```

`bun manifests:fix` rewrites it to `NVIDIA Graphics Driver 616.92`. The current tree is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzQytNKV9XLgfmiWzKT3kT