### PR TITLE
New package: Hytto.LovenseRemote version 1.39.9

### DIFF
--- a/manifests/h/Hytto/LovenseRemote/1.39.9/Hytto.LovenseRemote.installer.yaml
+++ b/manifests/h/Hytto/LovenseRemote/1.39.9/Hytto.LovenseRemote.installer.yaml
@@ -1,0 +1,21 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Hytto.LovenseRemote
+PackageVersion: 1.39.9
+InstallerType: inno
+InstallModes:
+- interactive
+- silent
+- silentWithProgress
+ProductCode: '{6CF0FC77-8ADB-477D-8E3F-0943B7EA1154}}_is1'
+ReleaseDate: 2026-08-24
+AppsAndFeaturesEntries:
+- ProductCode: '{6CF0FC77-8ADB-477D-8E3F-0943B7EA1154}}_is1'
+ElevationRequirement: elevatesSelf
+Installers:
+- Architecture: x86
+  InstallerUrl: https://cdn.lovense.com/files/apps/remote/remote.exe
+  InstallerSha256: 2CD6FFD7002F1B89A2D774393574CCC7D868F0D01616CDB7245ABA79121D0838
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/h/Hytto/LovenseRemote/1.39.9/Hytto.LovenseRemote.installer.yaml
+++ b/manifests/h/Hytto/LovenseRemote/1.39.9/Hytto.LovenseRemote.installer.yaml
@@ -6,8 +6,6 @@ PackageVersion: 1.39.9
 InstallerType: inno
 InstallModes:
 - interactive
-- silent
-- silentWithProgress
 ProductCode: '{6CF0FC77-8ADB-477D-8E3F-0943B7EA1154}}_is1'
 ReleaseDate: 2026-08-24
 AppsAndFeaturesEntries:

--- a/manifests/h/Hytto/LovenseRemote/1.39.9/Hytto.LovenseRemote.locale.en-US.yaml
+++ b/manifests/h/Hytto/LovenseRemote/1.39.9/Hytto.LovenseRemote.locale.en-US.yaml
@@ -1,0 +1,13 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Hytto.LovenseRemote
+PackageVersion: 1.39.9
+PackageLocale: en-US
+Publisher: Hytto Ltd.
+PackageName: Lovense Remote
+License: Proprietary
+ShortDescription: A companion app for controlling Lovense devices
+Moniker: lovense-remote
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/h/Hytto/LovenseRemote/1.39.9/Hytto.LovenseRemote.yaml
+++ b/manifests/h/Hytto/LovenseRemote/1.39.9/Hytto.LovenseRemote.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Hytto.LovenseRemote
+PackageVersion: 1.39.9
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Hytto.LovenseRemote.json
+++ b/shards/json/Hytto.LovenseRemote.json
@@ -1,0 +1,17 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "static",
+	"version": { "source": "product" },
+	"urls": [
+		{
+			"url": "https://cdn.lovense.com/files/apps/remote/remote.exe",
+			"architecture": "x86"
+		}
+	],
+	"state": {
+		"source": "response-header",
+		"url": "https://cdn.lovense.com/files/apps/remote/remote.exe",
+		"header": "last-modified"
+	},
+	"replace": true
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#259670, closed with the `Interactive-Only-Installer` label.

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

---

Absent from winget-pkgs and from this repo. Komac detected it cleanly as Inno Setup, with `ProductCode`, `elevatesSelf` and all three `InstallModes`.

## The upstream label is accurate: a bundled driver installer prompts

CI confirms it. The installer was started with Inno's silent switches and ran unattended for the full five-minute window, then the runner's cleanup reported:

```
14:14:13  Installer args: /SP- /VERYSILENT /SUPPRESSMSGBOXES /NORESTART /LOG="...-installer.log"
14:19:22  Terminate orphan process: pid (7304) (remote)
14:19:22  Terminate orphan process: pid (4600) (remote.tmp)
14:19:22  Terminate orphan process: pid (7924) (nrfconnect-driver-installer)
14:19:22  Terminate orphan process: pid (6420) (nrfconnect-driver-installer.tmp)
```

`nrfconnect-driver-installer` is the Nordic Semiconductor BLE driver installer for the USB dongle these devices use. It is bundled inside this installer, and its driver-trust prompt is outside Inno's control — `/VERYSILENT` suppresses Inno's own UI, not that.

`InstallModes` is therefore narrowed from komac's three to `[interactive]` in a second commit, after CI demonstrated the hang rather than before.

Worth distinguishing this from pl4nty/winget-extras#1416, where the same narrowing was deliberately **refused**: there the blocking component is a separately declared `PackageDependencies` entry that a user may already have installed, so claiming the package itself cannot install silently would be false. Here the driver installer is bundled and runs on every install, so no install of this package can complete unattended and the narrowed value is accurate.

## The download works — Cloudflare did not bite

A plain `GET` for `remote.exe` returns a 5.5 KB `Just a moment...` interstitial, even though `HEAD` reports the real `content-length: 117587088`. A tool that followed that blindly would hash the challenge page and produce a confidently wrong `InstallerSha256`, so the hash was verified twice, independently:

- fetched with a browser `User-Agent` and `Referer`, which returns the real 117 MB PE32 — `sha256 2cd6ffd7002f1b89a2d774393574ccc7d868f0d01616cdb7245aba79121d0838`
- komac, fetching on its own with no such headers, produced `2CD6FFD7...0838`

CI has now settled it from the other side too: winget downloaded the installer and executed it, so neither komac nor winget is being challenged.

`latest.yml` is separately "Access Blocked" at that CDN, so the `electron-builder` strategy is not available here.

## Version

The URL carries no version, so the shard uses `static` with `version: { source: "product" }` and a `last-modified` state source (this host sends no `etag`).

`1.39.9` is the installer's `RT_VERSION` `ProductVersion` (`ProductName: Lovense Remote`, `CompanyName: Hytto Ltd.`). Note the resource's binary `FileVersion` field is `0.0.0.0` and its string `FileVersion` is blank — `ProductVersion` is the only meaningful version in the file.

## Two things for a reviewer

**The `ProductCode` has a doubled closing brace**, exactly as read from the Inno data:

```
{6CF0FC77-8ADB-477D-8E3F-0943B7EA1154}}_is1
```

Inno's escaping doubles a leading `{`, not a trailing `}`, so this looks like a literal `}` in the vendor's `AppId` rather than a parsing artefact — i.e. the ARP key really is `...1154}}_is1`. Left as read rather than "corrected" to a single brace, since guessing here would break upgrade detection.

**The job summary step may fail independently of the install.** The same run logged:

```
##[error]$GITHUB_STEP_SUMMARY upload aborted, supports content up to a size of 1024k, got 1420k.
```

Inno's `/LOG` output for this installer is ~1.4 MB, over the 1024k step-summary cap. Nothing in the manifest controls that — winget supplies the `/LOG` argument itself — so if this check stays red after the `InstallModes` change, that step is the reason rather than the install. Truncating the log before appending it in `validate.yml`'s "Add validation logs to job summary" step would fix it for every large installer.

## Lint Project is failing on a `main` problem, not this PR

`Lint Project` on ac37a8f fails with:

```
warning[repository/upstream-versions] --> manifests/k/k0sproject/k0sctl/0.33.0/k0sproject.k0sctl.yaml:5:1
  PackageVersion 0.33.0 already exists in microsoft/winget-pkgs
```

That path is not in this diff — this PR touches only `manifests/h/Hytto/**` and `shards/json/Hytto.LovenseRemote.json`. `k0sproject.k0sctl` 0.33.0 came from 63c00d9 (#1419) and upstream has since published the same version, so the repo-wide rule now trips on it. Running `bun manifests:check --deny-warnings` against clean `main` at 435a829 reproduces it exactly, one warning, same package — so it will fail every open PR until it is resolved centrally, the way #1410 resolved the `Hashicorp.Terraform` case.

Unlike Terraform, an ignore entry looks like the wrong remedy here: the linter's advice is correct, upstream genuinely carries 0.33.0 now, and this repo is for packages winget-pkgs cannot carry. Deleting `manifests/k/k0sproject/k0sctl/0.33.0/` looks like the right fix — 0.32.2 is not flagged, so upstream does not have that one. Not doing it from this PR, since it is someone else's package and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cg5ocVwbGciXXmwpZTu9Ry
