### PR TITLE
New package: Hasleo.EasyUEFI version 6.4.0.2

### DIFF
--- a/manifests/h/Hasleo/EasyUEFI/6.4.0.2/Hasleo.EasyUEFI.installer.yaml
+++ b/manifests/h/Hasleo/EasyUEFI/6.4.0.2/Hasleo.EasyUEFI.installer.yaml
@@ -1,0 +1,24 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Hasleo.EasyUEFI
+PackageVersion: 6.4.0.2
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+ProductCode: EasyUEFI_is1
+ReleaseDate: 2026-05-28
+AppsAndFeaturesEntries:
+- ProductCode: EasyUEFI_is1
+ElevationRequirement: elevatesSelf
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles%\Hasleo\EasyUEFI'
+Installers:
+- Architecture: x64
+  Scope: machine
+  InstallerUrl: https://www.easyuefi.com/downloads/EasyUEFI_Trial.exe
+  InstallerSha256: 0C0F05D959C7E3A365F69957DC85C41A9436FAE2DBA1F19EFA74C80B74430B21
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/Hasleo/EasyUEFI/6.4.0.2/Hasleo.EasyUEFI.locale.en-US.yaml
+++ b/manifests/h/Hasleo/EasyUEFI/6.4.0.2/Hasleo.EasyUEFI.locale.en-US.yaml
@@ -1,0 +1,14 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Hasleo.EasyUEFI
+PackageVersion: 6.4.0.2
+PackageLocale: en-US
+Publisher: Hasleo Software
+PackageName: Hasleo EasyUEFI
+License: Proprietary
+Copyright: © 2013-2026 Hasleo Software.
+ShortDescription: A tool to manage EFI/UEFI boot entries and EFI system partitions
+Moniker: easyuefi
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/Hasleo/EasyUEFI/6.4.0.2/Hasleo.EasyUEFI.yaml
+++ b/manifests/h/Hasleo/EasyUEFI/6.4.0.2/Hasleo.EasyUEFI.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Hasleo.EasyUEFI
+PackageVersion: 6.4.0.2
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Hasleo.EasyUEFI.json
+++ b/shards/json/Hasleo.EasyUEFI.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{
+			"url": "https://www.easyuefi.com/downloads/EasyUEFI_Trial.exe",
+			"architecture": "x64"
+		}
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://www.easyuefi.com/downloads/EasyUEFI_Trial.exe",
+		"header": "last-modified"
+	},
+	"replace": true
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#14168, closed with the `Hardware` label.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Absent from winget-pkgs and from this repo. Upstream carries `Hasleo.BackupSuiteFree`, a different product from the same vendor, so `Hasleo.*` follows its publisher convention.

Komac detected this one cleanly — Inno Setup, `ProductCode: EasyUEFI_is1`, install location, `elevatesSelf`, and all three `InstallModes`. Only two things were changed by hand.

## Licence: `Proprietary`, not `Freeware`

The sibling package upstream uses `License: Freeware`, but that applies to Backup Suite **Free**. EasyUEFI is a commercial product with a free trial — the vendor's page sells "Professional License" and "Enterprise License" terms, and the download is literally `EasyUEFI_Trial.exe`. Copying `Freeware` across from the sibling would have been wrong, so it is `Proprietary`.

Only one binary is published; it serves the trial and the licensed editions alike, so there is nothing separate to package.

## Scope placement

`Scope: machine` is moved from the manifest root onto the installer. `validate.ps1` builds its matrix with `$_.Scope ?? $manifest.Scope` but then selects with `$_.Scope -eq $Scope`, so a root-level `Scope` makes the selector match nothing and the per-installer fields are silently dropped.

## Shard

The download URL carries no version, so the shard uses `static` with `version: { source: "product" }` — the version comes from the installer's own `RT_VERSION` resource (`ProductName: Hasleo EasyUEFI`, `ProductVersion: 6.4.0.2`), the same approach as `Auslogics.DiskDefragUltimate`.

The state source is `last-modified` rather than `etag`, because this host sends no `etag`; two shards in this repo already use that header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry)_