### PR TITLE
New package: EnkleSystemer.ENKRegnskap version 3.9.2

### DIFF
--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.installer.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.installer.yaml
@@ -10,9 +10,7 @@ InstallerSwitches:
 ProductCode: '{B6CD22F3-956C-41DA-A4F1-728CDC3A40DF}'
 ReleaseDate: 2026-09-10
 AppsAndFeaturesEntries:
-- DisplayName: ENK-elt regnskap
-  Publisher: starheim
-  ProductCode: '{B6CD22F3-956C-41DA-A4F1-728CDC3A40DF}'
+- ProductCode: '{B6CD22F3-956C-41DA-A4F1-728CDC3A40DF}'
   UpgradeCode: '{70F6D435-BEC1-5123-A68E-129FDE21506D}'
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles%/ENK-elt regnskap'

--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.installer.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.installer.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: EnkleSystemer.ENKRegnskap
+PackageVersion: 3.9.2
+InstallerType: wix
+Scope: machine
+InstallerSwitches:
+  InstallLocation: INSTALLDIR="<INSTALLPATH>"
+ProductCode: '{B6CD22F3-956C-41DA-A4F1-728CDC3A40DF}'
+ReleaseDate: 2026-09-10
+AppsAndFeaturesEntries:
+- DisplayName: ENK-elt regnskap
+  Publisher: starheim
+  ProductCode: '{B6CD22F3-956C-41DA-A4F1-728CDC3A40DF}'
+  UpgradeCode: '{70F6D435-BEC1-5123-A68E-129FDE21506D}'
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%/ENK-elt regnskap'
+Installers:
+- Architecture: x64
+  InstallerUrl: https://enkregnskap.no/last-ned/ENK-elt-regnskap-windows.msi
+  InstallerSha256: 4A7832D80039593D35BB452787A620F5378284FC6185DE02F79A8B823CBFA0A6
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.en-GB.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.en-GB.yaml
@@ -4,8 +4,8 @@
 PackageIdentifier: EnkleSystemer.ENKRegnskap
 PackageVersion: 3.9.2
 PackageLocale: en-GB
-Publisher: Enkle Systemer AS
-PackageName: ENK Regnskap
+Publisher: starheim
+PackageName: ENK-elt regnskap
 PackageUrl: https://enkregnskap.no/
 License: Proprietary
 ShortDescription: All of your financial statements, at an actually sensible price. Norway's first such system built solely for single-member companies. No big corp functions you never use. No surprises.

--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.en-GB.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.en-GB.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EnkleSystemer.ENKRegnskap
+PackageVersion: 3.9.2
+PackageLocale: en-GB
+Publisher: Enkle Systemer AS
+PackageName: ENK Regnskap
+PackageUrl: https://enkregnskap.no/
+License: Proprietary
+ShortDescription: All of your financial statements, at an actually sensible price. Norway's first such system built solely for single-member companies. No big corp functions you never use. No surprises.
+Tags:
+- bookkeeping
+- company-car-statistics
+- enk-regnskap
+- financial-statements
+- home-offices
+- invoicing
+- norway
+- single-member-companies
+- taxkeeping
+PurchaseUrl: https://enkregnskap.no/#pris
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.nb-NO.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.nb-NO.yaml
@@ -1,0 +1,25 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: EnkleSystemer.ENKRegnskap
+PackageVersion: 3.9.2
+PackageLocale: nb-NO
+Publisher: Enkle Systemer AS
+PackageName: ENK Regnskap
+PackageUrl: https://enkregnskap.no/
+License: Proprietær
+ShortDescription: Hele regnskapet ditt, til en pris som faktisk gir mening. Norges første regnskapsystem bygd kun for enkeltpersonforetak. Ingen AS-funksjoner du aldri bruker. Ingen overraskelser.
+Moniker: enkregnskap
+Tags:
+- bokføring
+- enk-regnskap
+- enkeltpersonforetak
+- fakturering
+- hjemmekontor
+- kjørebok
+- norge
+- regnskapsprogram
+- skattemeldinger
+PurchaseUrl: https://enkregnskap.no/#pris
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.nb-NO.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.nb-NO.yaml
@@ -4,8 +4,8 @@
 PackageIdentifier: EnkleSystemer.ENKRegnskap
 PackageVersion: 3.9.2
 PackageLocale: nb-NO
-Publisher: Enkle Systemer AS
-PackageName: ENK Regnskap
+Publisher: starheim
+PackageName: ENK-elt regnskap
 PackageUrl: https://enkregnskap.no/
 License: Proprietær
 ShortDescription: Hele regnskapet ditt, til en pris som faktisk gir mening. Norges første regnskapsystem bygd kun for enkeltpersonforetak. Ingen AS-funksjoner du aldri bruker. Ingen overraskelser.

--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.nn-NO.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.nn-NO.yaml
@@ -4,8 +4,8 @@
 PackageIdentifier: EnkleSystemer.ENKRegnskap
 PackageVersion: 3.9.2
 PackageLocale: nn-NO
-Publisher: Enkle Systemer AS
-PackageName: ENK Regnskap
+Publisher: starheim
+PackageName: ENK-elt regnskap
 PackageUrl: https://enkregnskap.no/
 License: Proprietær
 ShortDescription: Heile regnskapet ditt, til ein pris som faktisk gjer meining. Noregs første regnskapsystem bygd kun for enkeltpersonføretak. Ingen AS-funksjonar du aldri brukar. Ingen overraskingar.

--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.nn-NO.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.locale.nn-NO.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.locale.1.12.0.schema.json
+
+PackageIdentifier: EnkleSystemer.ENKRegnskap
+PackageVersion: 3.9.2
+PackageLocale: nn-NO
+Publisher: Enkle Systemer AS
+PackageName: ENK Regnskap
+PackageUrl: https://enkregnskap.no/
+License: Proprietær
+ShortDescription: Heile regnskapet ditt, til ein pris som faktisk gjer meining. Noregs første regnskapsystem bygd kun for enkeltpersonføretak. Ingen AS-funksjonar du aldri brukar. Ingen overraskingar.
+Tags:
+- bokføring
+- enk-regnskap
+- enkeltpersonføretak
+- fakturering
+- heimekontor
+- køyrebok
+- noreg
+- regnskapsprogram
+- skattemeldingar
+PurchaseUrl: https://enkregnskap.no/#pris
+ManifestType: locale
+ManifestVersion: 1.12.0

--- a/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.yaml
+++ b/manifests/e/EnkleSystemer/ENKRegnskap/3.9.2/EnkleSystemer.ENKRegnskap.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: EnkleSystemer.ENKRegnskap
+PackageVersion: 3.9.2
+DefaultLocale: nb-NO
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/EnkleSystemer.ENKRegnskap.json
+++ b/shards/json/EnkleSystemer.ENKRegnskap.json
@@ -1,17 +1,8 @@
 {
 	"$schema": "https://anthelion.unownplain.dev/schema.json",
-	"strategy": "static",
-	"version": { "source": "display" },
-	"urls": [
-		{
-			"url": "https://enkregnskap.no/last-ned/ENK-elt-regnskap-windows.msi",
-			"architecture": "x64"
-		}
-	],
-	"state": {
-		"source": "response-header",
-		"url": "https://enkregnskap.no/last-ned/ENK-elt-regnskap-windows.msi",
-		"header": "etag"
+	"strategy": "tauri",
+	"tauri": {
+		"url": "https://enkregnskap.no/last-ned/latest.json"
 	},
 	"replace": true
 }

--- a/shards/json/EnkleSystemer.ENKRegnskap.json
+++ b/shards/json/EnkleSystemer.ENKRegnskap.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "display" },
+	"urls": [
+		{
+			"url": "https://enkregnskap.no/last-ned/ENK-elt-regnskap-windows.msi",
+			"architecture": "x64"
+		}
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://enkregnskap.no/last-ned/ENK-elt-regnskap-windows.msi",
+		"header": "etag"
+	},
+	"replace": true
+}


### PR DESCRIPTION
Fixes #1408

Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#430382

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Manifests generated by komac; locale descriptions and tags carried over from the superseded microsoft/winget-pkgs#430382, which the requester closed because the static download URL had already moved on to 3.9.2. `Publisher` and `PackageName` come from the MSI's own `Manufacturer` and `ProductName`. The default locale is `nb-NO` because the publisher is Norwegian and only publishes Norwegian copy.

The app is a Tauri app, so the shard reads its updater manifest at `https://enkregnskap.no/last-ned/latest.json`, which reports the version and the `windows-x86_64` installer URL. `replace` is set because the download URL is unversioned and the previous version's installer is no longer retrievable once upstream rolls the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ft9yfqSKuLLMfgpEoWQkwj