### PR TITLE
New package: Splashtop.SoftwareUpdater version 1.5.6.20

### DIFF
--- a/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.installer.yaml
+++ b/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.installer.yaml
@@ -1,0 +1,23 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
+
+PackageIdentifier: Splashtop.SoftwareUpdater
+PackageVersion: 1.5.6.20
+InstallerType: zip
+NestedInstallerType: nullsoft
+NestedInstallerFiles:
+- RelativeFilePath: Splashtop_Software_Updater_v1.5.6.20.exe
+Scope: machine
+ProductCode: Splashtop Software Updater
+ReleaseDate: 2023-08-15
+AppsAndFeaturesEntries:
+- Publisher: Splashtop Inc.
+  ProductCode: Splashtop Software Updater
+InstallationMetadata:
+  DefaultInstallLocation: '%ProgramFiles(x86)%\Splashtop\Splashtop Software Updater'
+Installers:
+- Architecture: x86
+  InstallerUrl: https://support-splashtopbusiness.splashtop.com/hc/en-us/article_attachments/13970314478875
+  InstallerSha256: B2D04424D621861FA7AB8125EB5D2661D45E77E4027830E92C054FBF8F8C407E
+ManifestType: installer
+ManifestVersion: 1.12.0

--- a/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.installer.yaml
+++ b/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.installer.yaml
@@ -11,8 +11,7 @@ Scope: machine
 ProductCode: Splashtop Software Updater
 ReleaseDate: 2023-08-15
 AppsAndFeaturesEntries:
-- Publisher: Splashtop Inc.
-  ProductCode: Splashtop Software Updater
+- ProductCode: Splashtop Software Updater
 InstallationMetadata:
   DefaultInstallLocation: '%ProgramFiles(x86)%\Splashtop\Splashtop Software Updater'
 Installers:

--- a/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.locale.en-US.yaml
+++ b/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.locale.en-US.yaml
@@ -1,0 +1,16 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+
+PackageIdentifier: Splashtop.SoftwareUpdater
+PackageVersion: 1.5.6.20
+PackageLocale: en-US
+Publisher: Splashtop
+PublisherUrl: https://www.splashtop.com/
+PublisherSupportUrl: https://support-splashtopbusiness.splashtop.com/
+PackageName: Splashtop Software Updater
+PackageUrl: https://support-splashtopbusiness.splashtop.com/hc/en-us/articles/13667341031835-Splashtop-Software-Updater-released-note
+License: Freeware
+ShortDescription: Tool to keep Splashtop software updated.
+Moniker: splashtopsoftwareupdater
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0

--- a/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.locale.en-US.yaml
+++ b/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.locale.en-US.yaml
@@ -4,13 +4,13 @@
 PackageIdentifier: Splashtop.SoftwareUpdater
 PackageVersion: 1.5.6.20
 PackageLocale: en-US
-Publisher: Splashtop
+Publisher: Splashtop Inc.
 PublisherUrl: https://www.splashtop.com/
 PublisherSupportUrl: https://support-splashtopbusiness.splashtop.com/
 PackageName: Splashtop Software Updater
 PackageUrl: https://support-splashtopbusiness.splashtop.com/hc/en-us/articles/13667341031835-Splashtop-Software-Updater-released-note
 License: Freeware
 ShortDescription: Tool to keep Splashtop software updated.
-Moniker: splashtopsoftwareupdater
+Moniker: splashtop-software-updater
 ManifestType: defaultLocale
 ManifestVersion: 1.12.0

--- a/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.yaml
+++ b/manifests/s/Splashtop/SoftwareUpdater/1.5.6.20/Splashtop.SoftwareUpdater.yaml
@@ -1,0 +1,8 @@
+# Created by Anthelion using komac v2.16.0
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
+
+PackageIdentifier: Splashtop.SoftwareUpdater
+PackageVersion: 1.5.6.20
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.12.0

