### PR TITLE
New package: Sysprogs.WinCDEmu version 4.1

### DIFF
--- a/manifests/s/Sysprogs/WinCDEmu/4.1/Sysprogs.WinCDEmu.installer.yaml
+++ b/manifests/s/Sysprogs/WinCDEmu/4.1/Sysprogs.WinCDEmu.installer.yaml
@@ -1,0 +1,17 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Sysprogs.WinCDEmu
+PackageVersion: '4.1'
+InstallerType: exe
+InstallerSwitches:
+  Silent: /UNATTENDED
+  SilentWithProgress: /UNATTENDED
+ElevationRequirement: elevationRequired
+ReleaseDate: 2021-12-07
+Installers:
+- Architecture: x86
+  InstallerUrl: https://github.com/sysprogs/WinCDEmu/releases/download/v4.1/WinCDEmu-4.1.exe
+  InstallerSha256: C47763631D20120057766F2F71F781BF958E22712DA4AC933B21DB0D615DC93C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Sysprogs/WinCDEmu/4.1/Sysprogs.WinCDEmu.installer.yaml
+++ b/manifests/s/Sysprogs/WinCDEmu/4.1/Sysprogs.WinCDEmu.installer.yaml
@@ -8,6 +8,8 @@ InstallerSwitches:
   Silent: /UNATTENDED
   SilentWithProgress: /UNATTENDED
 ElevationRequirement: elevationRequired
+InstallModes:
+- interactive
 ReleaseDate: 2021-12-07
 Installers:
 - Architecture: x86

--- a/manifests/s/Sysprogs/WinCDEmu/4.1/Sysprogs.WinCDEmu.locale.en-US.yaml
+++ b/manifests/s/Sysprogs/WinCDEmu/4.1/Sysprogs.WinCDEmu.locale.en-US.yaml
@@ -1,0 +1,14 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Sysprogs.WinCDEmu
+PackageVersion: '4.1'
+PackageLocale: en-US
+Publisher: Sysprogs
+PackageName: WinCDEmu
+License: LGPL-3.0-only
+Copyright: LGPL
+ShortDescription: An open-source CD/DVD/BD emulator that mounts disc images with one click
+Moniker: wincdemu
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Sysprogs/WinCDEmu/4.1/Sysprogs.WinCDEmu.yaml
+++ b/manifests/s/Sysprogs/WinCDEmu/4.1/Sysprogs.WinCDEmu.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Sysprogs.WinCDEmu
+PackageVersion: '4.1'
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Sysprogs.WinCDEmu.json
+++ b/shards/json/Sysprogs.WinCDEmu.json
@@ -1,0 +1,8 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "github-release",
+	"github": { "owner": "sysprogs", "repo": "WinCDEmu" },
+	"urls": [
+		"https://github.com/sysprogs/WinCDEmu/releases/download/v{version}/WinCDEmu-{version}.exe"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#182560 and microsoft/winget-pkgs#36005, both closed with the `Interactive-Only-Installer` label.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Absent from winget-pkgs and from this repo. `Sysprogs.SmarTTY` is the only other Sysprogs package upstream.

## Silent switch, and why it is not enough

The switch is `/UNATTENDED`, not `/S`. It comes from the installer's own embedded help text:

> To perform unattended installation, invoke this file with /UNATTENDED option. Note that unless you have disabled unsigned driver warnings, you will still be prompted for installing the driver.

The first run of Installation Validation confirmed that second sentence. It hung for the full five-minute window, and the runner's cleanup reported:

```
Terminate orphan process: pid (7432) (WinCDEmu-4.1)
Terminate orphan process: pid (8012) (drvinst64)
```

`/UNATTENDED` suppresses the installer's own UI, but `drvinst64` — the Windows driver-trust prompt for WinCDEmu's virtual SCSI bus driver — is outside the installer's control. That is precisely what upstream's `Interactive-Only-Installer` label refers to.

`InstallModes: [interactive]` was therefore added in a second commit, after CI demonstrated the hang rather than before. The `/UNATTENDED` switch is kept because it is real and does reduce prompting; the manifest now describes both facts accurately.

`ElevationRequirement: elevationRequired` is set because driver installation needs it.

## Other notes

`License: LGPL-3.0-only` was read from the `LICENSE` file in `sysprogs/WinCDEmu`, which is the LGPLv3 text. The sources carry no "or (at your option) any later version" grant, so `-only` rather than `-or-later`. The installer's PE version resource independently reports `LGPL`.

`Architecture: x86` is what the installer stub actually is; it installs both 32- and 64-bit drivers from the one binary.

4.1 is the latest release — it dates from 2021-12-07, which is the project's current state, not a stale pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry