### PR TITLE
New package: fatedier.frp version 0.71.0

### DIFF
--- a/manifests/f/fatedier/frp/0.71.0/fatedier.frp.installer.yaml
+++ b/manifests/f/fatedier/frp/0.71.0/fatedier.frp.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: fatedier.frp
+PackageVersion: 0.71.0
+InstallerType: zip
+NestedInstallerType: portable
+ReleaseDate: 2026-08-14
+Installers:
+- Architecture: x64
+  NestedInstallerFiles:
+  - RelativeFilePath: frp_0.71.0_windows_amd64/frpc.exe
+  - RelativeFilePath: frp_0.71.0_windows_amd64/frps.exe
+  InstallerUrl: https://github.com/fatedier/frp/releases/download/v0.71.0/frp_0.71.0_windows_amd64.zip
+  InstallerSha256: 9E5062E3E5CF07E67144A3A4ACF175EF6A2486F3605DD6CF288BAE34AB39819F
+- Architecture: arm64
+  NestedInstallerFiles:
+  - RelativeFilePath: frp_0.71.0_windows_arm64/frpc.exe
+  - RelativeFilePath: frp_0.71.0_windows_arm64/frps.exe
+  InstallerUrl: https://github.com/fatedier/frp/releases/download/v0.71.0/frp_0.71.0_windows_arm64.zip
+  InstallerSha256: B56A5C2A1A2A55D11BC27AEEF6EDABD39F3D194360EA66660CC27281B502CB1C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/f/fatedier/frp/0.71.0/fatedier.frp.locale.en-US.yaml
+++ b/manifests/f/fatedier/frp/0.71.0/fatedier.frp.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: fatedier.frp
+PackageVersion: 0.71.0
+PackageLocale: en-US
+Publisher: fatedier
+PackageName: frp
+License: Apache-2.0
+Moniker: frp
+ShortDescription: A fast reverse proxy to expose a local server behind a NAT or firewall to the internet
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/f/fatedier/frp/0.71.0/fatedier.frp.yaml
+++ b/manifests/f/fatedier/frp/0.71.0/fatedier.frp.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: fatedier.frp
+PackageVersion: 0.71.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/fatedier.frp.json
+++ b/shards/json/fatedier.frp.json
@@ -1,0 +1,9 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "fatedier", "repo": "frp" },
+	"urls": [
+		"https://github.com/fatedier/frp/releases/download/v{version}/frp_{version}_windows_amd64.zip",
+		"https://github.com/fatedier/frp/releases/download/v{version}/frp_{version}_windows_arm64.zip"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#185709, closed with the `Binary-Validation-Error` label — upstream's binary scanner rejects the release archive, so it cannot be added there.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Neither `fatedier.frp` nor any equivalent exists upstream — winget-pkgs carries only `luckjiawei.frp-desktop`, a third-party GUI, not frp itself.

The request was filed at `0.61.0`; this packages the current release, `0.71.0`.

Windows assets ship for `amd64` and `arm64` only — there is no `windows_386` asset in this release, so the manifest carries two installers rather than three.

Each archive holds two independent binaries, `frpc.exe` (client) and `frps.exe` (server), so both are listed as `NestedInstallerFiles` under one package. The archive's top-level directory embeds the version and architecture, so the paths differ per installer and are set per-installer rather than at the manifest root.

`License: Apache-2.0` was read from the `LICENSE` file inside the archive, not assumed from the repository metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_