--- a/shards/json/Splashtop.SoftwareUpdater.json
+++ b/shards/json/Splashtop.SoftwareUpdater.json
@@ -1,0 +1,11 @@
+{
+	"$schema": "https://anthelion.unownplain.dev/schema.json",
+	"strategy": "page-match",
+	"pageMatch": {
+		"url": "https://support-splashtopbusiness.splashtop.com/api/v2/help_center/en-us/articles/13667341031835/attachments.json",
+		"regex": "\"id\":(?<id>\\d+)[^{}]*?\"file_name\":\"Splashtop_Software_Updater_v(?<version>\\d+(?:\\.\\d+)+)\\.zip\""
+	},
+	"urls": [
+		"https://support-splashtopbusiness.splashtop.com/hc/en-us/article_attachments/{captures.id}"
+	]
+}


### PR DESCRIPTION
Checklist for Pull Requests

- [x] Is there a related issue or pull request in [winget-pkgs](https://github.com/microsoft/winget-pkgs)? If so, add the link(s) below.
  - Relates to microsoft/winget-pkgs#433747

Manifests

- [x] Have you checked that there aren't other open [pull requests](https://github.com/pl4nty/winget-extras/pulls) for the same manifest update/change?
- [ ] Have you [validated](https://github.com/microsoft/winget-pkgs/blob/master/doc/Authoring.md#validation) your manifest locally with `winget validate --manifest <path>`?
- [ ] Have you tested your manifest locally with `winget install --manifest <path>`?
- [x] Does your manifest conform to the [1.28 schema](https://github.com/denelon/winget-pkgs/tree/docs/manifest-schema-1.28.0/doc/manifest/schema/1.28.0)?

Fixes #1439

---

Single x86 NSIS 2.46 installer, shipped inside a zip, so `zip` + `NestedInstallerType: nullsoft`. Komac read `requireAdministrator` from the nested exe's manifest and set `Scope: machine`.

## The shard reads the Zendesk API, not the release-note page

Upstream publishes only a Zendesk Help Center article, and that article's HTML sits behind a Cloudflare managed challenge — a plain `GET` returns a 403 `Just a moment...` page regardless of `User-Agent`. The attachment download itself is not challenged, and neither is the Help Center REST API, so the shard matches against:

```
/api/v2/help_center/en-us/articles/13667341031835/attachments.json
```

Two things have to come out of that response together:

- **The version appears nowhere but the attachment filename.** The article body does name `1.5.6.20` in prose, but as free text in a sentence that upstream rewrites each release; `file_name` is structured and has carried the version through every attachment so far.
- **The attachment ID is opaque and changes every release**, so the installer URL cannot be templated from `{version}` and has to be captured. `13970314478875` bears no relation to `1.5.6.20`.

Hence one `page-match` regex with two named captures, in the style of `Buypass.Javafri`:

```json
"\"id\":(?<id>\\d+)[^{}]*?\"file_name\":\"Splashtop_Software_Updater_v(?<version>\\d+(?:\\.\\d+)+)\\.zip\""
```

The `[^{}]*?` rather than `[\s\S]*?` is deliberate: `article_attachments` is an array, and if upstream ever attaches a second file, refusing to cross a `{`/`}` boundary keeps the ID and the version from being taken out of two different objects. It also can't match inside `display_file_name`, since the pattern requires the quote immediately before `file_name`.

The URL is rebuilt as `/hc/en-us/article_attachments/{captures.id}` rather than using the API's own `content_url` (`/hc/article_attachments/...`) so the shard reproduces the exact URL form this manifest and winget-pkgs#433747 already carry. Both forms serve the same bytes.

No `state` entry, so no `version-state/` seed — the resolved version is the change signal.

## Two notes

`ReleaseDate: 2023-08-15` is komac's, taken from the download's `last-modified`. winget-pkgs#433747 has `2026-04-22`, which appears to be the submission date rather than a release date. The zip's own zip entry and the Zendesk `created_at` both say 2023-03-25. All three disagree; the `last-modified` value is the one komac derives from the artefact itself, so it is left as generated.

`bun manifests:check --deny-warnings` passes (2631 files, shard coverage included). `bun test:shard` could not be run here — `anthelion` installs from a GitHub tarball outside this session's repo scope, so `bun install` 403s on that one dependency. The regex was instead verified directly against the live API response, which resolves `id=13970314478875` and `version=1.5.6.20`, matching the committed manifest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016YjkPn22mgcnB6mASJ7e6X

---
_Generated by [Claude Code](https://claude.ai/code/session_016YjkPn22mgcnB6mASJ7e6X)_