### PR TITLE
New package: Microchip.MicrochipStudio version 7.0.2594

### DIFF
--- a/manifests/m/Microchip/MicrochipStudio/7.0.2594/Microchip.MicrochipStudio.installer.yaml
+++ b/manifests/m/Microchip/MicrochipStudio/7.0.2594/Microchip.MicrochipStudio.installer.yaml
@@ -1,0 +1,37 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Microchip.MicrochipStudio
+PackageVersion: 7.0.2594
+InstallerType: burn
+ElevationRequirement: elevationRequired
+ReleaseDate: 2024-05-28
+AppsAndFeaturesEntries:
+- DisplayName: Microchip Studio
+  Publisher: Microchip
+  ProductCode: '{D92DF7BB-BC43-4267-A5FE-1BA3BDF1A813}'
+  UpgradeCode: '{CC644864-ECC1-4925-A8B2-B9AB11B59943}'
+  InstallerType: burn
+- DisplayName: Atmel LibUSB0 Driver (x64)
+  Publisher: Microchip
+  ProductCode: '{C1F86585-CDAC-4ABE-B163-161DDBCC4332}'
+  InstallerType: wix
+- DisplayName: Atmel WinUSB
+  Publisher: Microchip
+  ProductCode: '{22D3C72E-42F9-4B0F-B331-E0AA134ADF76}'
+  InstallerType: wix
+- DisplayName: Atmel Segger USB Drivers (501e)
+  Publisher: Microchip
+  ProductCode: '{156C0C95-4DDE-4F88-97A0-5EEE22269CE3}'
+  InstallerType: wix
+- DisplayName: Atmel Driver Files
+  Publisher: Microchip
+  ProductCode: '{CCC3AC39-5557-4D92-908F-66577DAB9B70}'
+  InstallerType: wix
+Installers:
+- Architecture: x86
+  Scope: machine
+  InstallerUrl: https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/as-installer-7.0.2594-full.exe
+  InstallerSha256: C964AD7F5F11924805D679A4F3E02D9D15EC82D3F84E58407675109FD8E93BC2
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/m/Microchip/MicrochipStudio/7.0.2594/Microchip.MicrochipStudio.locale.en-US.yaml
+++ b/manifests/m/Microchip/MicrochipStudio/7.0.2594/Microchip.MicrochipStudio.locale.en-US.yaml
@@ -1,0 +1,14 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Microchip.MicrochipStudio
+PackageVersion: 7.0.2594
+PackageLocale: en-US
+Publisher: Microchip Technology
+PackageName: Microchip Studio for AVR and SAM Devices
+License: Proprietary
+Copyright: © 2020 Microchip Technology, Inc.
+ShortDescription: An IDE for developing and debugging AVR and SAM microcontroller applications
+Moniker: microchipstudio
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/m/Microchip/MicrochipStudio/7.0.2594/Microchip.MicrochipStudio.yaml
+++ b/manifests/m/Microchip/MicrochipStudio/7.0.2594/Microchip.MicrochipStudio.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Microchip.MicrochipStudio
+PackageVersion: 7.0.2594
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Microchip.MicrochipStudio.json
+++ b/shards/json/Microchip.MicrochipStudio.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{
+			"url": "https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/as-installer-7.0.2594-full.exe",
+			"architecture": "x86"
+		}
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://ww1.microchip.com/downloads/aemDocuments/documents/DEV/ProductDocuments/SoftwareTools/as-installer-7.0.2594-full.exe",
+		"header": "etag"
+	},
+	"replace": true
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#112819, still open with the `Interactive-Only-Installer` label.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Upstream carries `Microchip.MPLABXC8CCompiler` and `Microchip.MPLABXC16CCompiler` but not the IDE itself.

This is the **full offline installer** (1.0 GB), not the web installer — the offline build is what carries the toolchain and device packs, so nothing is fetched at install time.

7.0.2594 is the final release: Microchip has moved development to MPLAB X, and the file has not changed since 2024-05-28.

## Installation Validation: the install needs longer than five minutes

It is **not** interactive, and it is **not** a download problem. The run shows all three stages plainly:

```
13:52:34  Downloading to path: ...\Microchip.MicrochipStudio.7.0.2594\c964ad7f...
13:52:49  Installer hash verified
13:52:50  Installer args: /quiet /norestart /log "...-installer.log"
13:52:50  Starting: 'as-installer-7.0.2594-full.exe' with arguments '/quiet /norestart /log ...'
13:57:48  Terminate orphan process: pid (3936) (as-installer-7.0.2594-full)
13:57:48  Terminate orphan process: pid (1688) (as-installer-7.0.2594-full)
13:57:48  Terminate orphan process: pid (8244) (xc8-installer-v2.36-win.x64)
```

The 1 GB download finished in 15 seconds and the hash verified. Burn then accepted `/quiet /norestart` and ran unattended for the full five-minute window — and the process it was executing when the runner killed it was `xc8-installer-v2.36-win.x64`, one of the bundled compiler installers. The bundle was making progress through its chain, not waiting for input.

So `InstallModes: [interactive]` is deliberately **not** added. I flagged it as a possibility before the first run; the evidence refutes it. Declaring a silently-installing bundle interactive-only would make `validate.ps1` demand a timeout and pass for the wrong reason, and would be wrong for users, who get a working silent install.

The real constraint is `validate.ps1`:

```powershell
$installer = Start-Process winget -ArgumentList $wingetArgs -PassThru -NoNewWindow
# 2GB+ zips like Cinebench need longer than 2 mins to extract
$success = $installer.WaitForExit(5 * 60 * 1000)
```

That budget covers download *and* install together, and it has already been raised once for large archives. A 1 GB IDE that installs a compiler toolchain, device packs and four driver MSIs does not fit in it. No manifest field can change that, so nothing is pushed here for it — raising the budget is a shared-CI change affecting every package, and belongs to a maintainer. Re-running would fail identically; the timeout is deterministic, not flaky.

## Installer

Komac identified it as a WiX Burn bundle, and read the bundle's `ProductCode`/`UpgradeCode` plus the four bundled Atmel USB driver MSIs out of the binary. Burn accepts winget's standard silent switches, so no `InstallerSwitches` override is needed — CI confirms winget passed `/quiet /norestart` and the bundle accepted them.

`ElevationRequirement: elevationRequired` is set because those driver packages need it. `Scope: machine` is on the installer rather than at the manifest root — a root-level `Scope` makes `validate.ps1`'s selector (`$_.Scope -eq $Scope`) match nothing, silently discarding the per-installer fields.

`Architecture: x86` is the installer as built; it targets both 32- and 64-bit Windows.

## Shard

The product page is script-rendered, so no page or redirect strategy can reach the download link from a plain fetch. The shard uses `static` against the fixed URL with an `etag` state source, matching `Auslogics.DiskDefragUltimate` and `CnCNet.RedAlert2YurisRevenge`. Since the product is end-of-life, a pinned URL is accurate rather than a workaround — and the `etag` still catches a silent re-publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry