### PR TITLE
fix: ignore upstream versions for Hashicorp.Terraform

### DIFF
--- a/scripts/manifest-linter/config.json
+++ b/scripts/manifest-linter/config.json
@@ -71,7 +71,8 @@
 			"fonts/g/gheyret/UKIJTuz": "discontinued"
 		},
 		"repository/upstream-versions": {
-			"manifests/m/Microsoft/VisualStudioCode/**": "upstream updates are frequently blocked on approval from vscode maintainers",
+			"manifests/h/Hashicorp/Terraform/**": "upstream updates are frequently blocked on approval from vscode maintainers",
+			"manifests/m/Microsoft/VisualStudioCode/**": "upstream updates are frequently blocked by Policy-Test-1.2 false positives",
 			"manifests/m/Mozilla/Firefox/**": "upstream only ships the Nullsoft installer; this package additionally bundles MSIX and portable installer types with an automated-update shard",
 			"manifests/w/WinDirStat/WinDirStat/2.8.0/**": "upstream is missing MSIX installers"
 		}


### PR DESCRIPTION
Checklist for Pull Requests

- [ ] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
   <!-- Example: Resolves #328283 -->
  - Relates to microsoft/winget-pkgs#[Issue Number]

Manifests

- [ ] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [ ] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Note: `<path>` is the directory's name containing the manifest you're submitting.

---
