### PR TITLE
New package: PeterVerbeek.PeaceEqualizer version 1.6.9.11

### DIFF
--- a/manifests/p/PeterVerbeek/PeaceEqualizer/1.6.9.11/PeterVerbeek.PeaceEqualizer.installer.yaml
+++ b/manifests/p/PeterVerbeek/PeaceEqualizer/1.6.9.11/PeterVerbeek.PeaceEqualizer.installer.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: PeterVerbeek.PeaceEqualizer
+PackageVersion: 1.6.9.11
+InstallerType: nullsoft
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: EqualizerAPO.EqualizerAPO
+ReleaseDate: 2025-11-02
+Installers:
+- Architecture: x86
+  InstallerUrl: https://sourceforge.net/projects/peace-equalizer-apo-extension/files/PeaceSetup.exe/download
+  InstallerSha256: D007A5EFCBE361EFBE5EC88EEA8EFF6191D0188E8C7111354CBB063FBAC26F2C
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/p/PeterVerbeek/PeaceEqualizer/1.6.9.11/PeterVerbeek.PeaceEqualizer.locale.en-US.yaml
+++ b/manifests/p/PeterVerbeek/PeaceEqualizer/1.6.9.11/PeterVerbeek.PeaceEqualizer.locale.en-US.yaml
@@ -1,0 +1,14 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: PeterVerbeek.PeaceEqualizer
+PackageVersion: 1.6.9.11
+PackageLocale: en-US
+Publisher: Peter Verbeek
+PackageName: Peace Equalizer
+License: GPL-2.0-only
+Copyright: P.E. Verbeek
+ShortDescription: A graphical interface for configuring Equalizer APO
+Moniker: peace
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/p/PeterVerbeek/PeaceEqualizer/1.6.9.11/PeterVerbeek.PeaceEqualizer.yaml
+++ b/manifests/p/PeterVerbeek/PeaceEqualizer/1.6.9.11/PeterVerbeek.PeaceEqualizer.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: PeterVerbeek.PeaceEqualizer
+PackageVersion: 1.6.9.11
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/PeterVerbeek.PeaceEqualizer.json
+++ b/shards/json/PeterVerbeek.PeaceEqualizer.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{
+			"url": "https://sourceforge.net/projects/peace-equalizer-apo-extension/files/PeaceSetup.exe/download",
+			"architecture": "x86"
+		}
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://sourceforge.net/projects/peace-equalizer-apo-extension/files/PeaceSetup.exe/download",
+		"header": "etag"
+	},
+	"replace": true
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#145076, closed with the `Hardware` label.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Peace is the configuration GUI for Equalizer APO. Absent from winget-pkgs and from this repo; `EqualizerAPO.EqualizerAPO` is already here and is declared as a `PackageDependencies` entry, since Peace is useless without it.

## Why not the `sourceforge` strategy

Because that strategy takes its version from the file *name*, and this project's installer has no version in it.

The schema allows exactly two keys, and version extraction hangs entirely off the second:

```json
"sourceforge": {
  "project": "SourceForge project slug (e.g. winscp).",
  "file":    "File name pattern with {version} placeholder."
}
```

`project` is the only required key; `additionalProperties` is false, so there is no alternative version source to point at. The download here is `PeaceSetup.exe`, sitting at the project root — `https://sourceforge.net/projects/peace-equalizer-apo-extension/files/PeaceSetup.exe/download` — with no version token for `{version}` to bind to. Both existing `sourceforge` shards in this repo do have one (`EqualizerAPO-x64-{version}.exe`, `LOIC-{version}-binary.zip`). Omitting `file` only widens the feed scan; it does not conjure a version, and on a feed of unversioned names the likely outcomes are no match or a version lifted from some unrelated file, which is worse than failing.

That is the reason for `static` + `version: { source: "product" }` — the version is read out of the downloaded binary, the same shape as `Auslogics.DiskDefragUltimate` and `CnCNet.RedAlert2YurisRevenge`.

Caveat on how far I checked: SourceForge's metadata endpoints are behind a Cloudflare challenge from where I am now — `/files/`, `best_release.json`, the project RSS and `rest/p/…` all return the `Just a moment...` interstitial — so I could not re-enumerate the project's full file list to confirm no *sibling* file carries a version. The schema argument stands on its own, but if you know the project publishes versioned files, switching is a one-line change and I will make it.

## Installation Validation times out inside the dependency, not inside Peace

The dependency machinery in `validate.ps1` worked exactly as intended — the log shows the whole chain:

```
14:10:39  Getting upstream file from remote: https://winget.tplant.com.au/cache/EqualizerAPO.EqualizerAPO-1.4.2.yaml
14:10:40  Selected installer URL: .../EqualizerAPO-x64-1.4.2.exe/download
14:10:43  Installer hash verified
14:10:44  Installer args: /S
14:10:44  Starting: '...\EqualizerAPO.EqualizerAPO.1.4.2\download.exe' with arguments '/S'
14:15:48  Terminate orphan process: pid (8616) (download)
14:15:48  Terminate orphan process: pid (8700) (DeviceSelector)
```

The first attempt failed on the missing dependency, the script added the `winget-extras` source, and winget then resolved and installed Equalizer APO 1.4.2 from it. What hung is `DeviceSelector` — Equalizer APO's device-selection dialog. Peace's own installer was never reached.

This is already known in this repo: `manifests/e/EqualizerAPO/EqualizerAPO/1.4.2/EqualizerAPO.EqualizerAPO.installer.yaml` on `main` carries `InstallModes: [interactive]` for precisely this reason.

### Why `InstallModes: [interactive]` is *not* being added to Peace

It would make the check go green, because `validate.ps1` computes

```powershell
$installModes = @($selectedInstaller.InstallModes ?? $manifest.InstallModes)
$expectTimeout = $installModes.Count -eq 1 -and $installModes[0] -eq 'interactive'
```

from the manifest under test only. But that field describes **Peace's** installer, which is NSIS and takes `/S`. Declaring Peace interactive-only to satisfy CI would tell winget that a user who already has Equalizer APO installed cannot install Peace silently — trading a real capability for a green tick. Left as-is deliberately.

The general fix would be for `$expectTimeout` to also consider the `InstallModes` of declared `PackageDependencies`, since installing a package installs its dependencies first. That is a shared-CI change, so it is not made from this PR. Not re-run either: the timeout is deterministic, not flaky.

## Version

One trap worth recording, because it would have produced a wrong version silently: the installer embeds a copy of `7za.exe`, and a naive scan of the file's version strings finds **7-Zip 21.07** first. The outer PE's own `RT_VERSION` resource is the right one and reads:

```
ProductName      Peace
ProductVersion   1.6.9.11
LegalCopyright   P.E. Verbeek
FileDescription  Setup Tool for Peace (Peter's Equalizer APO Configuration Extension)
```

`1.6.9.11` is taken from there.

## Installer type

Komac reported `portable`, which is wrong — it does not recognise this stub. The file is NSIS, confirmed from the firstheader rather than from the `NullsoftInst` string alone: the 8 bytes preceding that string are `00000000 efbeadde`, i.e. `flags = 0`, signature = `0xDEADBEEF`. Corrected to `InstallerType: nullsoft`, so winget uses NSIS's `/S`.

## Licence

`GPL-2.0-only`, from the SourceForge project metadata (`categories.license` → "GNU General Public License version 2.0 (GPLv2)"), not inferred from the project being open source.

## Note for reviewers

The project's own SourceForge summary opens with a warning that a scam site operates under the "Peace Equalizer" name and that the SourceForge project is the only official source. The manifest points only at the SourceForge download endpoint for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry
