### PR TITLE
New package: BigNox.NoxPlayer version 7.0.6.2

### DIFF
--- a/manifests/b/BigNox/NoxPlayer/7.0.6.2/BigNox.NoxPlayer.installer.yaml
+++ b/manifests/b/BigNox/NoxPlayer/7.0.6.2/BigNox.NoxPlayer.installer.yaml
@@ -1,0 +1,18 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: BigNox.NoxPlayer
+PackageVersion: 7.0.6.2
+InstallerType: exe
+InstallerSwitches:
+  Silent: -silent
+  SilentWithProgress: -silent
+ElevationRequirement: elevationRequired
+ReleaseDate: 2024-12-11
+Installers:
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://res06.bignox.com/full/20241211/ca6f347712204e4ba3f58edc0fb66b8e.exe?filename=nox_setup_v7.0.6.2_full_intl.exe
+  InstallerSha256: DC2F7733B629C8FBEC2B3CAEDDA0734A34043CE9EB280D534F66BDD661977555
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/b/BigNox/NoxPlayer/7.0.6.2/BigNox.NoxPlayer.installer.yaml
+++ b/manifests/b/BigNox/NoxPlayer/7.0.6.2/BigNox.NoxPlayer.installer.yaml
@@ -8,6 +8,9 @@ InstallerSwitches:
   Silent: -silent
   SilentWithProgress: -silent
 ElevationRequirement: elevationRequired
+ExpectedReturnCodes:
+- InstallerReturnCode: 104
+  ReturnResponse: systemNotSupported
 ReleaseDate: 2024-12-11
 Installers:
 - Architecture: x64

--- a/manifests/b/BigNox/NoxPlayer/7.0.6.2/BigNox.NoxPlayer.locale.en-US.yaml
+++ b/manifests/b/BigNox/NoxPlayer/7.0.6.2/BigNox.NoxPlayer.locale.en-US.yaml
@@ -1,0 +1,14 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: BigNox.NoxPlayer
+PackageVersion: 7.0.6.2
+PackageLocale: en-US
+Publisher: BigNox
+PackageName: NoxPlayer
+License: Proprietary
+Copyright: © 2022 Duodian Online Inc. All rights reserved.
+ShortDescription: An Android emulator for Windows
+Moniker: noxplayer
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/b/BigNox/NoxPlayer/7.0.6.2/BigNox.NoxPlayer.yaml
+++ b/manifests/b/BigNox/NoxPlayer/7.0.6.2/BigNox.NoxPlayer.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: BigNox.NoxPlayer
+PackageVersion: 7.0.6.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/BigNox.NoxPlayer.json
+++ b/shards/json/BigNox.NoxPlayer.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "redirect-match",
+	"redirectMatch": {
+		"url": ["https://www.bignox.com/en/download/fullPackage/win_64?formal"],
+		"regex": "/full/(?<date>\\d{8})/(?<build>[0-9a-f]{32})\\.exe\\?filename=nox_setup_v(?<version>\\d+(?:\\.\\d+)+)_full_intl\\.exe"
+	},
+	"urls": [
+		"https://res06.bignox.com/full/{captures.date}/{captures.build}.exe?filename=nox_setup_v{version}_full_intl.exe"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#78464, closed with the `Hardware` label — the emulator needs hardware virtualisation, so upstream cannot validate it.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Absent from winget-pkgs and from this repo.

## Which download

`bignox.com` offers three Windows builds — `win_64`, `win_64_9` and `win_64_12`, differing in the bundled Android ROM (7, 9, 12), all reporting the same app version `7.0.6.2`. This packages the default `win_64` build, the one the site's main download button serves. The other two would need their own identifiers to avoid three installers colliding on one architecture.

## Installation Validation cannot pass here

CI ran the installer with `-silent`; it exited `104` after five seconds. Two readings were possible — a rejected argument, or a platform gate — so the installer stub was examined rather than guessed at. It settles on the second:

- The stub holds a coherent switch table in UTF-16: `-auto`, `-cleanall`, `-disk`, `-dump`, `-loadAllSaveData`, `-loadVm`, `-pure`, `-romupdate`, `-silent`. `-silent` is a real switch, and the commoner `/S` and `/silent` spellings are absent.
- It also holds the string `This CPU model is currently not supported, installation cannot be completed`, probes `SOFTWARE\Microsoft\Windows\CurrentVersion\Component Based Servicing\Notifications\OptionalFeatures\Microsoft-Hyper-V-All`, and even ships `DISM /Online /Disable-Feature /FeatureName:Microsoft-Hyper-V-All`.

GitHub's Windows runners are themselves Hyper-V guests, so a nested hypervisor cannot start. That is exactly the condition upstream labelled `Hardware`.

`104` is therefore mapped through `ExpectedReturnCodes` to `systemNotSupported`, matching the `Nvidia.Driver.*` manifests already on `main`. The check stays red regardless, because `validate.ps1` compares winget's raw exit code against zero and so fails any manifest that correctly declares an expected return code — the same shared-CI limitation described in pl4nty/winget-extras#1253, which also keeps this repo's own driver-update PRs red. The mapping is kept because it is right for users on real hardware: they get "system not supported" instead of an opaque `104`.

## Corrections to komac's detection

Komac does not recognise BigNox's custom installer stub, so it guessed `portable`, and read the stub's 32-bit PE header as `x86`. Both are corrected by hand:

- `InstallerType: exe` — the stub is a real installer, not a portable binary.
- `Architecture: x64` — this is the `win_64` download; there is no 32-bit build offered.

`Scope: machine` is set on the installer rather than at the manifest root, because `validate.ps1` builds its matrix from `$_.Scope ?? $manifest.Scope` but then selects with `$_.Scope -eq $Scope` — a root-level `Scope` makes the selector match nothing and the per-installer fields are silently dropped.

## Shard

The CDN URL carries an opaque per-release path (`/full/<date>/<32-hex>.exe`) that no version template can reproduce, so the shard uses `redirect-match` against the stable `bignox.com` download endpoint and captures the date, the build hash and the version out of the redirect target — the same shape as `3u.3uTools`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry